### PR TITLE
fix(portal): edge function invocation failed

### DIFF
--- a/portal/server/vercel.json
+++ b/portal/server/vercel.json
@@ -1,5 +1,5 @@
 {
-    "framework": null,
+    "framework": "nextjs",
     "installCommand": "pnpm install",
     "buildCommand": "pnpm run build",
     "outputDirectory": ".next"


### PR DESCRIPTION
Server portal deployment was failing on vercel due to a cryptic `EDGE_FUNCTION_INVOCATION_FAILED` error.

To fix it I had to specify `"framework": "nextjs"` on `vercel.json`.