### PR TITLE
fix(deps): bump Sui to testnet-v1.27.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,7 +733,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b30ed1d6f8437a487a266c8293aeb95b61a23261273e3e02912cdb8b68bf798b"
 dependencies = [
- "bs58",
+ "bs58 0.4.0",
  "hmac",
  "k256",
  "once_cell",
@@ -907,6 +907,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bnum"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56953345e39537a3e18bdaeba4cb0c58a78c1f61f361dc0fa7c5c7340ae87c5f"
+
+[[package]]
 name = "brotli"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,6 +940,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 dependencies = [
  "sha2 0.9.9",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -1112,7 +1127,7 @@ dependencies = [
 [[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "fastcrypto",
  "mysten-network",
@@ -1695,7 +1710,7 @@ dependencies = [
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -1753,7 +1768,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto"
 version = "0.1.8"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=4988a4744fcaf8bc7f60bf660d9a223ed0f54cc6#4988a4744fcaf8bc7f60bf660d9a223ed0f54cc6"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=c101a5176799db3eb9c801b844e7add92153d291#c101a5176799db3eb9c801b844e7add92153d291"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1767,7 +1782,7 @@ dependencies = [
  "bincode",
  "blake2",
  "blst",
- "bs58",
+ "bs58 0.4.0",
  "cbc",
  "ctr",
  "curve25519-dalek-ng",
@@ -1807,7 +1822,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-derive"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=4988a4744fcaf8bc7f60bf660d9a223ed0f54cc6#4988a4744fcaf8bc7f60bf660d9a223ed0f54cc6"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=c101a5176799db3eb9c801b844e7add92153d291#c101a5176799db3eb9c801b844e7add92153d291"
 dependencies = [
  "quote 1.0.36",
  "syn 1.0.109",
@@ -1816,7 +1831,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-tbls"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=4988a4744fcaf8bc7f60bf660d9a223ed0f54cc6#4988a4744fcaf8bc7f60bf660d9a223ed0f54cc6"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=c101a5176799db3eb9c801b844e7add92153d291#c101a5176799db3eb9c801b844e7add92153d291"
 dependencies = [
  "bcs",
  "digest 0.10.7",
@@ -1834,7 +1849,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-zkp"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=4988a4744fcaf8bc7f60bf660d9a223ed0f54cc6#4988a4744fcaf8bc7f60bf660d9a223ed0f54cc6"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=c101a5176799db3eb9c801b844e7add92153d291#c101a5176799db3eb9c801b844e7add92153d291"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -1855,6 +1870,7 @@ dependencies = [
  "neptune",
  "num-bigint 0.4.5",
  "once_cell",
+ "regex",
  "reqwest",
  "schemars",
  "serde",
@@ -3093,7 +3109,7 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "move-binary-format",
  "move-bytecode-verifier-meter",
@@ -3102,12 +3118,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -3121,12 +3137,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3141,7 +3157,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -3153,7 +3169,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -3168,7 +3184,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -3178,7 +3194,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "anyhow",
  "difference",
@@ -3196,7 +3212,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3228,7 +3244,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3251,7 +3267,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3271,7 +3287,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3291,7 +3307,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -3309,7 +3325,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "anyhow",
  "hex",
@@ -3322,7 +3338,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -3335,7 +3351,7 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "enum-compat-util",
  "quote 1.0.36",
@@ -3345,7 +3361,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "once_cell",
  "phf",
@@ -3355,7 +3371,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -3364,7 +3380,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "move-vm-config",
  "once_cell",
@@ -3376,7 +3392,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -3390,7 +3406,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -3469,7 +3485,7 @@ dependencies = [
 [[package]]
 name = "mysten-metrics"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "async-trait",
  "axum",
@@ -3489,7 +3505,7 @@ dependencies = [
 [[package]]
 name = "mysten-network"
 version = "0.2.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "anemo",
  "bcs",
@@ -3513,7 +3529,7 @@ dependencies = [
 [[package]]
 name = "mysten-util-mem"
 version = "0.11.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "cfg-if",
  "ed25519-consensus",
@@ -3532,7 +3548,7 @@ dependencies = [
 [[package]]
 name = "mysten-util-mem-derive"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "proc-macro2 1.0.85",
  "syn 1.0.109",
@@ -3542,7 +3558,7 @@ dependencies = [
 [[package]]
 name = "narwhal-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "fastcrypto",
  "match_opt",
@@ -3559,7 +3575,7 @@ dependencies = [
 [[package]]
 name = "narwhal-crypto"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "bcs",
  "fastcrypto",
@@ -4289,7 +4305,7 @@ dependencies = [
 [[package]]
 name = "prometheus-closure-metric"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -4716,9 +4732,9 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.10.5"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7699249cc2c7d71939f30868f47e9d7add0bdc030d90ee10bfd16887ff8bb1c8"
+checksum = "a1c77081a55300e016cb86f2864415b7518741879db925b8d488a0ee0d2da6bf"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -5276,7 +5292,7 @@ dependencies = [
 [[package]]
 name = "shared-crypto"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "bcs",
  "eyre",
@@ -5336,7 +5352,7 @@ dependencies = [
  "serde_yaml 0.9.34+deprecated",
  "shared-crypto",
  "sui-keys",
- "sui-sdk",
+ "sui-sdk 1.27.2",
  "sui-types",
  "thiserror",
  "tokio",
@@ -5539,7 +5555,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 [[package]]
 name = "sui-config"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5566,7 +5582,7 @@ dependencies = [
 [[package]]
 name = "sui-enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -5574,7 +5590,7 @@ dependencies = [
 [[package]]
 name = "sui-json"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5591,7 +5607,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc-api"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -5611,7 +5627,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc-types"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5641,7 +5657,7 @@ dependencies = [
 [[package]]
 name = "sui-keys"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "anyhow",
  "bip32",
@@ -5660,7 +5676,7 @@ dependencies = [
 [[package]]
 name = "sui-macros"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "futures",
  "once_cell",
@@ -5670,8 +5686,8 @@ dependencies = [
 
 [[package]]
 name = "sui-open-rpc"
-version = "1.26.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+version = "1.27.2"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "bcs",
  "schemars",
@@ -5683,7 +5699,7 @@ dependencies = [
 [[package]]
 name = "sui-open-rpc-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.10.5",
@@ -5696,7 +5712,7 @@ dependencies = [
 [[package]]
 name = "sui-package-resolver"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "async-trait",
  "bcs",
@@ -5715,7 +5731,7 @@ dependencies = [
 [[package]]
 name = "sui-proc-macros"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "msim-macros",
  "proc-macro2 1.0.85",
@@ -5727,7 +5743,7 @@ dependencies = [
 [[package]]
 name = "sui-protocol-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "clap",
  "insta",
@@ -5742,7 +5758,7 @@ dependencies = [
 [[package]]
 name = "sui-protocol-config-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "proc-macro2 1.0.85",
  "quote 1.0.36",
@@ -5752,18 +5768,23 @@ dependencies = [
 [[package]]
 name = "sui-rest-api"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "bcs",
  "fastcrypto",
+ "itertools 0.10.5",
  "mime",
+ "mysten-network",
+ "prometheus",
  "rand",
  "reqwest",
  "serde",
  "serde_json",
  "serde_with 2.3.3",
+ "sui-sdk 0.0.0",
  "sui-types",
  "tap",
  "thiserror",
@@ -5771,8 +5792,25 @@ dependencies = [
 
 [[package]]
 name = "sui-sdk"
-version = "1.26.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+version = "0.0.0"
+source = "git+https://github.com/mystenlabs/sui-rust-sdk.git?rev=bb224b9e6b6edf5eeedcdf71c750a30b68073057#bb224b9e6b6edf5eeedcdf71c750a30b68073057"
+dependencies = [
+ "base64ct",
+ "bcs",
+ "bnum",
+ "bs58 0.5.1",
+ "hex",
+ "roaring",
+ "serde",
+ "serde_derive",
+ "serde_with 3.8.1",
+ "winnow",
+]
+
+[[package]]
+name = "sui-sdk"
+version = "1.27.2"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5805,7 +5843,7 @@ dependencies = [
 [[package]]
 name = "sui-transaction-builder"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5822,7 +5860,7 @@ dependencies = [
 [[package]]
 name = "sui-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "anemo",
  "anyhow",
@@ -5881,6 +5919,7 @@ dependencies = [
  "sui-enum-compat-util",
  "sui-macros",
  "sui-protocol-config",
+ "sui-sdk 0.0.0",
  "tap",
  "thiserror",
  "tonic",
@@ -6486,7 +6525,7 @@ dependencies = [
 [[package]]
 name = "typed-store-error"
 version = "0.4.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.26.0#d709c305ebf356a0d934a02d93cf77869383009e"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
 dependencies = [
  "serde",
  "thiserror",

--- a/deny.toml
+++ b/deny.toml
@@ -63,29 +63,11 @@ ignore = true
 # Lint level for when multiple versions of the same crate are detected
 multiple-versions = "deny"
 skip = [
-    { name = "itertools", version = "<=12.1" },
-    { name = "wyz", version = "<=0.5" },
-    { name = "webpki-roots", version = "<=0.25.4" },
-    { name = "untrusted", version = "<=0.9" },
-    { name = "unicode-xid", version = "<=0.2.4" },
-    { name = "tokio-rustls", version = "<=0.24.1" },
-    { name = "base64", version = "<=0.21.7" },
-    { name = "toml", version = "<=0.8.14" },
-    { name = "synstructure", version = "<=0.13.1" },
-    { name = "serde_yaml", version = "<=0.9.34" },
-    { name = "rustls", version = "<=0.21.12" },
-    { name = "bitflags", version = "<=2.5.0"},
-    { name = "funty", version = "<=2.0.0"},
-    { name = "heck", version = "<=0.5.0"},
-    { name = "hyper-rustls", version = "<=0.24.2"},
-    { name = "matchit", version = "<=0.7.3"},
-    { name = "radium", version = "<=0.7.0"},
-    { name = "redox_syscall", version = "<=0.5.2"},
-    { name = "ring", version = "<=0.17.8"},
 ]
 skip-tree = [
     # Mysten's libraries pull in several conflicting repo versions.
     { name = "fastcrypto", depth = 4 },
+    { name = "sui-rest-api", depth = 6},
     # several crates depend on an older version of windows-sys
     { name = "windows-sys", depth = 3, version = "0.48" },
 ]

--- a/site-builder/Cargo.toml
+++ b/site-builder/Cargo.toml
@@ -13,16 +13,16 @@ clap = { version = "4.5.7", features = ["derive"] }
 flate2 = "1.0.30"
 futures = "0.3.30"
 home = "0.5.9"
-move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.26.0" }
+move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.27.2" }
 notify = "6.1.1"
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"
 serde_with = { version = "3.8.1", features = ["base64"] }
 serde_yaml = "0.9"
-shared-crypto = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.26.0" }
-sui-keys = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.26.0" }
-sui-sdk = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.26.0" }
-sui-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.26.0" }
+shared-crypto = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.27.2" }
+sui-keys = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.27.2" }
+sui-sdk = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.27.2" }
+sui-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.27.2" }
 thiserror = "1.0.61"
 tokio = { version = "1.38.0", features = ["rt", "rt-multi-thread", "macros"] }
 toml = "0.8.14"

--- a/site-builder/src/site/macros.rs
+++ b/site-builder/src/site/macros.rs
@@ -19,7 +19,17 @@ macro_rules! match_for_correct_type {
 macro_rules! get_dynamic_field {
     ($struct:expr, $field_name:expr, $field_type:path $({ $var:ident })*) => {
         match_for_correct_type!(
-            $struct.read_dynamic_field_value($field_name),
+            // TODO(mlegner): Change this back to $struct.field_value($field_name) when bumping Sui
+            // to a version that includes https://github.com/MystenLabs/sui/pull/18193.
+            match &$struct {
+                sui_sdk::rpc_types::SuiMoveStruct::WithFields(fields) => {
+                    fields.get($field_name).cloned()
+                }
+                sui_sdk::rpc_types::SuiMoveStruct::WithTypes { type_: _, fields } => {
+                    fields.get($field_name).cloned()
+                }
+                _ => None,
+            },
             $field_type $({ $var })*
         ).ok_or(anyhow!(
             "SuiMoveStruct does not contain field {} with expected type {}: {:?}",


### PR DESCRIPTION
Includes a workaround for a (temporarily) removed function.

Also simplifies the `deny.toml` configuration.

Contributes to #42 