### PR TITLE
fix(portal): fix landing page server portal infinite loop

### DIFF
--- a/portal/common/lib/domain_parsing.ts
+++ b/portal/common/lib/domain_parsing.ts
@@ -62,6 +62,6 @@ function splitUrl(url: URL): UrlExtract {
  * @param path The path to remove the last forward-slash from.
  * @returns The path without the last forward-slash.
  */
-function removeLastSlash(path: string): string {
+export function removeLastSlash(path: string): string {
     return path.endsWith("/") ? path.slice(0, -1) : path;
 }

--- a/portal/server/app/route.ts
+++ b/portal/server/app/route.ts
@@ -1,17 +1,19 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { getDomain, getSubdomainAndPath } from '@lib/domain_parsing'
+import { getDomain, getSubdomainAndPath, removeLastSlash } from '@lib/domain_parsing'
 import { redirectToAggregatorUrlResponse, redirectToPortalURLResponse } from '@lib/redirects'
 import { getBlobIdLink, getObjectIdLink } from '@lib/links'
 import { resolveAndFetchPage } from '@lib/page_fetching'
+import { NextResponse } from 'next/server'
+import path from 'path'
 
 export async function GET(req: Request) {
     const originalUrl = req.headers.get('x-original-url')
     if (!originalUrl) {
         throw new Error('No original url found in request headers')
     }
-    const url = new URL(originalUrl ?? req.url)
+    const url = new URL(originalUrl)
 
     const objectIdPath = getObjectIdLink(url.toString())
     if (objectIdPath) {
@@ -34,16 +36,27 @@ export async function GET(req: Request) {
         return resolveAndFetchPage(parsedUrl)
     }
 
-    const scopeString = new URL(req.url).origin
+    const atBaseUrl = portalDomain == url.host.split(':')[0]
+    if (atBaseUrl) {
+        console.log('serving the landing page from another service')
+        const landingPageServiceName = `https://walrus.site`
+        const response = await fetch(`${landingPageServiceName}${parsedUrl?.path}`)
+        const data = await response.text()
+        console.log(response.headers.get('content-type'))
 
-    // Handle the case in which we are at the root `BASE_URL`
-    if (req.url === scopeString || req.url === scopeString + 'index.html') {
-        console.log('serving the landing page')
-        const newUrl = scopeString + 'index-sw-enabled.html'
+        // Proxy requests for CSS and fonts
+        const proxiedData = data.replace(
+            /(href|src)="\/([^"]+)"/g,
+            `$1="${landingPageServiceName}/$2"`
+        )
 
-        return fetch(newUrl)
+        // Return the fetched data as a response
+        return new Response(proxiedData, {
+            headers: {
+                'content-type': response.headers.get('content-type') ?? 'text/html'
+            }
+        })
     }
 
-    const response = await fetch(req)
-    return response
+    return new Response(`Resource at ${originalUrl} not found!`, { status: 404 })
 }

--- a/portal/server/vercel.json
+++ b/portal/server/vercel.json
@@ -1,0 +1,6 @@
+{
+    "framework": null,
+    "installCommand": "pnpm install",
+    "buildCommand": "pnpm run build",
+    "outputDirectory": "dist"
+}


### PR DESCRIPTION
Resolves https://github.com/MystenLabs/walrus-sites/issues/147

## Changes 

Add the functionality so that while browsing the landing page of the server portal fetch the page contents by the worker portal.

## Future work 
This is a temporary solution in order to make the server side portal work. 

As an improvement to this, in a following PR we can consider redirecting to fetch the page from another service on vercel (similar to how the worker portal works). 


