### PR TITLE
feat(site-builder): update existing resources before operations

### DIFF
--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -279,6 +279,16 @@ impl ResourceSet {
     }
 }
 
+// Implement IntoIterator for ResourceSet (consuming version)
+impl IntoIterator for ResourceSet {
+    type Item = Resource;
+    type IntoIter = std::collections::btree_set::IntoIter<Resource>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner.into_iter()
+    }
+}
+
 impl FromIterator<Resource> for ResourceSet {
     fn from_iter<I: IntoIterator<Item = Resource>>(source: I) -> Self {
         Self {

--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -251,18 +251,17 @@ impl ResourceSet {
         update_operations: &[ResourceOp<'a>],
     ) -> Vec<&'a Resource> {
         // Collect the set of created or deleted resources for fast lookup.
-        let affected_resources: BTreeSet<&Resource> = update_operations
-            .iter()
-            .map(|op| match op {
-                ResourceOp::Created(resource) | ResourceOp::Deleted(resource) => *resource,
-            })
-            .collect();
+        let affected_resources: BTreeSet<&Resource> =
+            update_operations.iter().map(|op| op.inner()).collect();
 
-        // Filter the new resources (self.inner) to find those that are not in the affected set.
-        self.inner
-            .iter()
-            .filter(|resource| !affected_resources.contains(resource))
-            .collect() // Collect unchanged resources into a Vec
+        // Collect references to resources in self.inner.
+        let self_resources: BTreeSet<&Resource> = self.inner.iter().collect();
+
+        // Use `difference` to find resources in self.inner that are not in affected_resources.
+        self_resources
+            .difference(&affected_resources)
+            .cloned()
+            .collect()
     }
 
     /// Returns a vector of deletion and creation operations to move

--- a/site-builder/src/walrus.rs
+++ b/site-builder/src/walrus.rs
@@ -68,8 +68,8 @@ impl Walrus {
     }
 
     /// Issues a `store` JSON command to the Walrus CLI, returning the parsed output.
-    pub fn store(&self, file: PathBuf, epochs: u64, force: bool) -> Result<StoreOutput> {
-        create_command!(self, store, file, epochs, force)
+    pub fn store(&self, file: PathBuf, epochs: u64) -> Result<StoreOutput> {
+        create_command!(self, store, file, epochs)
     }
 
     // TODO(giac): currently blocking. Parallelize reads.

--- a/site-builder/src/walrus/command.rs
+++ b/site-builder/src/walrus/command.rs
@@ -49,12 +49,6 @@ pub enum Command {
         /// The number of epochs for which to store the file.
         #[serde(default = "default::epochs")]
         epochs: u64,
-        /// Do not check for the blob status before storing it.
-        ///
-        /// This will create a new blob even if the blob is already certified for a sufficient
-        /// duration.
-        #[serde(default)]
-        force: bool,
     },
     /// Reads a blob from Walrus.
     Read {
@@ -147,12 +141,8 @@ impl WalrusCmdBuilder {
     }
 
     /// Adds a [`Command::Store`] command to the builder.
-    pub fn store(self, file: PathBuf, epochs: u64, force: bool) -> WalrusCmdBuilder<Command> {
-        let command = Command::Store {
-            file,
-            epochs,
-            force,
-        };
+    pub fn store(self, file: PathBuf, epochs: u64) -> WalrusCmdBuilder<Command> {
+        let command = Command::Store { file, epochs };
         self.with_command(command)
     }
 


### PR DESCRIPTION
In order to avoid changing the publish and operations functions, this is an approach that aims to check and update the existing resources using the store command before executing all the current functionality.