### PR TITLE
feat(portal): add more unit tests to the portal common library

### DIFF
--- a/portal/common/lib/links.test.ts
+++ b/portal/common/lib/links.test.ts
@@ -1,0 +1,44 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, test } from 'vitest';
+import { getObjectIdLink, getBlobIdLink } from './links';
+import { DomainDetails } from './types';
+
+const getObjectIdLinkTestCases: [string, DomainDetails | null][] = [
+    ["https://example.suiobj/resource/path", { subdomain: "example", path: "/resource/path" }],
+    ["https://another-example.suiobj/another/resource/path",
+        { subdomain: "another-example", path: "/another/resource/path" }],
+    ["https://invalidsite.com/something", null],
+    ["https://example.suiobj/", { subdomain: "example", path: "/" }],
+    ["https://example.suiobj", null],
+    ["https://example.suiobj/resource", { subdomain: "example", path: "/resource" }],
+];
+
+describe('getObjectIdLink', () => {
+    getObjectIdLinkTestCases.forEach(([input, expected]) => {
+        test(`Extracting from ${input} should return
+            ${expected ? JSON.stringify(expected) : 'null'}`, () => {
+                const result = getObjectIdLink(input);
+                expect(result).toEqual(expected);
+            });
+    });
+});
+
+const getBlobIdLinkTestCases: [string, string | null][] = [
+    ["https://blobid.walrus/blob-id-123", "blob-id-123"],
+    ["https://blobid.walrus/another-blob-id", "another-blob-id"],
+    ["https://invalidsite.com/something", null],
+    ["https://blobid.walrus/", null],
+    ["https://blobid.walrus", null],
+    ["https://blobid.walrus/blob-id-456", "blob-id-456"],
+];
+
+describe('getBlobIdLink', () => {
+    getBlobIdLinkTestCases.forEach(([input, expected]) => {
+        test(`Extracting from ${input} should return ${expected ? expected : 'null'}`, () => {
+            const result = getBlobIdLink(input);
+            expect(result).toEqual(expected);
+        });
+    });
+});

--- a/portal/common/lib/objectId_operations.test.ts
+++ b/portal/common/lib/objectId_operations.test.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, test } from 'vitest';
+import { subdomainToObjectId, HEXtoBase36, Base36ToHEX } from './objectId_operations';
+
+// Test cases for subdomainToObjectId
+const subdomainToObjectIdTestCases: [string, string | null][] = [
+    ["29gjzk8yjl1v7zm2etee1siyzaqfj9jaru5ufs6yyh1yqsgun2",
+        // Example Base36 subdomain
+        "0x5ac988828a0c9842d91e6d5bdd9552ec9fcdddf11c56bf82dff6d5566685a31e"],
+    ["invalidsubdomain", null], // Invalid subdomain that doesn't map to a valid object ID
+];
+
+describe('subdomainToObjectId', () => {
+    subdomainToObjectIdTestCases.forEach(([input, expected]) => {
+        test(`Converting subdomain ${input} should return ${expected ? expected : 'null'}`, () => {
+            const result = subdomainToObjectId(input);
+            expect(result).toEqual(expected);
+        });
+    });
+});
+
+// Test cases for HEXtoBase36 and Base36ToHEX
+const HEXtoBase36TestCases: [string, string][] = [
+    ["0x5ac988828a0c9842d91e6d5bdd9552ec9fcdddf11c56bf82dff6d5566685a31e",
+        "29gjzk8yjl1v7zm2etee1siyzaqfj9jaru5ufs6yyh1yqsgun2"], // Valid HEX to Base36
+    ["0x0000000000000000000000000000000000000001", "1"], // Minimal HEX to Base36
+];
+
+describe('HEXtoBase36 and Base36ToHEX', () => {
+    HEXtoBase36TestCases.forEach(([hexInput, base36Expected]) => {
+        test(`Converting HEX ${hexInput} to Base36 should return ${base36Expected}`, () => {
+            const result = HEXtoBase36(hexInput);
+            expect(result).toBe(base36Expected);
+        });
+
+        test(`Converting Base36 ${base36Expected} back to HEX should return ${hexInput}`, () => {
+            const result = Base36ToHEX(base36Expected);
+            expect(result).toBe(hexInput);
+        });
+    });
+});

