### PR TITLE
refactor: Remove redundant pageData fetch

### DIFF
--- a/portal/common/lib/resource.test.ts
+++ b/portal/common/lib/resource.test.ts
@@ -243,18 +243,6 @@ describe('fetchResource', () => {
             },
         });
 
-        getObject.mockResolvedValueOnce({
-            data: {
-                bcs: { dataType: 'moveObject', bcsBytes: 'mockBcsBytes' },
-            },
-        });
-
-        getObject.mockResolvedValueOnce({
-            data: {
-                bcs: { dataType: 'moveObject', bcsBytes: 'mockBcsBytes' },
-            },
-        });
-
         // Mock fromB64 to simulate the decoding process
         (fromB64 as any).mockReturnValueOnce('decodedBcsBytes');
 

--- a/portal/common/lib/resource.test.ts
+++ b/portal/common/lib/resource.test.ts
@@ -113,16 +113,6 @@ describe('fetchResource', () => {
             },
         });
 
-        // Mock the redirect object response
-        getObject.mockResolvedValueOnce({
-            data: {
-                bcs: {
-                    dataType: 'moveObject',
-                    bcsBytes: 'mockBcsBytes',
-                },
-            },
-        });
-
         // Mock dynamic field response for the redirected object
         getDynamicFieldObject.mockResolvedValueOnce({
             data: {
@@ -166,10 +156,6 @@ describe('fetchResource', () => {
 
         // Final resource fetch after resolving the redirect
         expect(mockClient.getObject).toHaveBeenNthCalledWith(1, {
-            id: '0xRedirectId',
-            options: { showBcs: true },
-        });
-        expect(mockClient.getObject).toHaveBeenNthCalledWith(2, {
             id: '0xFinalObjectId',
             options: { showBcs: true },
         });
@@ -307,14 +293,6 @@ describe('fetchResource', () => {
 
         // Ensure that getObject was called for each step in the chain
         expect(getObject).toHaveBeenNthCalledWith(1, {
-            id: '0xredirect1',
-            options: { showBcs: true },
-        });
-        expect(getObject).toHaveBeenNthCalledWith(2, {
-            id: '0xredirect2',
-            options: { showBcs: true },
-        });
-        expect(getObject).toHaveBeenNthCalledWith(3, {
             id: '0xFinalObjectId',
             options: { showBcs: true },
         });

--- a/portal/common/lib/resource.ts
+++ b/portal/common/lib/resource.ts
@@ -42,9 +42,9 @@ export async function fetchResource(
         return HttpStatusCodes.LOOP_DETECTED;
     } else if (depth >= MAX_REDIRECT_DEPTH) {
         return HttpStatusCodes.TOO_MANY_REDIRECTS;
-    } else {
-        seenResources.add(objectId);
     }
+
+    seenResources.add(objectId);
 
     let [redirectId, dynamicFields] = await Promise.all([
         checkRedirect(client, objectId),
@@ -56,14 +56,6 @@ export async function fetchResource(
 
     if (redirectId) {
         console.log("Redirect found");
-        const redirectPage = await client.getObject({
-            id: redirectId,
-            options: { showBcs: true },
-        });
-        console.log("Redirect page: ", redirectPage);
-        if (!redirectPage.data) {
-            return HttpStatusCodes.NOT_FOUND;
-        }
         // Recurs increasing the recursion depth.
         return fetchResource(client, redirectId, path, seenResources, depth + 1);
     }


### PR DESCRIPTION
Inside `fetchResource` when a redirectId is found,
 there was a `client.getObject` call to fetch the
`redirectPage.data` and check if the page data exist.

This is redundant, as this is already checked
when fetching the `pageData` a few lines bellow,
so we can emit the aforementioned check, and
directly recur calling `fetchResource`.

Bonus: 
- remove redundant `else` clause
- update fetchResource tests in order to pass (it's no longer
needed to mock all those getObject calls, which is also an indicator
of the performance improvement here).