### PR TITLE
feat(service-worker): track seen resources to avoid infinite redirect loops

### DIFF
--- a/portal/src/http_status_codes.ts
+++ b/portal/src/http_status_codes.ts
@@ -3,16 +3,7 @@
 
 // Purpose: Contains the enumeration of HTTP status codes.
 export enum HttpStatusCodes {
-    OK = 200,
-    CREATED = 201,
-    NO_CONTENT = 204,
-    MOVED_PERMANENTLY = 301,
-    FOUND = 302,
     TOO_MANY_REDIRECTS = 310,
-    BAD_REQUEST = 400,
-    UNAUTHORIZED = 401,
-    FORBIDDEN = 403,
     NOT_FOUND = 404,
-    INTERNAL_SERVER_ERROR = 500,
     LOOP_DETECTED = 508
 }

--- a/portal/src/http_status_codes.ts
+++ b/portal/src/http_status_codes.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Purpose: Contains the enumeration of HTTP status codes.
+export enum HttpStatusCodes {
+    OK = 200,
+    CREATED = 201,
+    NO_CONTENT = 204,
+    MOVED_PERMANENTLY = 301,
+    FOUND = 302,
+    TOO_MANY_REDIRECTS = 310,
+    BAD_REQUEST = 400,
+    UNAUTHORIZED = 401,
+    FORBIDDEN = 403,
+    NOT_FOUND = 404,
+    INTERNAL_SERVER_ERROR = 500,
+    LOOP_DETECTED = 508
+}

--- a/portal/src/walrus-sites-sw.ts
+++ b/portal/src/walrus-sites-sw.ts
@@ -397,12 +397,10 @@ async function fetchResource(
 ): Promise<Resource | HttpStatusCodes> {
     if (seenResources.has(objectId)) {
         return HttpStatusCodes.LOOP_DETECTED;
+    } else if (depth >= MAX_REDIRECT_DEPTH) {
+        return HttpStatusCodes.TOO_MANY_REDIRECTS;
     } else {
         seenResources.add(objectId);
-    }
-
-    if (depth > MAX_REDIRECT_DEPTH) {
-        return HttpStatusCodes.TOO_MANY_REDIRECTS;
     }
 
     let [redirectId, dynamicFields] = await Promise.all([

--- a/portal/src/walrus-sites-sw.ts
+++ b/portal/src/walrus-sites-sw.ts
@@ -339,7 +339,7 @@ async function fetchPage(client: SuiClient, objectId: string, path: string): Pro
     const result = await fetchResource(client, objectId, path, new Set<string>);
     if (!isResource(result)) {
         const httpStatus = result as number;
-        return new Response("Unable to fetch the site resource.", { status: result });
+        return new Response("Unable to fetch the site resource.", { status: httpStatus });
     }
 
     if (!result.blob_id) {

--- a/portal/src/walrus-sites-sw.ts
+++ b/portal/src/walrus-sites-sw.ts
@@ -337,8 +337,7 @@ async function resolveAndFetchPage(parsedUrl: Path): Promise<Response> {
  */
 async function fetchPage(client: SuiClient, objectId: string, path: string): Promise<Response> {
     const result = await fetchResource(client, objectId, path, new Set<string>);
-    const unsuccessfulResourceFetch = !isResource(result)
-    if (unsuccessfulResourceFetch) {
+    if (!isResource(result)) {
         const httpStatus = result as number;
         return new Response("Unable to fetch the site resource.", { status: result });
     }


### PR DESCRIPTION
When recursively redirecting to the object ids of a Display, keep track of the "visited" object ids to avoid 
infinite loops. Source: https://github.com/MystenLabs/walrus-sites/pull/58#discussion_r1635253806

Also refactored the return type of the fetchResource function It would return `null` for cases where the resource would not be able to load. 

This is not ideal, since we need to be more expressive with our responses (we introduce another error of INFINITE_LOOPS 508 and 310 for maximum number of redirects reached). 

Using an http status codes enum enables us to propagate the nature of those errors to the response of `fetchPage`.