### PR TITLE
refactor(site-builder): deduplicate args for publish and update

### DIFF
--- a/site-builder/src/main.rs
+++ b/site-builder/src/main.rs
@@ -228,12 +228,14 @@ async fn run() -> Result<()> {
                 },
         } => {
             publish_site(
-                directory,
-                content_encoding,
-                site_name,
+                PublishOptions {
+                    directory: directory.to_path_buf(),
+                    content_encoding: *content_encoding,
+                    site_name: site_name.to_string(),
+                    epochs: *epochs,
+                    list_directory: *list_directory,
+                },
                 &config,
-                *epochs,
-                *list_directory,
             )
             .await?
         }

--- a/site-builder/src/main.rs
+++ b/site-builder/src/main.rs
@@ -223,7 +223,7 @@ async fn run() -> Result<()> {
         Commands::Publish {
             publish_options,
             site_name,
-        } => publish_site(publish_options.clone(), site_name.to_string(), &config).await?,
+        } => publish_site(publish_options, site_name, &config).await?,
         Commands::Update {
             publish_options,
             object_id,

--- a/site-builder/src/main.rs
+++ b/site-builder/src/main.rs
@@ -244,7 +244,7 @@ async fn run() -> Result<()> {
                 PublishOptions {
                     directory,
                     content_encoding,
-                    site_name: _,
+                    site_name,
                     epochs,
                     list_directory,
                 },
@@ -253,14 +253,17 @@ async fn run() -> Result<()> {
             force,
         } => {
             update_site(
-                directory,
-                content_encoding,
+                PublishOptions {
+                    directory: directory.to_path_buf(),
+                    content_encoding: *content_encoding,
+                    site_name: site_name.to_string(),
+                    epochs: *epochs,
+                    list_directory: *list_directory,
+                },
                 object_id,
                 &config,
                 *watch,
-                *epochs,
                 *force,
-                *list_directory,
             )
             .await?;
         }

--- a/site-builder/src/main.rs
+++ b/site-builder/src/main.rs
@@ -230,7 +230,7 @@ async fn run() -> Result<()> {
             watch,
             force,
         } => {
-            update_site(publish_options.clone(), &object_id, &config, watch, force).await?;
+            update_site(publish_options, &object_id, &config, watch, force).await?;
         }
         // Add a path to be watched. All files and directories at that path and
         // below will be monitored for changes.

--- a/site-builder/src/main.rs
+++ b/site-builder/src/main.rs
@@ -120,6 +120,9 @@ enum Commands {
     Publish {
         #[clap(flatten)]
         publish_options: PublishOptions,
+        /// The name of the site.
+        #[clap(short, long, default_value = "test site")]
+        site_name: String,
     },
     /// Update an existing site
     Update {
@@ -222,19 +225,19 @@ async fn run() -> Result<()> {
                 PublishOptions {
                     directory,
                     content_encoding,
-                    site_name,
                     epochs,
                     list_directory,
                 },
+            site_name,
         } => {
             publish_site(
                 PublishOptions {
                     directory: directory.to_path_buf(),
                     content_encoding: *content_encoding,
-                    site_name: site_name.to_string(),
                     epochs: *epochs,
                     list_directory: *list_directory,
                 },
+                site_name,
                 &config,
             )
             .await?
@@ -244,7 +247,6 @@ async fn run() -> Result<()> {
                 PublishOptions {
                     directory,
                     content_encoding,
-                    site_name,
                     epochs,
                     list_directory,
                 },
@@ -256,7 +258,6 @@ async fn run() -> Result<()> {
                 PublishOptions {
                     directory: directory.to_path_buf(),
                     content_encoding: *content_encoding,
-                    site_name: site_name.to_string(),
                     epochs: *epochs,
                     list_directory: *list_directory,
                 },

--- a/site-builder/src/publish.rs
+++ b/site-builder/src/publish.rs
@@ -30,7 +30,7 @@ use crate::{
     Config,
 };
 
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Clone)]
 pub struct PublishOptions {
     /// The directory containing the site sources.
     pub directory: PathBuf,
@@ -46,7 +46,11 @@ pub struct PublishOptions {
     pub list_directory: bool,
 }
 
-pub async fn publish_site(publish_options: PublishOptions, site_name: String, config: &Config) -> Result<()> {
+pub async fn publish_site(
+    publish_options: PublishOptions,
+    site_name: String,
+    config: &Config,
+) -> Result<()> {
     edit_site(
         &publish_options.directory,
         &publish_options.content_encoding,

--- a/site-builder/src/publish.rs
+++ b/site-builder/src/publish.rs
@@ -46,15 +46,11 @@ pub struct PublishOptions {
     pub list_directory: bool,
 }
 
-pub async fn publish_site(
-    publish_options: PublishOptions,
-    site_name: &str,
-    config: &Config,
-) -> Result<()> {
+pub async fn publish_site(publish_options: PublishOptions, site_name: String, config: &Config) -> Result<()> {
     edit_site(
         &publish_options.directory,
         &publish_options.content_encoding,
-        SiteIdentifier::NewSite(site_name.to_owned()),
+        SiteIdentifier::NewSite(site_name),
         config,
         publish_options.epochs,
         false,

--- a/site-builder/src/publish.rs
+++ b/site-builder/src/publish.rs
@@ -45,22 +45,15 @@ pub struct PublishOptions {
     pub list_directory: bool,
 }
 
-pub async fn publish_site(
-    directory: &Path,
-    content_encoding: &ContentEncoding,
-    site_name: &str,
-    config: &Config,
-    epochs: u64,
-    preprocess: bool,
-) -> Result<()> {
+pub async fn publish_site(publish_options: PublishOptions, config: &Config) -> Result<()> {
     edit_site(
-        directory,
-        content_encoding,
-        SiteIdentifier::NewSite(site_name.to_owned()),
+        &publish_options.directory,
+        &publish_options.content_encoding,
+        SiteIdentifier::NewSite(publish_options.site_name.to_owned()),
         config,
-        epochs,
+        publish_options.epochs,
         false,
-        preprocess,
+        publish_options.list_directory,
     )
     .await
 }

--- a/site-builder/src/publish.rs
+++ b/site-builder/src/publish.rs
@@ -1,14 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::path::PathBuf;
 use std::{path::Path, sync::mpsc::channel};
 
 use anyhow::{anyhow, Result};
+use clap::Parser;
 use notify::{RecursiveMode, Watcher};
 use sui_sdk::rpc_types::{
-    SuiExecutionStatus,
-    SuiTransactionBlockEffects,
-    SuiTransactionBlockResponse,
+    SuiExecutionStatus, SuiTransactionBlockEffects, SuiTransactionBlockResponse,
 };
 use sui_types::base_types::{ObjectID, SuiAddress};
 
@@ -25,6 +25,25 @@ use crate::{
     walrus::Walrus,
     Config,
 };
+
+#[derive(Parser, Debug)]
+pub struct PublishOptions {
+    /// The directory containing the site sources.
+    pub directory: PathBuf,
+    #[clap(short = 'e', long, value_enum, default_value_t = ContentEncoding::PlainText)]
+    /// The encoding for the contents of the site's resources.
+    pub content_encoding: ContentEncoding,
+    /// The name of the site.
+    #[clap(short, long, default_value = "test site")]
+    pub site_name: String,
+    /// The number of epochs for which to save the resources on Walrus.
+    #[clap(long, default_value_t = 1)]
+    pub epochs: u64,
+    /// Preprocess the directory before publishing.
+    /// See the `list-directory` command. Warning: Rewrites all `index.html` files.
+    #[clap(long, action)]
+    pub list_directory: bool,
+}
 
 pub async fn publish_site(
     directory: &Path,

--- a/site-builder/src/publish.rs
+++ b/site-builder/src/publish.rs
@@ -1,17 +1,20 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::path::PathBuf;
-use std::{path::Path, sync::mpsc::channel};
+use std::{
+    path::{Path, PathBuf},
+    sync::mpsc::channel,
+};
 
 use anyhow::{anyhow, Result};
 use clap::Parser;
 use notify::{RecursiveMode, Watcher};
 use sui_sdk::rpc_types::{
-    SuiExecutionStatus, SuiTransactionBlockEffects, SuiTransactionBlockResponse,
+    SuiExecutionStatus,
+    SuiTransactionBlockEffects,
+    SuiTransactionBlockResponse,
 };
 use sui_types::base_types::{ObjectID, SuiAddress};
-use sui_types::crypto::PublicKey;
 
 use crate::{
     display,

--- a/site-builder/src/publish.rs
+++ b/site-builder/src/publish.rs
@@ -37,9 +37,6 @@ pub struct PublishOptions {
     #[clap(short = 'e', long, value_enum, default_value_t = ContentEncoding::PlainText)]
     /// The encoding for the contents of the site's resources.
     pub content_encoding: ContentEncoding,
-    /// The name of the site.
-    #[clap(short, long, default_value = "test site")]
-    pub site_name: String,
     /// The number of epochs for which to save the resources on Walrus.
     #[clap(long, default_value_t = 1)]
     pub epochs: u64,
@@ -49,11 +46,15 @@ pub struct PublishOptions {
     pub list_directory: bool,
 }
 
-pub async fn publish_site(publish_options: PublishOptions, config: &Config) -> Result<()> {
+pub async fn publish_site(
+    publish_options: PublishOptions,
+    site_name: &str,
+    config: &Config,
+) -> Result<()> {
     edit_site(
         &publish_options.directory,
         &publish_options.content_encoding,
-        SiteIdentifier::NewSite(publish_options.site_name.to_owned()),
+        SiteIdentifier::NewSite(site_name.to_owned()),
         config,
         publish_options.epochs,
         false,

--- a/site-builder/src/publish.rs
+++ b/site-builder/src/publish.rs
@@ -11,6 +11,7 @@ use sui_sdk::rpc_types::{
     SuiExecutionStatus, SuiTransactionBlockEffects, SuiTransactionBlockResponse,
 };
 use sui_types::base_types::{ObjectID, SuiAddress};
+use sui_types::crypto::PublicKey;
 
 use crate::{
     display,
@@ -98,35 +99,32 @@ pub async fn watch_edit_site(
 
 #[allow(clippy::too_many_arguments)]
 pub async fn update_site(
-    directory: &Path,
-    content_encoding: &ContentEncoding,
+    publish_options: PublishOptions,
     site_object: &ObjectID,
     config: &Config,
     watch: bool,
-    epochs: u64,
     force: bool,
-    preprocess: bool,
 ) -> Result<()> {
     if watch {
         watch_edit_site(
-            directory,
-            content_encoding,
+            publish_options.directory.as_path(),
+            &publish_options.content_encoding,
             SiteIdentifier::ExistingSite(*site_object),
             config,
-            epochs,
+            publish_options.epochs,
             force,
-            preprocess,
+            publish_options.list_directory,
         )
         .await
     } else {
         edit_site(
-            directory,
-            content_encoding,
+            publish_options.directory.as_path(),
+            &publish_options.content_encoding,
             SiteIdentifier::ExistingSite(*site_object),
             config,
-            epochs,
+            publish_options.epochs,
             force,
-            preprocess,
+            publish_options.list_directory,
         )
         .await
     }


### PR DESCRIPTION
## Description

Deduplicate the arguments of Publish and Update
commands. 

There was a duplication of some fields that were
shared among the publish and update.

## Changes

The overlapping options were consolidated by
creating a PublishOptions struct that is then
added to both commands.
This new struct is also used in the publish_site
and update_site functions resolving the
"too many arguments" issue.

## Testing

- Rebuild the `site-builder` executable: 
 ```shell  
cargo build --release 
```

- Publish the example site: 
```shell
./target/release/site-builder --config site-builder/assets/builder-example.yaml publish ./examples/snake
``` 

- Update the site using the object id from the above: 
```shell
./target/release/site-builder --config site-builder/assets/builder-example.yaml update ./examples/snake 0x4f5...
```
