### PR TITLE
Fix missing newline in the 404 page

### DIFF
--- a/portal/common/lib/http/http_error_responses.ts
+++ b/portal/common/lib/http/http_error_responses.ts
@@ -5,23 +5,27 @@ import template_404 from "../../static/404-page.template.html";
 
 export function siteNotFound(): Response {
     return Response404(
-        "You have reached the end of the internet, please turn back!" +
+        "You have reached the end of the internet, please turn back!",
         "Invalid URL: The object ID is not a valid Walrus Site."
     );
 }
 
 export function noObjectIdFound(): Response {
-    return Response404("You have reached the end of the internet, please turn back!" +
-        "Invalid URL: No object ID could be found.");
+    return Response404(
+        "You have reached the end of the internet, please turn back!",
+        "Invalid URL: No object ID could be found."
+    );
 }
 
 export function fullNodeFail(): Response {
     return Response404("Failed to contact the full node.");
 }
 
-function Response404(message: String): Response {
-    console.log();
-    return new Response(template_404.replace("${message}", message), {
+function Response404(message: String, secondaryMessage?: String): Response {
+    const interpolated = template_404
+        .replace("${message}", message)
+        .replace("${secondaryMessage}", secondaryMessage ?? '')
+    return new Response(interpolated, {
         status: 404,
         headers: {
             "Content-Type": "text/html",

--- a/portal/common/static/404-page.template.html
+++ b/portal/common/static/404-page.template.html
@@ -107,6 +107,7 @@
                     <div class="center InterTightMedium" style="color: #696969;">
                         <div style="font-size: 88px; line-height: 160%;">🙅🏽</div>
                         <div style="font-size: 16px; line-height: 160%;">${message}</div>
+                        <div style="font-size: 16px; line-height: 160%;">${secondaryMessage}</div>
                         <a href="https://walrus.site/" style="color: #696969; font-size: 16px; line-height: 160%;">Open Walrus.site</a>
                     </div>
                 </div>


### PR DESCRIPTION
The message shown would be like the
following:

"You have ... internet!Please turn back!"
In order to add the newline, I would have
break this sentence into two, because
in HTML cannot be added simply
including the "\n" character.