### PR TITLE
fix(portal): fetch walrus sites index sw enabled

### DIFF
--- a/portal/server/app/route.ts
+++ b/portal/server/app/route.ts
@@ -39,7 +39,7 @@ export async function GET(req: Request) {
     const atBaseUrl = portalDomain == url.host.split(':')[0]
     if (atBaseUrl) {
         console.log('serving the landing page from another service')
-        const landingPageServiceName = `https://walrus.site`
+        const landingPageServiceName = `https://walrus.site/index-sw-enabled.html`
         const response = await fetch(`${landingPageServiceName}${parsedUrl?.path}`)
         const data = await response.text()
         console.log(response.headers.get('content-type'))


### PR DESCRIPTION
While fetching `walrus.site/index.html` is registering a service worker, which
we don't want in our server portal implementation.

`index-sw-enabled.html` in the same, but without the service worker registration.