### PR TITLE
refactor(portal): Rename index-sw-enabled.html upon publish landing page

### DIFF
--- a/portal/server/app/route.ts
+++ b/portal/server/app/route.ts
@@ -37,14 +37,11 @@ export async function GET(req: Request) {
     const atBaseUrl = portalDomain == url.host.split(':')[0]
     if (atBaseUrl) {
         console.log('Serving the landing page from walrus...')
-        const blobId = '55onty23j6xl6axb7z2o03t5zs6gmosw30qjb4lqr3t60ukc0a'
-        const resourcePath = parsedUrl?.path == '/index.html' ?
-            '/index-sw-enabled.html' :
-            parsedUrl?.path ?? '/index-sw-enabled.html'
+        const blobId = '60y9fj0iyk5nt1pu3uebk6ppivknyw04wvx9rbqwqpai5jjwu6'
         const response = await resolveAndFetchPage(
             {
                 subdomain: blobId,
-                path: resourcePath
+                path: parsedUrl?.path ?? '/index.html'
             }
         )
         return response

--- a/publish_landing_page.sh
+++ b/publish_landing_page.sh
@@ -8,11 +8,9 @@ cargo build --release && \
 echo "Creating temporary landing page directory..." && \
 mkdir temp-landing-page && \
 cp -r portal/common/static/* temp-landing-page && \
-rm temp-landing-page/{\
-    index.html,\
-    404-page.template.html,\
-    sw.js,walrus-sites-portal-register-sw.js\
-    } && \
+rm temp-landing-page/index.html && \
+mv temp-landing-page/index-sw-enabled.html temp-landing-page/index.html && \
+rm temp-landing-page/{404-page.template.html,sw.js,walrus-sites-portal-register-sw.js} && \
 echo "Publishing landing page to walrus sites..."
 ./target/release/site-builder --config \
 site-builder/assets/builder-example.yaml publish temp-landing-page/ \


### PR DESCRIPTION
While publishing the landing page to walrus,
the `index-sw-enabled.html` is renamed to `index.html` to avoid resolving this mapping on
`portal/server/app/route.ts`.