### PR TITLE
feat(portal): add caching to the service worker

### DIFF
--- a/portal/common/lib/page_fetching.ts
+++ b/portal/common/lib/page_fetching.ts
@@ -85,7 +85,8 @@ async function fetchPage(client: SuiClient, objectId: string, path: string): Pro
         headers: {
             "Content-Type": result.content_type,
             "x-resource-sui-object-version": result.version,
-            "x-resource-sui-object-id": objectId,
+            "x-resource-sui-object-id": result.objectId,
+            "x-created-at": Date.now().toString()
         },
     });
 }

--- a/portal/common/lib/page_fetching.ts
+++ b/portal/common/lib/page_fetching.ts
@@ -86,7 +86,7 @@ async function fetchPage(client: SuiClient, objectId: string, path: string): Pro
             "Content-Type": result.content_type,
             "x-resource-sui-object-version": result.version,
             "x-resource-sui-object-id": result.objectId,
-            "x-created-at": Date.now().toString()
+            "x-unix-time-cached": Date.now().toString()
         },
     });
 }

--- a/portal/common/lib/page_fetching.ts
+++ b/portal/common/lib/page_fetching.ts
@@ -84,6 +84,8 @@ async function fetchPage(client: SuiClient, objectId: string, path: string): Pro
     return new Response(decompressed, {
         headers: {
             "Content-Type": result.content_type,
+            "x-resource-sui-object-version": result.version,
+            "x-resource-sui-object-id": objectId,
         },
     });
 }

--- a/portal/common/lib/resource.ts
+++ b/portal/common/lib/resource.ts
@@ -88,6 +88,7 @@ export async function fetchResource(
     const versionedSiteResource = {
         ...siteResource,
         version: pageData.data?.version,
+        objectId: dynamicFields.data.objectId,
     };
     return versionedSiteResource;
 }

--- a/portal/common/lib/resource.ts
+++ b/portal/common/lib/resource.ts
@@ -3,7 +3,7 @@
 
 import { HttpStatusCodes } from "./http/http_status_codes";
 import { SuiClient, SuiObjectData } from "@mysten/sui/client";
-import { Resource } from "./types";
+import { Resource, VersionedResource } from "./types";
 import { MAX_REDIRECT_DEPTH, RESOURCE_PATH_MOVE_TYPE } from "./constants";
 import { checkRedirect } from "./redirects";
 import { fromB64 } from "@mysten/bcs";
