### PR TITLE
chore: change issue templates to match walrus-docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/code-bug.yaml
+++ b/.github/ISSUE_TEMPLATE/code-bug.yaml
@@ -1,6 +1,5 @@
 name: Bug Report
 description: File a bug report.
-title: "[Bug]: "
 labels: ["bug"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -1,6 +1,5 @@
 name: Feature Request
 description: File a feature request.
-title: "[Feature]: "
 labels: ["enhancement"]
 body:
   - type: markdown


### PR DESCRIPTION
Removes the `[title]:` titles for consistency