### PR TITLE
feat(service-worker): Redirect to blob.store if SW not able to install

### DIFF
--- a/portal/common/lib/constants.ts
+++ b/portal/common/lib/constants.ts
@@ -10,5 +10,7 @@ export const SITE_NAMES: { [key: string]: string } = {
     // e.g.,
     // landing: "0x1234..."
 };
+// The default portal to redirect to if the browser does not support service workers.
+export const FALLBACK_PORTAL = "blob.store"
 // The string representing the ResourcePath struct in the walrus_site package.
 export const RESOURCE_PATH_MOVE_TYPE = SITE_PACKAGE + "::site::ResourcePath";

--- a/portal/common/static/walrus-sites-portal-register-sw.js
+++ b/portal/common/static/walrus-sites-portal-register-sw.js
@@ -24,20 +24,14 @@ function main() {
             })
             .catch(handleError);
     } else {
-        displayErrorMessage(swNotSupportedNode());
+        const currentUrl = new URL(window.location.href);
+        console.warn("This browser does not yet support Walrus Sites 💔, redirecting to blob.store");
+        window.location.href = currentUrl.toString().replace('walrus.site', 'blob.store');
     }
 }
 
 function handleError(error) {
     displayErrorMessage(swNotLoadingNode());
-}
-
-function swNotSupportedNode() {
-    return titleSubtitleNode(
-        "This browser does not yet support Walrus Sites 💔",
-        'Please try using a different browser, such as Chrome, Firefox (not in "Private mode"), \
-        or Safari.'
-    );
 }
 
 function swNotLoadingNode() {

--- a/portal/worker/src/walrus-sites-portal-register-sw.ts
+++ b/portal/worker/src/walrus-sites-portal-register-sw.ts
@@ -41,7 +41,7 @@ function swNotLoadingNode() {
     );
 }
 
-function titleSubtitleNode(title, subtitle) {
+function titleSubtitleNode(title: string, subtitle: string) {
     let h3 = document.createElement("h3");
     h3.textContent = title;
     h3.className = "InterTightMedium";
@@ -56,7 +56,7 @@ function titleSubtitleNode(title, subtitle) {
     return div;
 }
 
-function displayErrorMessage(messageNode) {
+function displayErrorMessage(messageNode: any) {
     let messageDiv = document.getElementById("loading-message");
     messageDiv.replaceChildren(messageNode);
 }

--- a/portal/worker/src/walrus-sites-portal-register-sw.ts
+++ b/portal/worker/src/walrus-sites-portal-register-sw.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+import { getSubdomainAndPath } from "@lib/domain_parsing";
 
 function main() {
     if ("serviceWorker" in navigator) {
@@ -26,7 +27,17 @@ function main() {
     } else {
         const currentUrl = new URL(window.location.href);
         console.warn("This browser does not yet support Walrus Sites 💔, redirecting to blob.store");
-        window.location.href = currentUrl.toString().replace('walrus.site', 'blob.store');
+        const domainDetails = getSubdomainAndPath(currentUrl)
+        console.log("DOMAIN: ", domainDetails);
+        const alternativePortal = "blob.store";
+        window.location.href = new URL(
+            `${currentUrl.pathname}${currentUrl.search}${currentUrl.hash}`,
+            `https://${
+            domainDetails.subdomain ?
+            domainDetails.subdomain + '.'
+            : ''
+            }${alternativePortal}`
+        ).toString();
     }
 }
 

--- a/portal/worker/src/walrus-sites-portal-register-sw.ts
+++ b/portal/worker/src/walrus-sites-portal-register-sw.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 import { getSubdomainAndPath } from "@lib/domain_parsing";
+import { FALLBACK_PORTAL } from "@lib/constants";
 
 function main() {
     if ("serviceWorker" in navigator) {
@@ -28,15 +29,13 @@ function main() {
         const currentUrl = new URL(window.location.href);
         console.warn("This browser does not yet support Walrus Sites 💔, redirecting to blob.store");
         const domainDetails = getSubdomainAndPath(currentUrl)
-        console.log("DOMAIN: ", domainDetails);
-        const alternativePortal = "blob.store";
         window.location.href = new URL(
             `${currentUrl.pathname}${currentUrl.search}${currentUrl.hash}`,
             `https://${
             domainDetails.subdomain ?
             domainDetails.subdomain + '.'
             : ''
-            }${alternativePortal}`
+            }${FALLBACK_PORTAL}`
         ).toString();
     }
 }

--- a/portal/worker/tsconfig.json
+++ b/portal/worker/tsconfig.json
@@ -5,7 +5,8 @@
     "moduleResolution": "node",
     "lib": [
       "esnext",
-      "webworker"
+      "webworker",
+      "dom"
     ],
     "baseUrl": "./",
       "paths": {

--- a/portal/worker/webpack.config.common.js
+++ b/portal/worker/webpack.config.common.js
@@ -8,6 +8,7 @@ module.exports = {
     watch: true,
     entry: {
         "walrus-sites-sw": "./src/walrus-sites-sw.ts",
+        "walrus-sites-portal-register-sw": "./src/walrus-sites-portal-register-sw.ts",
     },
     module: {
         rules: [


### PR DESCRIPTION
Some browsers (like in-app browsers) don't support service workers.

Instead of throwing an error to the user, we
redirect to `blob.store`, where the resolution of the site resources happens on the server side.