@@ -37,7 +37,7 @@ export async function fetchResource(
     path: string,
     seenResources: Set<string>,
     depth: number = 0,
-): Promise<Resource | HttpStatusCodes> {
+): Promise<VersionedResource | HttpStatusCodes> {
     if (seenResources.has(objectId)) {
         return HttpStatusCodes.LOOP_DETECTED;
     } else if (depth >= MAX_REDIRECT_DEPTH) {
@@ -85,7 +85,11 @@ export async function fetchResource(
     if (!siteResource || !siteResource.blob_id) {
         return HttpStatusCodes.NOT_FOUND;
     }
-    return siteResource;
+    const versionedSiteResource = {
+        ...siteResource,
+        version: pageData.data?.version,
+    };
+    return versionedSiteResource;
 }
 
 /**

--- a/portal/common/lib/types/index.ts
+++ b/portal/common/lib/types/index.ts
@@ -27,6 +27,10 @@ export type Resource = {
     blob_id: string;
 };
 
+export type VersionedResource = Resource & {
+    version: string; // the sui object version of the site
+};
+
 /**
  * Type guard for the Resource type.
 */

--- a/portal/common/lib/types/index.ts
+++ b/portal/common/lib/types/index.ts
@@ -28,7 +28,8 @@ export type Resource = {
 };
 
 export type VersionedResource = Resource & {
-    version: string; // the sui object version of the site
+    version: string; // the sui object version of the site resource
+    objectId: string; // the sui object id of the site resource
 };
 
 /**

--- a/portal/worker/src/caching.ts
+++ b/portal/worker/src/caching.ts
@@ -1,0 +1,100 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { resolveAndFetchPage } from "@lib/page_fetching";
+import { SuiClient, getFullnodeUrl } from "@mysten/sui/client";
+import { NETWORK } from "@lib/constants";
+import { DomainDetails } from "@lib/types";
+
+const CACHE_NAME = "walrus-sites-cache";
+// TODO - move it to .env
+const CACHE_EXPIRATION_TIME = 24 * 60 * 60 * 1000 // 24 hours in milliseconds
+
+/**
+* Respond to the request using the cache API.
+*/
+export default async function respondUsingCache(
+    event: FetchEvent, parsedUrl: DomainDetails, urlString: string
+) {
+    event.respondWith((async () => {
+        if (!('caches' in self)) {
+            // When not being in a secure context, the Cache API is not available.
+            console.warn('Cache API not available');
+            return await resolveAndFetchPage(parsedUrl);
+        }
+
+        const cache = await caches.open(CACHE_NAME);
+        const cachedResponse = await cache.match(urlString);
+        const cacheWasFresh = !(await cleanExpiredCache(cachedResponse, urlString));
+
+        let isCacheSameAsNetwork: boolean;
+        if (cachedResponse && cacheWasFresh) {
+            console.log('Cache hit!')
+            try {
+                isCacheSameAsNetwork = await checkCachedVersionMatchesOnChain(cachedResponse);
+                if (isCacheSameAsNetwork) return cachedResponse;
+            } catch (e) {
+                console.error("Error checking cache version against chain:", e);
+            }
+        }
+        console.log("Cache miss!", urlString);
+        const resolvedPage = await resolveAndFetchPage(parsedUrl);
+
+        cache.put(urlString, resolvedPage.clone());
+        return resolvedPage;
+    })());
+}
+
+/**
+* Removes an entry of the cache, if that entry is expired.
+*
+* The expiration time is set by the `CACHE_EXPIRATION_TIME` constant.
+* If the cached response is older than the expiration time, it's no longer
+* "fresh" and it is removed from the cache.
+*
+* @param urlString the key of the cached entry to check
+* @returns true if the cache entry was removed, false otherwise
+*/
+async function cleanExpiredCache(cachedResponse: Response, urlString: string): Promise<boolean> {
+    const cache = await caches.open(CACHE_NAME);
+    const now = Date.now();
+
+    if (cachedResponse) { // Cache hit!
+        const timestamp = parseInt(cachedResponse.headers.get("x-unix-time-cached") || "0");
+        const hasExpired = now - timestamp > CACHE_EXPIRATION_TIME
+        if (hasExpired) {
+            await cache.delete(urlString);
+            console.log('Removed expired cache entry:', urlString);
+            return true;
+        }
+        console.log('Cache entry is still fresh:', urlString)
+    }
+    return false;
+}
+
+/**
+* Check if the cached version of the Resource object matches the current on-chain version.
+*
+* @param cachedResponse the response to check the version of
+* @returns true if the cached version matches the current version of the Resource object
+*/
+async function checkCachedVersionMatchesOnChain(cachedResponse: Response): Promise<boolean> {
+    if (!cachedResponse){
+        throw new Error("Cached response is null!");
+    }
+    const rpcUrl = getFullnodeUrl(NETWORK);
+    const client = new SuiClient({ url: rpcUrl });
+    const cachedVersion = cachedResponse.headers.get("x-resource-sui-object-version")
+    const objectId = cachedResponse.headers.get("x-resource-sui-object-id");
+    if (!cachedVersion || !objectId) {
+        throw new Error("Cached response does not have the required headers");
+    }
+    const resourceObject = await client.getObject({id: objectId});
+    if (!resourceObject.data) {
+        throw new Error("Could not retrieve Resource object.");
+    }
+    console.log("Cached version: ", cachedVersion)
+    console.log("Current version: ", resourceObject.data?.version)
+    const currentObjectVersion = resourceObject.data?.version;
+    return cachedVersion === currentObjectVersion;
+}

--- a/portal/worker/src/caching.ts
+++ b/portal/worker/src/caching.ts
@@ -7,7 +7,6 @@ import { NETWORK } from "@lib/constants";
 import { DomainDetails } from "@lib/types";
 
 const CACHE_NAME = "walrus-sites-cache";
-// TODO - move it to .env
 const CACHE_EXPIRATION_TIME = 24 * 60 * 60 * 1000 // 24 hours in milliseconds
 
 /**

--- a/portal/worker/src/walrus-sites-sw.ts
+++ b/portal/worker/src/walrus-sites-sw.ts
@@ -49,15 +49,17 @@ self.addEventListener("fetch", async (event) => {
     console.log("Parsed URL: ", parsedUrl);
 
     if (requestDomain == portalDomain && parsedUrl && parsedUrl.subdomain) {
+        let response: Promise<Response>;
         if (!("caches" in self)) {
             // When not being in a secure context, the Cache API is not available.
             console.warn("Cache API not available");
-            const response = resolveAndFetchPage(parsedUrl)
-            event.respondWith(response);
-            return
+            response = resolveAndFetchPage(parsedUrl);
+        } else {
+            response = resolveWithCache(parsedUrl, urlString);
         }
-        const response = resolveWithCache(parsedUrl, urlString)
-        return event.respondWith(response);
+        event.respondWith(response);
+        return;
+
     }
 
     // Handle the case in which we are at the root `BASE_URL`

--- a/portal/worker/src/walrus-sites-sw.ts
+++ b/portal/worker/src/walrus-sites-sw.ts
@@ -6,6 +6,8 @@ import { redirectToAggregatorUrlResponse, redirectToPortalURLResponse } from "@l
 import { getBlobIdLink, getObjectIdLink } from "@lib/links";
 import { resolveAndFetchPage } from "@lib/page_fetching";
 
+const cacheName = "walrus-sites-cache";
+
 // This is to get TypeScript to recognize `clients` and `self` Default type of `self` is
 // `WorkerGlobalScope & typeof globalThis` https://github.com/microsoft/TypeScript/issues/14877
 declare var self: ServiceWorkerGlobalScope;
@@ -51,7 +53,19 @@ self.addEventListener("fetch", async (event) => {
 
     if (requestDomain == portalDomain && parsedUrl && parsedUrl.subdomain) {
         console.log("fetching from the service worker");
-        event.respondWith(resolveAndFetchPage(parsedUrl));
+        if (('caches' in self)) {
+            console.warn('Cache API not available');
+        } else {
+            console.log('Cache API available');
+        }
+        // const cachedResponse = await caches.match(event.request);
+        // if (cachedResponse) {
+        //     console.log("CACHE FIRED!")
+        //     event.respondWith(cachedResponse);
+        // } else {
+        const page = resolveAndFetchPage(parsedUrl)
+        event.respondWith(page);
+        // }
         return;
     }
 

--- a/portal/worker/src/walrus-sites-sw.ts
+++ b/portal/worker/src/walrus-sites-sw.ts
@@ -68,7 +68,7 @@ self.addEventListener("fetch", async (event) => {
             let isCacheSameAsNetwork: boolean;
             try {
                 if (cachedResponse) {
-                    isCacheSameAsNetwork = await checkCachedVersionMatchesOnChain(cachedResponse)
+                    isCacheSameAsNetwork = await checkCachedVersionMatchesOnChain(cachedResponse);
                 }
             } catch (e) {
                 console.error("Error checking cache version against chain:", e);

--- a/portal/worker/src/walrus-sites-sw.ts
+++ b/portal/worker/src/walrus-sites-sw.ts
@@ -8,7 +8,7 @@ import { resolveAndFetchPage } from "@lib/page_fetching";
 import { SuiClient, getFullnodeUrl } from "@mysten/sui/client";
 import { NETWORK } from "@lib/constants";
 
-const cacheName = "walrus-sites-cache";
+const CACHE_NAME = "walrus-sites-cache";
 // TODO - move it to .env
 const CACHE_EXPIRATION_TIME = 24 * 60 * 60 * 1000 // 24 hours in milliseconds
 
@@ -63,7 +63,7 @@ self.addEventListener("fetch", async (event) => {
                 return await resolveAndFetchPage(parsedUrl);
             }
 
-            const cache = await caches.open(cacheName);
+            const cache = await caches.open(CACHE_NAME);
             const cachedResponse = await cache.match(urlString);
             let isCacheSameAsNetwork: boolean;
             try {
@@ -113,7 +113,7 @@ self.addEventListener("fetch", async (event) => {
 * for the O(n) complexity to affect UX.
 */
 async function cleanExpiredCache() {
-    const cache = await caches.open(cacheName);
+    const cache = await caches.open(CACHE_NAME);
     const keys = await cache.keys();
     const now = Date.now();
 

--- a/portal/worker/src/walrus-sites-sw.ts
+++ b/portal/worker/src/walrus-sites-sw.ts
@@ -15,8 +15,6 @@ const CACHE_EXPIRATION_TIME = 24 * 60 * 60 * 1000 // 24 hours in milliseconds
 declare var self: ServiceWorkerGlobalScope;
 declare var clients: Clients;
 
-// Event listeners.
-
 self.addEventListener("install", (_event) => {
     self.skipWaiting();
 });
@@ -100,6 +98,17 @@ self.addEventListener("fetch", async (event) => {
     return response;
 });
 
+/**
+* Clean the cache of expired entries.
+*
+* Iterates over all the cache entries and removes the ones that have expired.
+* The expiration time is set by the `CACHE_EXPIRATION_TIME` constant.
+* The cache key contains the timestamp of the entry, which is used to determine
+* if the entry has expired.
+*
+* The `CACHE_EXPIRATION_TIME` will not be large enough (usually max 24h)
+* for the O(n) complexity to affect UX.
+*/
 async function cleanExpiredCache() {
     const cache = await caches.open(cacheName);
     const keys = await cache.keys();

--- a/portal/worker/src/walrus-sites-sw.ts
+++ b/portal/worker/src/walrus-sites-sw.ts
@@ -87,24 +87,22 @@ async function respondUsingCache(event: FetchEvent, parsedUrl: DomainDetails, ur
         const cache = await caches.open(CACHE_NAME);
         const cachedResponse = await cache.match(urlString);
         const cacheWasFresh = !(await cleanExpiredCache(cachedResponse, urlString));
-        let isCacheSameAsNetwork: boolean;
-        try {
-            if (cachedResponse && cacheWasFresh) {
-                isCacheSameAsNetwork = await checkCachedVersionMatchesOnChain(cachedResponse);
-            }
-        } catch (e) {
-            console.error("Error checking cache version against chain:", e);
-        }
-        if (cachedResponse && isCacheSameAsNetwork) {
-            console.log("Cache hit!", urlString);
-            return cachedResponse;
-        } else {
-            console.log("Cache miss!", urlString);
-            const resolvedPage = await resolveAndFetchPage(parsedUrl);
 
-            cache.put(urlString, resolvedPage.clone());
-            return resolvedPage;
+        let isCacheSameAsNetwork: boolean;
+        if (cachedResponse && cacheWasFresh) {
+            console.log('Cache hit!')
+            try {
+                isCacheSameAsNetwork = await checkCachedVersionMatchesOnChain(cachedResponse);
+                if (isCacheSameAsNetwork) return cachedResponse;
+            } catch (e) {
+                console.error("Error checking cache version against chain:", e);
+            }
         }
+        console.log("Cache miss!", urlString);
+        const resolvedPage = await resolveAndFetchPage(parsedUrl);
+
+        cache.put(urlString, resolvedPage.clone());
+        return resolvedPage;
     })());
 }
 

--- a/portal/worker/src/walrus-sites-sw.ts
+++ b/portal/worker/src/walrus-sites-sw.ts
@@ -124,7 +124,7 @@ async function cleanExpiredCache() {
     for (const urlString of keys) {
         const response = await cache.match(urlString);
         if (response) {
-            const timestamp = parseInt(response.headers.get("x-created-at") || "0");
+            const timestamp = parseInt(response.headers.get("x-unix-time-cached") || "0");
             if (now - timestamp > CACHE_EXPIRATION_TIME) {
                 await cache.delete(urlString);
                 console.log('Removed expired cache entry:', urlString.url);

--- a/portal/worker/src/walrus-sites-sw.ts
+++ b/portal/worker/src/walrus-sites-sw.ts
@@ -4,14 +4,7 @@
 import { getDomain, getSubdomainAndPath } from "@lib/domain_parsing";
 import { redirectToAggregatorUrlResponse, redirectToPortalURLResponse } from "@lib/redirects";
 import { getBlobIdLink, getObjectIdLink } from "@lib/links";
-import { resolveAndFetchPage } from "@lib/page_fetching";
-import { SuiClient, getFullnodeUrl } from "@mysten/sui/client";
-import { NETWORK } from "@lib/constants";
-import { DomainDetails } from "@lib/types";
-
-const CACHE_NAME = "walrus-sites-cache";
-// TODO - move it to .env
-const CACHE_EXPIRATION_TIME = 24 * 60 * 60 * 1000 // 24 hours in milliseconds
+import respondUsingCache from './caching'
 
 // This is to get TypeScript to recognize `clients` and `self` Default type of `self` is
 // `WorkerGlobalScope & typeof globalThis` https://github.com/microsoft/TypeScript/issues/14877
@@ -72,90 +65,3 @@ self.addEventListener("fetch", async (event) => {
     const response = await fetch(event.request);
     return response;
 });
-
-/**
-* Respond to the request using the cache API.
-*/
-async function respondUsingCache(event: FetchEvent, parsedUrl: DomainDetails, urlString: string) {
-    event.respondWith((async () => {
-        if (!('caches' in self)) {
-            // When not being in a secure context, the Cache API is not available.
-            console.warn('Cache API not available');
-            return await resolveAndFetchPage(parsedUrl);
-        }
-
-        const cache = await caches.open(CACHE_NAME);
-        const cachedResponse = await cache.match(urlString);
-        const cacheWasFresh = !(await cleanExpiredCache(cachedResponse, urlString));
-
-        let isCacheSameAsNetwork: boolean;
-        if (cachedResponse && cacheWasFresh) {
-            console.log('Cache hit!')
-            try {
-                isCacheSameAsNetwork = await checkCachedVersionMatchesOnChain(cachedResponse);
-                if (isCacheSameAsNetwork) return cachedResponse;
-            } catch (e) {
-                console.error("Error checking cache version against chain:", e);
-            }
-        }
-        console.log("Cache miss!", urlString);
-        const resolvedPage = await resolveAndFetchPage(parsedUrl);
-
-        cache.put(urlString, resolvedPage.clone());
-        return resolvedPage;
-    })());
-}
-
-/**
-* Removes an entry of the cache, if that entry is expired.
-*
-* The expiration time is set by the `CACHE_EXPIRATION_TIME` constant.
-* If the cached response is older than the expiration time, it's no longer
-* "fresh" and it is removed from the cache.
-*
-* @param urlString the key of the cached entry to check
-* @returns true if the cache entry was removed, false otherwise
-*/
-async function cleanExpiredCache(cachedResponse: Response, urlString: string): Promise<boolean> {
-    const cache = await caches.open(CACHE_NAME);
-    const now = Date.now();
-
-    if (cachedResponse) { // Cache hit!
-        const timestamp = parseInt(cachedResponse.headers.get("x-unix-time-cached") || "0");
-        const hasExpired = now - timestamp > CACHE_EXPIRATION_TIME
-        if (hasExpired) {
-            await cache.delete(urlString);
-            console.log('Removed expired cache entry:', urlString);
-            return true;
-        }
-        console.log('Cache entry is still fresh:', urlString)
-    }
-    return false;
-}
-
-/**
-* Check if the cached version of the Resource object matches the current on-chain version.
-*
-* @param cachedResponse the response to check the version of
-* @returns true if the cached version matches the current version of the Resource object
-*/
-async function checkCachedVersionMatchesOnChain(cachedResponse: Response): Promise<boolean> {
-    if (!cachedResponse){
-        throw new Error("Cached response is null!");
-    }
-    const rpcUrl = getFullnodeUrl(NETWORK);
-    const client = new SuiClient({ url: rpcUrl });
-    const cachedVersion = cachedResponse.headers.get("x-resource-sui-object-version")
-    const objectId = cachedResponse.headers.get("x-resource-sui-object-id");
-    if (!cachedVersion || !objectId) {
-        throw new Error("Cached response does not have the required headers");
-    }
-    const resourceObject = await client.getObject({id: objectId});
-    if (!resourceObject.data) {
-        throw new Error("Could not retrieve Resource object.");
-    }
-    console.log("Cached version: ", cachedVersion)
-    console.log("Current version: ", resourceObject.data?.version)
-    const currentObjectVersion = resourceObject.data?.version;
-    return cachedVersion === currentObjectVersion;
-}

--- a/portal/worker/src/walrus-sites-sw.ts
+++ b/portal/worker/src/walrus-sites-sw.ts
@@ -80,10 +80,6 @@ self.addEventListener("fetch", async (event) => {
                 console.log("Cache miss!", urlString);
                 const resolvedPage = await resolveAndFetchPage(parsedUrl);
 
-                // The urlString (i.e. the cache key) will also contain the timestamp
-                // to ensure that the cache is not stale.
-                // The delimiter used is an illegal URI character
-                // to avoid any conflicts with the actual URL.
                 cache.put(urlString, resolvedPage.clone());
                 return resolvedPage;
             }

--- a/portal/worker/src/walrus-sites-sw.ts
+++ b/portal/worker/src/walrus-sites-sw.ts
@@ -84,10 +84,7 @@ self.addEventListener("fetch", async (event) => {
                 // to ensure that the cache is not stale.
                 // The delimiter used is an illegal URI character
                 // to avoid any conflicts with the actual URL.
-                const timestamp = Date.now().toString();
-                const illegalURIChar = "#"
-                cache.put(urlString + illegalURIChar + timestamp, resolvedPage.clone());
-
+                cache.put(urlString, resolvedPage.clone());
                 return resolvedPage;
             }
         })());
@@ -127,7 +124,7 @@ async function cleanExpiredCache() {
     for (const urlString of keys) {
         const response = await cache.match(urlString);
         if (response) {
-            const timestamp = parseInt(urlString.url.split("#")[1]);
+            const timestamp = parseInt(response.headers.get("x-created-at") || "0");
             if (now - timestamp > CACHE_EXPIRATION_TIME) {
                 await cache.delete(urlString);
                 console.log('Removed expired cache entry:', urlString.url);


### PR DESCRIPTION
Create a caching mechanism on the service worker. 

Caches are expired when:

1. The timestamp is too old
2. The cached sui object version of the `site::Resource` does not match the one that is on-chain. 

~~The `caches` api is only available for "secure contexts" so in order to test this locally one needs to use a tool like `mkcert` for local https certs.~~ 

Localhost is a secure context, so no need to issue a cert to test this. If you still experience issues with the browser's state, use chrome's incognito mode.