### PR TITLE
fix(portal): force old sw uninstall

### DIFF
--- a/portal/static/sw.js
+++ b/portal/static/sw.js
@@ -1,0 +1,20 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Inspired from https://github.com/NekR/self-destroying-sw
+self.addEventListener("install", (event) => {
+    self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+    self.registration
+        .unregister()
+        .then(() => self.clients.matchAll())
+        .then((clients) => {
+            clients.forEach((client) => {
+                if (client.url && "navigate" in client) {
+                    client.navigate(client.url);
+                }
+            });
+        });
+});


### PR DESCRIPTION
Fixes the problem some clients experienced after having renamed the service worker file (#98 ).

The re-introduced `/sw.js` should be removed after sufficient time has passed (#101 ).