### PR TITLE
feat(site-builder): on publish raise an error when a file is empty

### DIFF
--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -347,10 +347,11 @@ impl ResourceManager {
 
         let plain_content = std::fs::read(full_path)?;
         if plain_content.is_empty() {
-            let error_message = format!("The file {} is empty.", full_path.to_string_lossy());
-            return Err(
-                anyhow!(error_message).context("Walrus does not support empty files.")
+            let error_message = format!(
+                "The file {} is empty. Walrus does not support empty files.",
+                full_path.to_string_lossy()
             );
+            return Err(anyhow!(error_message));
         }
         // TODO(giac): this could be (i) async; (ii) pre configured with the number of shards to
         //     avoid chain interaction (maybe after adding `info` to the JSON commands).

--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -347,11 +347,10 @@ impl ResourceManager {
 
         let plain_content = std::fs::read(full_path)?;
         if plain_content.is_empty() {
-            let error_message = format!(
-                "The file {} is empty.",
-                full_path.to_string_lossy()
+            let error_message = format!("The file {} is empty.", full_path.to_string_lossy());
+            return Err(
+                anyhow!(error_message).context("Walrus sites does not support empty files.")
             );
-            return Err(anyhow!(error_message).context("Walrus sites does not support empty files."));
         }
         // TODO(giac): this could be (i) async; (ii) pre configured with the number of shards to
         //     avoid chain interaction (maybe after adding `info` to the JSON commands).

--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -349,7 +349,7 @@ impl ResourceManager {
         if plain_content.is_empty() {
             let error_message = format!("The file {} is empty.", full_path.to_string_lossy());
             return Err(
-                anyhow!(error_message).context("Walrus sites does not support empty files.")
+                anyhow!(error_message).context("Walrus does not support empty files.")
             );
         }
         // TODO(giac): this could be (i) async; (ii) pre configured with the number of shards to

--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -348,7 +348,7 @@ impl ResourceManager {
         let plain_content = std::fs::read(full_path)?;
         if plain_content.is_empty() {
             let error_message = format!(
-                "The file {} is empty. Walrus does not support empty files.",
+                "the file {} is empty; Walrus does not support empty files",
                 full_path.to_string_lossy()
             );
             return Err(anyhow!(error_message));

--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -344,15 +344,18 @@ impl ResourceManager {
             extension.to_string_lossy(),
             full_path.to_string_lossy()
         ))?)?;
+
+        let plain_content = std::fs::read(full_path)?;
+        if plain_content.is_empty() {
+            let error_message = format!(
+                "The file {} is empty.",
+                full_path.to_string_lossy()
+            );
+            return Err(anyhow!(error_message).context("Walrus sites does not support empty files."));
+        }
         // TODO(giac): this could be (i) async; (ii) pre configured with the number of shards to
         //     avoid chain interaction (maybe after adding `info` to the JSON commands).
         let output = self.walrus.blob_id(full_path.to_owned(), None)?;
-        // Need to check the size to avoid calling encode on empty files.
-        let plain_content = std::fs::read(full_path)?;
-        if plain_content.is_empty() {
-            // We are ignoring empty files.
-            return Ok(None);
-        }
 
         // TODO(giac): How to encode based on the content encoding? Temporary file? No encoding?
         //     let content = match content_encoding {


### PR DESCRIPTION
So far the `site-builder` was silently ignoring empty files.

This PR adds a check that raises an error when an empty file is included in the directory that is to be published.
Also, the check should be done before trying to create a walrus blob id.   

i.e. 
```shell
❯ ./target/release/site-builder --config site-builder/assets/builder-example.yaml publish examples/snake/

...
Parsing the directory examples/snake/ and locally computing blob IDs ...
Error during execution
Error: error while reading resource `examples/snake/empty.txt`

Caused by:
    0: Walrus sites does not support empty files.
    1: The file examples/snake/empty.txt is empty.
```