--- a/portal/common/lib/redirects.test.ts
+++ b/portal/common/lib/redirects.test.ts
@@ -1,0 +1,47 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Import necessary functions and types
+import { describe, expect, test } from 'vitest';
+import { redirectToPortalURLResponse, redirectToAggregatorUrlResponse } from './redirects';
+import { DomainDetails } from './types/index';
+
+const redirectToPortalURLTestCases: [string, DomainDetails, string][] = [
+    ['https://example.com', { subdomain: 'subname', path: '/index.html' },
+        'https://subname.example.com/index.html'],
+    ['https://walrus.site', { subdomain: 'name', path: '/index.html' },
+        'https://name.walrus.site/index.html'],
+    ['http://localhost:8080', { subdomain: 'docs', path: '/css/print.css' },
+        'http://docs.localhost:8080/css/print.css'],
+    ['https://portalname.co.uk', { subdomain: 'subsubname.subname', path: '/index.html' },
+        'https://subsubname.subname.portalname.co.uk/index.html'],
+];
+
+describe('redirectToPortalURLResponse', () => {
+    redirectToPortalURLTestCases.forEach(([input, path, expected]) => {
+        test(`${input} with subdomain: ${path.subdomain} and path: ${path.path} -> ${expected}`,
+            () => {
+            const scope = new URL(input);
+            const response = redirectToPortalURLResponse(scope, path);
+            expect(response.status).toBe(302);
+            expect(response.headers.get('Location')).toBe(expected);
+        });
+    });
+});
+
+const redirectToAggregatorUrlTestCases: [string, string, string][] = [
+    ['https://example.com', '12345', 'https://aggregator-devnet.walrus.space/v1/12345'],
+    ['https://walrus.site', 'blob-id', 'https://aggregator-devnet.walrus.space/v1/blob-id'],
+    ['http://localhost:8080', 'abcde', 'https://aggregator-devnet.walrus.space/v1/abcde'],
+];
+
+describe('redirectToAggregatorUrlResponse', () => {
+    redirectToAggregatorUrlTestCases.forEach(([input, blobId, expected]) => {
+        test(`${input} with blobId: ${blobId} -> ${expected}`, () => {
+            const scope = new URL(input);
+            const response = redirectToAggregatorUrlResponse(scope, blobId);
+            expect(response.status).toBe(302);
+            expect(response.headers.get('Location')).toBe(expected);
+        });
+    });
+});

