### PR TITLE
Revert "fix(portal): fetch walrus sites index sw enabled (#154)"

### DIFF
--- a/portal/server/app/route.ts
+++ b/portal/server/app/route.ts
@@ -39,7 +39,7 @@ export async function GET(req: Request) {
     const atBaseUrl = portalDomain == url.host.split(':')[0]
     if (atBaseUrl) {
         console.log('serving the landing page from another service')
-        const landingPageServiceName = `https://walrus.site/index-sw-enabled.html`
+        const landingPageServiceName = `https://walrus.site`
         const response = await fetch(`${landingPageServiceName}${parsedUrl?.path}`)
         const data = await response.text()
         console.log(response.headers.get('content-type'))


### PR DESCRIPTION
This reverts commit 0327bc7d927dec1f47e8bebcc213e0956423b7c9.

The portal server would not load when fetching the walrus.site/index-sw-enabled.html.

In the near future we will make a cleaner implementation of the portal's landing page so that this complexity of a shared landing page between different portal implementations will be removed.

Only temporarily, we can accept fetching the walrus.site/index.html that installs a service worker to the user's browser, even though it's not needed.