### PR TITLE
feat(site-builder): add preproc to publish directories with files

### DIFF
--- a/site-builder/src/main.rs
+++ b/site-builder/src/main.rs
@@ -131,10 +131,9 @@ enum Commands {
         #[clap(long, default_value_t = 1)]
         epochs: u64,
         /// Preprocess the directory before publishing.
-        ///
-        /// See the `preprocess` command. Warning: Rewrites all `index.html` files.
+        /// See the `list-directory` command. Warning: Rewrites all `index.html` files.
         #[clap(long, action)]
-        preprocess: bool,
+        list_directory: bool,
     },
     /// Update an existing site
     Update {
@@ -157,10 +156,9 @@ enum Commands {
         #[clap(long, action)]
         force: bool,
         /// Preprocess the directory before updating.
-        ///
-        /// See the `preprocess` command. Warning: Rewrites all `index.html` files.
+        /// See the `list-directory` command. Warning: Rewrites all `index.html` files.
         #[clap(long, action)]
-        preprocess: bool,
+        list_directory: bool,
     },
     /// Convert an object ID in hex format to the equivalent Base36 format.
     ///
@@ -172,10 +170,9 @@ enum Commands {
     /// Show the pages composing the site at the given object ID.
     Sitemap { object: ObjectID },
     /// Preprocess the directory, creating and linking index files.
-    ///
     /// This command allows to publish directories as sites. Warning: Rewrites all `index.html`
     /// files.
-    Preprocess { path: PathBuf },
+    ListDirectory { path: PathBuf },
 }
 
 /// The configuration for the site builder.
@@ -249,7 +246,7 @@ async fn run() -> Result<()> {
             content_encoding,
             site_name,
             epochs,
-            preprocess,
+            list_directory,
         } => {
             publish_site(
                 directory,
@@ -257,7 +254,7 @@ async fn run() -> Result<()> {
                 site_name,
                 &config,
                 *epochs,
-                *preprocess,
+                *list_directory,
             )
             .await?
         }
@@ -268,7 +265,7 @@ async fn run() -> Result<()> {
             watch,
             epochs,
             force,
-            preprocess,
+            list_directory,
         } => {
             update_site(
                 directory,
@@ -278,7 +275,7 @@ async fn run() -> Result<()> {
                 *watch,
                 *epochs,
                 *force,
-                *preprocess,
+                *list_directory,
             )
             .await?;
         }
@@ -294,7 +291,7 @@ async fn run() -> Result<()> {
             }
         }
         Commands::Convert { object_id } => println!("{}", id_to_base36(object_id)?),
-        Commands::Preprocess { path } => {
+        Commands::ListDirectory { path } => {
             Preprocessor::preprocess(path)?;
         }
     };

--- a/site-builder/src/preprocessor.rs
+++ b/site-builder/src/preprocessor.rs
@@ -68,7 +68,10 @@ impl DirNode {
     fn path_to_html(path: &Path, root: &Path) -> Result<String> {
         let mut link_name = path
             .file_name()
-            .ok_or(anyhow::anyhow!("no file name"))?
+            .ok_or(anyhow::anyhow!(
+                "no valid filename found for path {}; root `/` and `..` paths are not allowed",
+                path.to_string_lossy(),
+            ))?
             .to_string_lossy()
             .to_string();
 

--- a/site-builder/src/preprocessor.rs
+++ b/site-builder/src/preprocessor.rs
@@ -38,8 +38,7 @@ impl Preprocessor {
     }
 
     pub fn preprocess(path: &Path) -> Result<()> {
-        let nodes = Self::iter_dir(path)?;
-        for node in nodes {
+        for node in Self::iter_dir(path)? {
             node.write_index(path)?;
         }
         Ok(())
@@ -85,30 +84,22 @@ impl DirNode {
     }
 
     fn to_html(&self, root: &Path) -> Result<String> {
-        let relative_dir_path = full_path_to_resource_path(&self.path, root)?;
-        let title_string = format!("Directory listing for {}", relative_dir_path);
-        let title = format!("<title>{}</title>", title_string);
-        let h1 = format!("<h1>{}</h1>", title_string);
+        let title_string = format!(
+            "Directory listing for {}",
+            full_path_to_resource_path(&self.path, root)?
+        );
 
         let mut contents: Vec<String> = self
             .contents
             .iter()
-            .map(|p| Self::path_to_html(p, root))
+            .map(|p| Ok(format!("<li>{}</li>", Self::path_to_html(p, root)?)))
             .collect::<Result<_>>()?;
         contents.sort();
-
-        let mut body = String::new();
-        body.push_str("<hr>\n");
-        body.push_str("<ul>\n");
-        for c in contents {
-            body.push_str(&format!("<li>{}</li>\n", c));
-        }
-        body.push_str("</ul>\n");
-        body.push_str("<hr>\n");
+        let body = contents.join("\n");
 
         Ok(format!(
-            "<!DOCTYPE html>\n<html>\n<head>\n{}\n</head>\n<body>\n{}\n{}</body>\n</html>",
-            title, h1, body
+            "<!DOCTYPE html>\n<html>\n<head>\n<title>{title_string}</title>\n</head>\n\
+            <body>\n<h1>{title_string}</h1>\n<hr>\n<ul>\n{body}\n</ul>\n<hr>\n</body>\n</html>",
         ))
     }
 

--- a/site-builder/src/preprocessor.rs
+++ b/site-builder/src/preprocessor.rs
@@ -1,0 +1,152 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pre-process a directory tree adding index files to make them browsable.
+//!
+//! The look and feel is taken from Python's `list_directory` method in `http.server`.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+
+use crate::site::resource::full_path_to_resource_path;
+
+pub struct Preprocessor;
+
+impl Preprocessor {
+    pub fn iter_dir(path: &Path) -> Result<Vec<DirNode>> {
+        let mut nodes = vec![];
+        let items = std::fs::read_dir(path)?;
+        let mut cur_node = DirNode::new(path.to_path_buf());
+        for item in items.flatten() {
+            let item_path = item.path();
+            // Ignore index files.
+            if item_path
+                .file_name()
+                .is_some_and(|name| name == "index.html")
+            {
+                continue;
+            }
+            cur_node.contents.push(item_path.to_path_buf());
+            if item_path.is_dir() {
+                let sub_nodes = Self::iter_dir(&item_path)?;
+                nodes.extend(sub_nodes);
+            }
+        }
+        nodes.push(cur_node);
+        Ok(nodes)
+    }
+
+    pub fn preprocess(path: &Path) -> Result<()> {
+        let nodes = Self::iter_dir(path)?;
+        for node in nodes {
+            node.write_index(path)?;
+        }
+        Ok(())
+    }
+}
+
+/// A directory in the directory tree of the preprocessor.
+#[derive(Debug)]
+pub struct DirNode {
+    /// The paths of files in the directory.
+    contents: Vec<PathBuf>,
+    path: PathBuf,
+}
+
+impl DirNode {
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            contents: vec![],
+            path,
+        }
+    }
+
+    fn index_path(&self) -> PathBuf {
+        self.path.join("index.html")
+    }
+
+    fn path_to_html(path: &Path, root: &Path) -> Result<String> {
+        let mut link_name = path
+            .file_name()
+            .ok_or(anyhow::anyhow!("no file name"))?
+            .to_string_lossy()
+            .to_string();
+
+        let actual_link = if path.is_dir() {
+            link_name.push('/');
+            path.join("index.html")
+        } else {
+            path.to_path_buf()
+        };
+
+        let resource_path = full_path_to_resource_path(&actual_link, root)?;
+        Ok(format!("<a href=\"{}\">{}</a>", resource_path, link_name,))
+    }
+
+    fn to_html(&self, root: &Path) -> Result<String> {
+        let relative_dir_path = full_path_to_resource_path(&self.path, root)?;
+        let title_string = format!("Directory listing for {}", relative_dir_path);
+        let title = format!("<title>{}</title>", title_string);
+        let h1 = format!("<h1>{}</h1>", title_string);
+
+        let mut contents: Vec<String> = self
+            .contents
+            .iter()
+            .map(|p| Self::path_to_html(p, root))
+            .collect::<Result<_>>()?;
+        contents.sort();
+
+        let mut body = String::new();
+        body.push_str("<hr>\n");
+        body.push_str("<ul>\n");
+        for c in contents {
+            body.push_str(&format!("<li>{}</li>\n", c));
+        }
+        body.push_str("</ul>\n");
+        body.push_str("<hr>\n");
+
+        Ok(format!(
+            "<!DOCTYPE html>\n<html>\n<head>\n{}\n</head>\n<body>\n{}\n{}</body>\n</html>",
+            title, h1, body
+        ))
+    }
+
+    pub fn write_index(&self, root: &Path) -> Result<()> {
+        let html = self.to_html(root)?;
+        std::fs::write(self.index_path(), html)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_dirnode_to_html() {
+        let dir = DirNode {
+            contents: vec![
+                PathBuf::from("/my/sub/path"),
+                PathBuf::from("/my/sub/another"),
+            ],
+            path: PathBuf::from("/my/sub"),
+        };
+        let expected = r#"<!DOCTYPE html>
+<html>
+<head>
+<title>Directory listing for /sub</title>
+</head>
+<body>
+<h1>Directory listing for /sub</h1>
+<hr>
+<ul>
+<li><a href="/sub/another">another</a></li>
+<li><a href="/sub/path">path</a></li>
+</ul>
+<hr>
+</body>
+</html>"#;
+        assert_eq!(dir.to_html(Path::new("/my/")).unwrap(), expected);
+    }
+}

--- a/site-builder/src/preprocessor.rs
+++ b/site-builder/src/preprocessor.rs
@@ -16,6 +16,7 @@ pub struct Preprocessor;
 impl Preprocessor {
     pub fn iter_dir(path: &Path) -> Result<Vec<DirNode>> {
         let mut nodes = vec![];
+        debug_assert!(path.is_dir());
         let items = std::fs::read_dir(path)?;
         let mut cur_node = DirNode::new(path.to_path_buf());
         for item in items.flatten() {

--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -6,7 +6,7 @@
 use std::{
     collections::BTreeSet,
     fmt::{self, Display},
-    fs::read_dir,
+    fs,
     io::Write,
     path::{Path, PathBuf},
 };
@@ -385,7 +385,7 @@ impl ResourceManager {
         content_encoding: &ContentEncoding,
     ) -> Result<Vec<Resource>> {
         let mut resources: Vec<Resource> = vec![];
-        let entries = read_dir(start)?;
+        let entries = fs::read_dir(start)?;
         for entry in entries.flatten() {
             let path = entry.path();
             if path.is_dir() {


### PR DESCRIPTION
Mimics Python's `list_directory` function when calling `http.server` on a directory without `index.html`.

Closes #84 