--- a/portal/common/lib/resource.test.ts
+++ b/portal/common/lib/resource.test.ts
@@ -1,0 +1,314 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Import necessary functions and types
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { fetchResource } from './resource';
+import { SuiClient } from '@mysten/sui/client';
+import { HttpStatusCodes } from './http/http_status_codes';
+import { checkRedirect } from './redirects';
+import { fromB64 } from '@mysten/bcs';
+import { DynamicFieldStruct } from './bcs_data_parsing';
+import { RESOURCE_PATH_MOVE_TYPE } from './constants';
+
+// Mock SuiClient methods
+const getDynamicFieldObject = vi.fn();
+const getObject = vi.fn();
+
+const mockClient = {
+    getDynamicFieldObject,
+    getObject,
+} as unknown as SuiClient;
+
+// Mock checkRedirect
+vi.mock('./redirects', () => ({
+    checkRedirect: vi.fn(),
+}));
+
+// Mock fromB64
+vi.mock('@mysten/bcs', async () => {
+    const actual = await vi.importActual<typeof import('@mysten/bcs')>('@mysten/bcs');
+    return {
+        ...actual,
+        fromB64: vi.fn(),
+    };
+});
+
+vi.mock('./bcs_data_parsing', async (importOriginal) => {
+    const actual = await importOriginal() as typeof import('./bcs_data_parsing');
+    return {
+        ...actual,
+        DynamicFieldStruct: vi.fn(() => ({
+            parse: vi.fn(() => ({ value: { blob_id: '0xresourceBlobId' } })),
+        })),
+    };
+});
+
+describe('fetchResource', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    test('should return LOOP_DETECTED if objectId is already in seenResources', async () => {
+        const seenResources = new Set<string>(['0xParentId']);
+
+        const result = await fetchResource(mockClient, '0xParentId', '/path', seenResources);
+        expect(result).toBe(HttpStatusCodes.LOOP_DETECTED);
+    });
+
+    test('should return TOO_MANY_REDIRECTS if recursion depth exceeds MAX_REDIRECT_DEPTH',
+        async () => {
+            const seenResources = new Set<string>();
+            // Assuming MAX_REDIRECT_DEPTH is 3
+            const result = await fetchResource(mockClient, '0xParentId', '/path', seenResources, 4);
+            expect(result).toBe(HttpStatusCodes.TOO_MANY_REDIRECTS);
+        });
+
+    test('should fetch resource without redirect', async () => {
+        // Mock no redirect
+        (checkRedirect as any).mockResolvedValueOnce(null);
+        // Mock dynamic field response
+        getDynamicFieldObject.mockResolvedValueOnce({
+            data: {
+                objectId: '0xObjectId',
+            },
+        });
+        // Mock object response
+        getObject.mockResolvedValueOnce({
+            data: {
+                bcs: {
+                    dataType: 'moveObject',
+                    bcsBytes: 'mockBcsBytes',
+                },
+            },
+        });
+        (fromB64 as any).mockReturnValueOnce('decodedBcsBytes');
+
+        const result = await fetchResource(mockClient, '0xParentId', '/path', new Set());
+
+        expect(result).toEqual({ blob_id: '0xresourceBlobId' });
+        expect(checkRedirect).toHaveBeenCalledWith(mockClient, '0xParentId');
+        expect(mockClient.getDynamicFieldObject).toHaveBeenCalledWith({
+            parentId: '0xParentId',
+            name: { type: RESOURCE_PATH_MOVE_TYPE, value: '/path' },
+        });
+        expect(mockClient.getObject).toHaveBeenCalledWith({
+            id: '0xObjectId',
+            options: { showBcs: true },
+        });
+    });
+
+    test('should follow redirect and recursively fetch resource', async () => {
+        // Mock the redirect check to return a redirect ID on the first call
+        (checkRedirect as any).mockResolvedValueOnce('0xRedirectId');
+        // On the second call (after redirect), mock to return null (no further redirect)
+        (checkRedirect as any).mockResolvedValueOnce(null);
+
+        // Mock dynamic field response for the initial object
+        getDynamicFieldObject.mockResolvedValueOnce({
+            data: {
+                objectId: '0xInitialObjectId',
+            },
+        });
+
+        // Mock the redirect object response
+        getObject.mockResolvedValueOnce({
+            data: {
+                bcs: {
+                    dataType: 'moveObject',
+                    bcsBytes: 'mockBcsBytes',
+                },
+            },
+        });
+
+        // Mock dynamic field response for the redirected object
+        getDynamicFieldObject.mockResolvedValueOnce({
+            data: {
+                objectId: '0xFinalObjectId',
+            },
+        });
+
+        // Mock the final resource object response
+        getObject.mockResolvedValueOnce({
+            data: {
+                bcs: {
+                    dataType: 'moveObject',
+                    bcsBytes: 'mockBcsBytes',
+                },
+            },
+        });
+
+        const result = await fetchResource(mockClient, '0xParentId', '/path', new Set());
+
+        // Verify the results
+        expect(result).toEqual({ blob_id: '0xresourceBlobId' });
+
+        // Verify the correct sequence of calls
+
+        // Initial redirect check and dynamic field fetch
+        expect(checkRedirect).toHaveBeenNthCalledWith(1, mockClient, '0xParentId');
+        expect(mockClient.getDynamicFieldObject).toHaveBeenNthCalledWith(1, {
+            parentId: '0xParentId',
+            name: { type: RESOURCE_PATH_MOVE_TYPE, value: '/path' },
+        });
+
+        // Redirected object fetch and second dynamic field fetch
+        expect(checkRedirect).toHaveBeenNthCalledWith(2, mockClient, '0xRedirectId');
+
+        expect(mockClient.getDynamicFieldObject).toHaveBeenNthCalledWith(2, {
+            parentId: '0xRedirectId',
+            name: { type: RESOURCE_PATH_MOVE_TYPE, value: '/path' },
+        });
+
+        // Final resource fetch after resolving the redirect
+        expect(mockClient.getObject).toHaveBeenNthCalledWith(1, {
+            id: '0xRedirectId',
+            options: { showBcs: true },
+        });
+        expect(mockClient.getObject).toHaveBeenNthCalledWith(2, {
+            id: '0xFinalObjectId',
+            options: { showBcs: true },
+        });
+    });
+
+    test('should return NOT_FOUND if the resource does not contain a blob_id', async () => {
+        const seenResources = new Set<string>();
+        const mockResource = {};  // No blob_id
+
+        // No redirect is returned
+        (checkRedirect as any).mockResolvedValueOnce(null);
+
+        // Mock getDynamicFieldObject to return a valid object ID
+        getDynamicFieldObject.mockResolvedValueOnce({
+            data: { objectId: '0xObjectId' },
+        });
+
+        // Mock getObject to return a valid BCS object
+        getObject.mockResolvedValueOnce({
+            data: {
+                bcs: {
+                    dataType: 'moveObject',
+                    bcsBytes: 'mockBcsBytes',
+                },
+            },
+        });
+
+        // Mock fromB64 to simulate the decoding process
+        (fromB64 as any).mockReturnValueOnce('decodedBcsBytes');
+
+        // Mock DynamicFieldStruct to return a resource without a blob_id
+        (DynamicFieldStruct as any).mockImplementation(() => ({
+            parse: () => ({ value: mockResource }),
+        }));
+
+        const result = await fetchResource(mockClient, '0xParentId', '/path', seenResources);
+
+        // Since the resource does not have a blob_id, the function should return NOT_FOUND
+        expect(result).toBe(HttpStatusCodes.NOT_FOUND);
+    });
+
+
+    test('should return NOT_FOUND if dynamic fields are not found', async () => {
+        const seenResources = new Set<string>();
+
+        // Mock to return no redirect
+        (checkRedirect as any).mockResolvedValueOnce(null);
+
+        // Mock to simulate that dynamic fields are not found
+        getDynamicFieldObject.mockResolvedValueOnce({ data: null });
+
+        const result = await fetchResource(mockClient, '0xParentId', '/path', seenResources);
+
+        // Check that the function returns NOT_FOUND
+        expect(result).toBe(HttpStatusCodes.NOT_FOUND);
+    });
+
+    test('should correctly handle a chain of redirects', async () => {
+        const seenResources = new Set<string>();
+        const mockResource = { blob_id: '0xresourceBlobId' };
+
+        // Mock the redirect chain: First redirect points to '0xredirect1',
+        //which then redirects to '0xredirect2'
+        (checkRedirect as any).mockResolvedValueOnce('0xredirect1');  // First call
+        (checkRedirect as any).mockResolvedValueOnce('0xredirect2');  // Second call
+        (checkRedirect as any).mockResolvedValueOnce(null);  // Third call, no more redirects
+
+        // Mock getDynamicFieldObject to return valid structures
+        getDynamicFieldObject.mockResolvedValueOnce({
+            data: { objectId: '0xredirect1' },
+        });  // For '0xParentId', redirects to '0xredirect1'
+
+        getDynamicFieldObject.mockResolvedValueOnce({
+            data: { objectId: '0xredirect2' },
+        });  // For '0xredirect1', redirects to '0xredirect2'
+
+        getDynamicFieldObject.mockResolvedValueOnce({
+            data: { objectId: '0xFinalObjectId' },
+        });  // For '0xredirect2', final object
+
+        // Mock getObject to return a valid response for each object in the chain
+        getObject.mockResolvedValueOnce({
+            data: {
+                bcs: { dataType: 'moveObject', bcsBytes: 'mockBcsBytes' },
+            },
+        });
+
+        getObject.mockResolvedValueOnce({
+            data: {
+                bcs: { dataType: 'moveObject', bcsBytes: 'mockBcsBytes' },
+            },
+        });
+
+        getObject.mockResolvedValueOnce({
+            data: {
+                bcs: { dataType: 'moveObject', bcsBytes: 'mockBcsBytes' },
+            },
+        });
+
+        // Mock fromB64 to simulate the decoding process
+        (fromB64 as any).mockReturnValueOnce('decodedBcsBytes');
+
+        // Mock DynamicFieldStruct to parse the BCS data and return the mock resource
+        (DynamicFieldStruct as any).mockImplementation(() => ({
+            parse: () => ({ value: mockResource }),
+        }));
+
+        const result = await fetchResource(mockClient, '0xParentId', '/path', seenResources);
+
+        // Validate the correct resource is returned after following the chain of redirects
+        expect(result).toEqual({ blob_id: '0xresourceBlobId' });
+
+        // Ensure that checkRedirect was called in sequence
+        expect(checkRedirect).toHaveBeenNthCalledWith(1, mockClient, '0xParentId');
+        expect(checkRedirect).toHaveBeenNthCalledWith(2, mockClient, '0xredirect1');
+        expect(checkRedirect).toHaveBeenNthCalledWith(3, mockClient, '0xredirect2');
+
+        // Ensure that getDynamicFieldObject was called three times as expected
+        expect(mockClient.getDynamicFieldObject).toHaveBeenNthCalledWith(1, {
+            parentId: '0xParentId',
+            name: { type: RESOURCE_PATH_MOVE_TYPE, value: '/path' },
+        });
+        expect(mockClient.getDynamicFieldObject).toHaveBeenNthCalledWith(2, {
+            parentId: '0xredirect1',
+            name: { type: RESOURCE_PATH_MOVE_TYPE, value: '/path' },
+        });
+        expect(mockClient.getDynamicFieldObject).toHaveBeenNthCalledWith(3, {
+            parentId: '0xredirect2',
+            name: { type: RESOURCE_PATH_MOVE_TYPE, value: '/path' },
+        });
+
+        // Ensure that getObject was called for each step in the chain
+        expect(getObject).toHaveBeenNthCalledWith(1, {
+            id: '0xredirect1',
+            options: { showBcs: true },
+        });
+        expect(getObject).toHaveBeenNthCalledWith(2, {
+            id: '0xredirect2',
+            options: { showBcs: true },
+        });
+        expect(getObject).toHaveBeenNthCalledWith(3, {
+            id: '0xFinalObjectId',
+            options: { showBcs: true },
+        });
+    });
+});

