### PR TITLE
feat(site-builder): allow empty files

### DIFF
--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -357,13 +357,6 @@ impl ResourceManager {
             };
 
         let plain_content = std::fs::read(full_path)?;
-        if plain_content.is_empty() {
-            let error_message = format!(
-                "the file {} is empty; Walrus does not support empty files",
-                full_path.to_string_lossy()
-            );
-            return Err(anyhow!(error_message));
-        }
         // TODO(giac): this could be (i) async; (ii) pre configured with the number of shards to
         //     avoid chain interaction (maybe after adding `info` to the JSON commands).
         let output = self.walrus.blob_id(full_path.to_owned(), None)?;


### PR DESCRIPTION
This should only be merged after the re-deployment of the Walrus Devnet.

Closes #125 