### PR TITLE
feat(site-builder): treat unknown file extensions defaulting to arbitrary binary data

### DIFF
--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -347,11 +347,10 @@ impl ResourceManager {
 
         let plain_content = std::fs::read(full_path)?;
         if plain_content.is_empty() {
-            let error_message = format!(
-                "The file {} is empty.",
-                full_path.to_string_lossy()
+            let error_message = format!("The file {} is empty.", full_path.to_string_lossy());
+            return Err(
+                anyhow!(error_message).context("Walrus sites does not support empty files.")
             );
-            return Err(anyhow!(error_message).context("Walrus sites does not support empty files."));
         }
         // TODO(giac): this could be (i) async; (ii) pre configured with the number of shards to
         //     avoid chain interaction (maybe after adding `info` to the JSON commands).

--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -348,7 +348,7 @@ impl ResourceManager {
                 Err(_) => {
                     tracing::warn!(
                         "The extension {} string for file {} could not be decoded.
-                        Defaulting to arbitraty binary content type: octet-stream.",
+                        Defaulting to arbitrary binary content type: octet-stream.",
                         extension.to_string_lossy(),
                         full_path.to_string_lossy()
                     );

--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -344,15 +344,18 @@ impl ResourceManager {
             extension.to_string_lossy(),
             full_path.to_string_lossy()
         ))?)?;
+
+        let plain_content = std::fs::read(full_path)?;
+        if plain_content.is_empty() {
+            let error_message = format!(
+                "The file {} is empty.",
+                full_path.to_string_lossy()
+            );
+            return Err(anyhow!(error_message).context("Walrus sites does not support empty files."));
+        }
         // TODO(giac): this could be (i) async; (ii) pre configured with the number of shards to
         //     avoid chain interaction (maybe after adding `info` to the JSON commands).
         let output = self.walrus.blob_id(full_path.to_owned(), None)?;
-        // Need to check the size to avoid calling encode on empty files.
-        let plain_content = std::fs::read(full_path)?;
-        if plain_content.is_empty() {
-            // We are ignoring empty files.
-            return Ok(None);
-        }
 
         // TODO(giac): How to encode based on the content encoding? Temporary file? No encoding?
         //     let content = match content_encoding {

--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -339,11 +339,22 @@ impl ResourceManager {
                 .expect("the path should not terminate in `..`"),
         );
 
-        let content_type = ContentType::try_from_extension(extension.to_str().ok_or(anyhow!(
-            "the extension {} string for file {} could not be decoded",
-            extension.to_string_lossy(),
-            full_path.to_string_lossy()
-        ))?)?;
+        let content_type =
+            match ContentType::try_from_extension(extension.to_str().ok_or(anyhow!(
+                "Could not convert the extension {:?} to a string.",
+                extension.to_string_lossy()
+            ))?) {
+                Ok(content_type) => content_type,
+                Err(_) => {
+                    tracing::warn!(
+                        "The extension {} string for file {} could not be decoded.
+                        Defaulting to arbitraty binary content type: octet-stream.",
+                        extension.to_string_lossy(),
+                        full_path.to_string_lossy()
+                    );
+                    ContentType::ApplicationOctetstream // arbitrary binary data RFC 2046
+                }
+            };
 
         let plain_content = std::fs::read(full_path)?;
         if plain_content.is_empty() {


### PR DESCRIPTION
## Summary

Treat files without or with unknown
extension as binary files.

Whenever the dir that is to be published contains a file with no extension 
(e.g. `file`) or an unknown extension (e.g. `file.<unknown>`), a binary
content type will be assigned to it, and a warning will be shown.

The octet-stream content type indicates
a response body with arbitrary binary data
as defined in RFC 2046.

https://datatracker.ietf.org/doc/html/rfc2046#section-4.5.1

## Example output

Given the following tree structure:
```
snake
    ├── Oi-Regular.ttf
    ├── file.UNKNOWN_EXTENSION  <----- [!]
    ├── index.html
    └── walrus.svg
```  
And running `./target/release/site-builder --config site-builder/assets/builder-example.yaml publish examples/snake/`

Returns: 
```
[...]
Parsing the directory examples/snake/ and locally computing blob IDs ... 2024-07-18T11:59:04.889753Z  
WARN site_builder::site::resource: The extension UNKNOWN_EXTENSION string for file examples/snake/file.UNKNOWN_EXTENSION could not be decoded.
                        Defaulting to arbitraty binary content type: octet-stream.
                                                                         [Ok]
Storing resource on Walrus: /Oi-Regular.ttf ... [Ok]
Storing resource on Walrus: /file.UNKNOWN_EXTENSION ... [Ok]
Storing resource on Walrus: /index.html ... [Ok]
Storing resource on Walrus: /walrus.svg ... [Ok]
Updating the Walrus Site object on Sui ... 2024-07-18T11:59:11.853632Z  WARN sui_sdk::wallet_context: Client/Server api version mismatch, client api version : 1.27.2, server api version : 1.29.2
[warn] Client/Server api version mismatch, client api version : 1.27.2, server api version : 1.29.2

Execution completed
Operations performed:
  - created resource /Oi-Regular.ttf with blob ID 2YLU3Usb-WoJAgoNSZUNAFnmyo8cfV8hJYt2YdHL2Hs
  - created resource /file.UNKNOWN_EXTENSION with blob ID dxrDLHUYJTgMnctlYPvnWrS-RhlAUr5H3X3oruzxPcM
  - created resource /index.html with blob ID pZTI8Wk_CRgsYLrsgo2TUDEoR1_OiuFpjwUdZn6W7fU
  - created resource /walrus.svg with blob ID cfbbG-JRn8NHIWVJtNmo7-hEC02NpM5Rpmc8-AF8n1g

Created new site: test site
New site object ID: 0x0160cac917f5bcf0bde281b2331cc44fe1efd857ef00232bb41bb77671f07c71
Browse the resulting site at: https://18iimu4lot8c4jrkomn96zdzo748bv86a5o1exp7gyvx4wuwh.walrus.site
```

[Here](https://suiscan.xyz/testnet/object/0xfe5f318c3a28061e7c89f14e4465c2ea6756a29274ddcc0f0a1b4a9dbf92c29e) is the site Resource object of the file with unknown extension. 

Closes #110