--- a/portal/common/lib/suins.test.ts
+++ b/portal/common/lib/suins.test.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { resolveSuiNsAddress, hardcodedSubdmains } from './suins';
+import { SuiClient } from "@mysten/sui/client";
+
+const resolveSuiNsAddressTestCases: [string, string | null][] = [
+    ["subname", "0x123"],
+    ["example", "0xabc"],
+    ["nonexistent", null],
+];
+
+describe('resolveSuiNsAddress', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    test.each(resolveSuiNsAddressTestCases)(
+        'should resolve the SuiNS address for %s',
+        async (input, expected) => {
+            const mockClient = {
+                call: vi.fn().mockResolvedValueOnce(expected)
+            } as unknown as SuiClient;
+
+            const result = await resolveSuiNsAddress(mockClient, input);
+            expect(result).toBe(expected);
+            expect(mockClient.call).toHaveBeenCalledWith("suix_resolveNameServiceAddress",
+                [`${input}.sui`]);
+        }
+    );
+
+    test('should return null for an unknown SuiNS address', async () => {
+        const mockClient = {
+            call: vi.fn().mockResolvedValueOnce(null)
+        } as unknown as SuiClient;
+
+        const result = await resolveSuiNsAddress(mockClient, "unknown");
+        expect(result).toBeNull();
+        expect(mockClient.call).toHaveBeenCalledWith("suix_resolveNameServiceAddress",
+            ["unknown.sui"]);
+    });
+});

