### PR TITLE
feat(portal): encode blob_id before concatenation

### DIFF
--- a/portal/src/sw.ts
+++ b/portal/src/sw.ts
@@ -471,7 +471,7 @@ async function decompressData(
  * Returns the URL to fetch the blob of given ID from the aggregator/cache.
  */
 function aggregatorEndpoint(blob_id: string): URL {
-    return new URL(AGGREGATOR + "/v1/" + blob_id);
+    return new URL(AGGREGATOR + "/v1/" + encodeURIComponent(blob_id));
 }
 
 /**


### PR DESCRIPTION
Automated tools flag this as a potential issue, even though it's not (since blob_id is trusted). In any case, out of an abundance of caution, we should encodeURIComponent.