### PR TITLE
fix(portal): extract portal link

### DIFF
--- a/portal/common/static/404-page.template.html
+++ b/portal/common/static/404-page.template.html
@@ -12,19 +12,18 @@
     </head>
     <script>
     function getPortalName() {
-        const url = window.location.href;
-        if (url.includes("walrus.site")) {
-            console.log("URL contains 'walrus.site'");
-            return ["https://walrus.site/", "Open walrus.site"];
+        const url = new URL(window.location.href);
+        const domainParts = url.host.split('.');
+        const portalName = domainParts.slice(-2).join('.');
+        if (portalName.includes('localhost')) {
+            return 'http://localhost' + `:${url.port}`
         }
-        return ["https://blob.store/", "Open blob.store"];
+        return `https://${portalName}`
     };
 
     window.onload = function() {
         const portalLink = document.getElementById('portalLink');
-        const [link, text] = getPortalName();
-        portalLink.href = link;
-        portalLink.textContent = text;
+        portalLink.href = getPortalName();
     };
     </script>
     <style>
@@ -125,7 +124,7 @@
                         <div style="font-size: 88px; line-height: 160%;">🙅🏽</div>
                         <div style="font-size: 16px; line-height: 160%;">${message}</div>
                         <div style="font-size: 16px; line-height: 160%;">${secondaryMessage}</div>
-                        <a id="portalLink" style="color: #696969; font-size: 16px; line-height: 160%;">Open Walrus.site</a>
+                        <a id="portalLink" style="color: #696969; font-size: 16px; line-height: 160%;">Open the landing page</a>
                     </div>
                 </div>
                 <footer class="InterTightBold">

--- a/portal/common/static/404-page.template.html
+++ b/portal/common/static/404-page.template.html
@@ -10,6 +10,23 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>404 Walrus Site Not Found</title>
     </head>
+    <script>
+    function getPortalName() {
+        const url = window.location.href;
+        if (url.includes("walrus.site")) {
+            console.log("URL contains 'walrus.site'");
+            return ["https://walrus.site/", "Open walrus.site"];
+        }
+        return ["https://blob.store/", "Open blob.store"];
+    };
+
+    window.onload = function() {
+        const portalLink = document.getElementById('portalLink');
+        const [link, text] = getPortalName();
+        portalLink.href = link;
+        portalLink.textContent = text;
+    };
+    </script>
     <style>
         body {
             margin: 0;
@@ -108,7 +125,7 @@
                         <div style="font-size: 88px; line-height: 160%;">🙅🏽</div>
                         <div style="font-size: 16px; line-height: 160%;">${message}</div>
                         <div style="font-size: 16px; line-height: 160%;">${secondaryMessage}</div>
-                        <a href="https://walrus.site/" style="color: #696969; font-size: 16px; line-height: 160%;">Open Walrus.site</a>
+                        <a id="portalLink" style="color: #696969; font-size: 16px; line-height: 160%;">Open Walrus.site</a>
                     </div>
                 </div>
                 <footer class="InterTightBold">


### PR DESCRIPTION
Closes #190 

Page 404 would provide a link for
walrus.site, even when the server side
portal is used (blob.store).

## Changes
Created a new function that extracts the 
appropriate redirection
link based on the current URL in order to
point to the correct portal, and uses it
to the `<a href=...>` tag.

i.e. if the user typed `<name>.walrus.site`
he should be redirected to `walrus.site` when
clicking the hyperlink.
Likewise, if the user typed `<name>.blob.store`, 
he should be redirected to `blob.store`.