--- a/portal/common/lib/url_safe_base64.test.ts
+++ b/portal/common/lib/url_safe_base64.test.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, test } from 'vitest';
+import { base64UrlSafeEncode } from './url_safe_base64';
+
+// Test cases for base64UrlSafeEncode
+const base64UrlSafeEncodeTestCases: [Uint8Array, string][] = [
+    [new Uint8Array([104, 101, 108, 108, 111]), 'aGVsbG8'], // "hello"
+    [new Uint8Array([119, 111, 114, 108, 100]), 'd29ybGQ'], // "world"
+    [new Uint8Array([]), ''], // empty array
+];
+
+describe('base64UrlSafeEncode', () => {
+    base64UrlSafeEncodeTestCases.forEach(([input, expected]) => {
+        test(`Encoding ${input.toString()} should return ${expected}`, () => {
+            const result = base64UrlSafeEncode(input);
+            expect(result).toBe(expected);
+        });
+    });
+});


### PR DESCRIPTION
**Add More Unit Tests to the Portal Common Library**

This PR enhances the test coverage of the Portal common library by adding additional unit tests.

Tests Added:

- Links Tests (links.test.ts)
- Object ID Operations Tests (objectId_operations.test.ts)
- Redirects Tests (redirects.test.ts)
- Resource Fetching Tests (resource.test.ts)
- SuiNS Resolution Tests (suins.test.ts)
- URL Safe Base64 Encoding Tests (url_safe_base64.test.ts)

These tests use vitest.fn to mock responses for different scenarios, validating the code under various conditions.