### PR TITLE
feat(portal): Bench flatland - fetchPage & fetchResource

### DIFF
--- a/portal/common/lib/constants.ts
+++ b/portal/common/lib/constants.ts
@@ -17,7 +17,9 @@ export const RESOURCE_PATH_MOVE_TYPE = SITE_PACKAGE + "::site::ResourcePath";
 
 const LANDING_PAGE_OID = '0x5fa99da7c4af9e2e2d0fb4503b058b9181693e463998c87c40be78fa2a1ca271';
 const FLATLAND_OID = '0x049b6d3f34789904efcc20254400b7dca5548ee35cd7b5b145a211f85b2532fa';
+const FLATLANDER_OID = '0x3dcce3b879a015f3e9ab8d48af76df333b4b64db59ac5a3bb8c19ff81c0ad586';
 export const SITES_USED_FOR_BENCHING = [
     [LANDING_PAGE_OID, "landing page"],
-    [FLATLAND_OID, "flatland"]
+    [FLATLAND_OID, "flatland"],
+    [FLATLANDER_OID, "flatlander"]
 ]

--- a/portal/common/lib/constants.ts
+++ b/portal/common/lib/constants.ts
@@ -14,3 +14,10 @@ export const SITE_NAMES: { [key: string]: string } = {
 export const FALLBACK_PORTAL = "blob.store"
 // The string representing the ResourcePath struct in the walrus_site package.
 export const RESOURCE_PATH_MOVE_TYPE = SITE_PACKAGE + "::site::ResourcePath";
+
+const LANDING_PAGE_OID = '0x5fa99da7c4af9e2e2d0fb4503b058b9181693e463998c87c40be78fa2a1ca271';
+const FLATLAND_OID = '0x049b6d3f34789904efcc20254400b7dca5548ee35cd7b5b145a211f85b2532fa';
+export const SITES_USED_FOR_BENCHING = [
+    [LANDING_PAGE_OID, "landing page"],
+    [FLATLAND_OID, "flatland"]
+]

--- a/portal/common/lib/page_fetching.bench.ts
+++ b/portal/common/lib/page_fetching.bench.ts
@@ -5,17 +5,12 @@ import { bench, describe, expect } from 'vitest';
 import { fetchPage } from './page_fetching';
 import { SuiClient, getFullnodeUrl } from '@mysten/sui/client'
 import { NETWORK } from './constants';
+import { SITES_USED_FOR_BENCHING } from './constants';
 
-const LANDING_PAGE_OID = '0x5fa99da7c4af9e2e2d0fb4503b058b9181693e463998c87c40be78fa2a1ca271';
-const FLATLAND_OID = '0x049b6d3f34789904efcc20254400b7dca5548ee35cd7b5b145a211f85b2532fa';
-const ws_pages = [
-    [LANDING_PAGE_OID, "landing page"],
-    [FLATLAND_OID, "flatland"]
-]
 const rpcUrl = getFullnodeUrl(NETWORK);
 const client = new SuiClient({ url: rpcUrl });
 describe('Page fetching', () => {
-    ws_pages.forEach(([objectId, siteName]) => {
+    SITES_USED_FOR_BENCHING.forEach(([objectId, siteName]) => {
         bench(`fetchResource: fetch the ${siteName} walrus site`, async () => {
             const resourcePath = '/index.html';
             const res = await fetchPage(client, objectId, resourcePath);

--- a/portal/common/lib/page_fetching.bench.ts
+++ b/portal/common/lib/page_fetching.bench.ts
@@ -6,13 +6,20 @@ import { fetchPage } from './page_fetching';
 import { SuiClient, getFullnodeUrl } from '@mysten/sui/client'
 import { NETWORK } from './constants';
 
+const LANDING_PAGE_OID = '0x5fa99da7c4af9e2e2d0fb4503b058b9181693e463998c87c40be78fa2a1ca271';
+const FLATLAND_OID = '0x049b6d3f34789904efcc20254400b7dca5548ee35cd7b5b145a211f85b2532fa';
+const ws_pages = [
+    [LANDING_PAGE_OID, "landing page"],
+    [FLATLAND_OID, "flatland"]
+]
+const rpcUrl = getFullnodeUrl(NETWORK);
+const client = new SuiClient({ url: rpcUrl });
 describe('Page fetching', () => {
-    bench('fetchPage: fetch the landing page walrus site', async () => {
-        const rpcUrl = getFullnodeUrl(NETWORK);
-        const client = new SuiClient({ url: rpcUrl });
-        const objectId = '0x5fa99da7c4af9e2e2d0fb4503b058b9181693e463998c87c40be78fa2a1ca271';
-        const resourcePath = '/index.html';
-        const res = await fetchPage(client, objectId, resourcePath);
-        expect(res.status).toEqual(200); // If this fails, then the bench will result in 0ms
-    });
+    ws_pages.forEach(([objectId, siteName]) => {
+        bench(`fetchResource: fetch the ${siteName} walrus site`, async () => {
+            const resourcePath = '/index.html';
+            const res = await fetchPage(client, objectId, resourcePath);
+            expect(res.status).toEqual(200); // If this fails, then the bench will result in 0ms
+        });
+    })
 });

--- a/portal/common/lib/resource.bench.ts
+++ b/portal/common/lib/resource.bench.ts
@@ -5,15 +5,22 @@ import { bench, describe, expect } from 'vitest';
 import { fetchResource } from './resource';
 import { SuiClient, getFullnodeUrl } from '@mysten/sui/client'
 import { NETWORK } from './constants';
-import { isResource, isVersionedResource, VersionedResource } from './types';
+import { isVersionedResource } from './types';
 
-describe('Page fetching', () => {
-    bench('fetchResource: fetch the landing page walrus site', async () => {
-        const rpcUrl = getFullnodeUrl(NETWORK);
-        const client = new SuiClient({ url: rpcUrl });
-        const objectId = '0x5fa99da7c4af9e2e2d0fb4503b058b9181693e463998c87c40be78fa2a1ca271';
-        const resourcePath = '/index.html';
-        const resp = await fetchResource(client, objectId, resourcePath, new Set());
-        expect(isVersionedResource(resp)).toBeTruthy();
-    });
+const LANDING_PAGE_OID = '0x5fa99da7c4af9e2e2d0fb4503b058b9181693e463998c87c40be78fa2a1ca271';
+const FLATLAND_OID = '0x049b6d3f34789904efcc20254400b7dca5548ee35cd7b5b145a211f85b2532fa';
+const ws_pages = [
+    [LANDING_PAGE_OID, "landing page"],
+    [FLATLAND_OID, "flatland"]
+]
+const rpcUrl = getFullnodeUrl(NETWORK);
+const client = new SuiClient({ url: rpcUrl });
+describe('Resource fetching', () => {
+    ws_pages.forEach(([objectId, siteName]) => {
+        bench(`fetchResource: fetch the ${siteName} walrus site`, async () => {
+            const resourcePath = '/index.html';
+            const resp = await fetchResource(client, objectId, resourcePath, new Set());
+            expect(isVersionedResource(resp)).toBeTruthy();
+        });
+    })
 });

--- a/portal/common/lib/resource.bench.ts
+++ b/portal/common/lib/resource.bench.ts
@@ -6,17 +6,12 @@ import { fetchResource } from './resource';
 import { SuiClient, getFullnodeUrl } from '@mysten/sui/client'
 import { NETWORK } from './constants';
 import { isVersionedResource } from './types';
+import { SITES_USED_FOR_BENCHING } from './constants';
 
-const LANDING_PAGE_OID = '0x5fa99da7c4af9e2e2d0fb4503b058b9181693e463998c87c40be78fa2a1ca271';
-const FLATLAND_OID = '0x049b6d3f34789904efcc20254400b7dca5548ee35cd7b5b145a211f85b2532fa';
-const ws_pages = [
-    [LANDING_PAGE_OID, "landing page"],
-    [FLATLAND_OID, "flatland"]
-]
 const rpcUrl = getFullnodeUrl(NETWORK);
 const client = new SuiClient({ url: rpcUrl });
 describe('Resource fetching', () => {
-    ws_pages.forEach(([objectId, siteName]) => {
+    SITES_USED_FOR_BENCHING.forEach(([objectId, siteName]) => {
         bench(`fetchResource: fetch the ${siteName} walrus site`, async () => {
             const resourcePath = '/index.html';
             const resp = await fetchResource(client, objectId, resourcePath, new Set());


### PR DESCRIPTION
Bench flatland with fetchPage and fetchResource.

The addition was simple: use the already existing bench files for fetchPage and fetchResource, 
create some abstractions to keep it DRY, and include the flatland WS objectId. 