### PR TITLE
 feat: publish multi-object resources

### DIFF
--- a/move/blocksite/sources/blocksite.move
+++ b/move/blocksite/sources/blocksite.move
@@ -28,6 +28,7 @@ module blocksite::blocksite {
         version: u64,
         content_type: String,
         content_encoding: String,
+        parts: u64,
         contents: vector<u8>,
     }
 
@@ -56,6 +57,7 @@ module blocksite::blocksite {
         name: String,
         content_type: String,
         content_encoding: String,
+        parts: u64,
         contents: vector<u8>,
         clk: &Clock,
     ): BlockResource {
@@ -66,6 +68,7 @@ module blocksite::blocksite {
             version: 1,
             content_type,
             content_encoding,
+            parts,
             contents,
         }
     }

--- a/site-builder/src/main.rs
+++ b/site-builder/src/main.rs
@@ -95,7 +95,7 @@ fn blocksite_module() -> Identifier {
 }
 
 fn testnet_package() -> ObjectID {
-    ObjectID::from_hex_literal("0x66b0b2d46dcd2e56952f1bd9e90218deaab0885e0f60ca29163f5e53c72ef810")
+    ObjectID::from_hex_literal("0x8dae89b2505ce9d84592e0e57d38848a2d863ead6a0e946a49fd8edbc8c7b919")
         .expect("valid hex literal")
 }
 

--- a/site-builder/src/publish.rs
+++ b/site-builder/src/publish.rs
@@ -134,7 +134,7 @@ fn print_effects(
     println!("{}", edit_string);
     let base36 = id_to_base36(&object_id).expect("Could not convert the id to base 36.");
     println!(
-        "Find it at https://{}.blocksite.net\nor http://{}.localhost:8000",
+        "Find it at https://{}.blocksite.net\nor http://{}.localhost:8080",
         &base36, &base36,
     );
     if let Some(explorer_url) = config.network.explorer_url(&object_id) {

--- a/site-builder/src/site/builder.rs
+++ b/site-builder/src/site/builder.rs
@@ -130,6 +130,7 @@ impl BlocksiteCall {
         resource_name: &str,
         content_type: &str,
         content_encoding: &str,
+        parts: usize,
         contents: &[u8],
     ) -> Result<BlocksiteCall> {
         tracing::info!("New Move call: Creating {}", resource_name);
@@ -139,6 +140,7 @@ impl BlocksiteCall {
                 pure_call_arg(&resource_name)?,
                 pure_call_arg(&content_type)?,
                 pure_call_arg(&content_encoding)?,
+                pure_call_arg(&parts)?,
                 pure_call_arg(&contents)?,
                 CallArg::CLOCK_IMM,
             ],

--- a/site-builder/src/site/manager.rs
+++ b/site-builder/src/site/manager.rs
@@ -25,9 +25,10 @@ use crate::{
 
 pub const MAX_TX_SIZE: usize = 131_072;
 pub const MAX_ARG_SIZE: usize = 16_300;
+pub const MAX_OBJ_SIZE: usize = 256_000;
 pub const ARG_MARGIN: usize = 1_000; // TODO: check if there is better way
 pub const TX_MARGIN: usize = 10_000; // TODO: check if there is better way
-pub const MAX_OBJ_SIZE: usize = 256_000;
+pub const OBJ_MARGIN: usize = 10_000; // TODO: check if there is better way
 
 pub struct SiteManager<'a> {
     pub client: SuiClient,


### PR DESCRIPTION
Publish resources of size > 256 KB by splitting them across multiple objects and recovering them in parallel in the portal.

Closes #17 