### PR TITLE
Revert "fix(portal): edge function invocation failed (#153)"

### DIFF
--- a/portal/server/vercel.json
+++ b/portal/server/vercel.json
@@ -1,5 +1,5 @@
 {
-    "framework": "nextjs",
+    "framework": null,
     "installCommand": "pnpm install",
     "buildCommand": "pnpm run build",
     "outputDirectory": ".next"


### PR DESCRIPTION
The portal server would not load when fetching the walrus.site/index-sw-enabled.html.

In the near future we will make a cleaner implementation of the portal's landing page so that this complexity of a shared landing page between different portal implementations will be removed.

Only temporarily, we can accept fetching the walrus.site/index.html that installs a service worker to the user's browser, even though it's not needed.

This reverts commit 4fdab4af7ab7668615f243f6e11c0c5eeb0a9d5d.