### PR TITLE
feat(portal): fallback to 404.html blob if available

### DIFF
--- a/portal/src/sw.ts
+++ b/portal/src/sw.ts
@@ -325,7 +325,11 @@ async function resolveAndFetchPage(parsedUrl: Path): Promise<Response> {
 async function fetchPage(client: SuiClient, objectId: string, path: string): Promise<Response> {
     const resource = await fetchResource(client, objectId, path);
     if (resource === null || !resource.blob_id) {
-        return siteNotFound();
+        if (path !== '/404.html') {
+            return fetchPage(client, objectId, '/404.html');
+        } else {
+            return siteNotFound();
+        }
     }
 
     console.log("Fetched Resource: ", resource);


### PR DESCRIPTION
Works great overall. Very smooth.

One improvement I'd like: custom 404 blob for a site, something that would be returned for the site if there's nothing found for the path.

Take a look at the sample site I deployed: https://1e1maorotlxkr4feuf7m9jqliu9j12dlr8lxvt28u23f3lur5s.walrus.site/

Everything just works, out of the box, awesome, I was like going to cancel my Heroku plan.

The only thing is that if you navigate to links from the page with history api:

https://1e1maorotlxkr4feuf7m9jqliu9j12dlr8lxvt28u23f3lur5s.walrus.site/ -> https://1e1maorotlxkr4feuf7m9jqliu9j12dlr8lxvt28u23f3lur5s.walrus.site/capsule/0xfd72e8611ed8ebfa2f93acf9640bd8a5096923880feeeae7fabc96d4f6cffab2

it shows the page, but shows 404 if you do refresh. Which is expected, and we can use hash-navigation as a workaround, but would be 100% super if it would support common pattern for SPA - serve specified .html file for any path. (just custom 404 would be great for some cases too).

Adjusted service worker quickly to check if there's '404.html' blob in the root near 'index.html' and serves it on 'Not found' if it's there.