### PR TITLE
fix(codspeed): use main instead of master

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -4,7 +4,7 @@ on:
   # Run on pushes to the main branch
   push:
     branches:
-      - "master" # or "main"
+      - "main"
   # Run on pull requests
   pull_request:
   # `workflow_dispatch` allows CodSpeed to trigger backtest


### PR DESCRIPTION
The fact that the branch that codspeed monitors was set to **master**, resulted in the performance graphs not showing to the dashboard: https://codspeed.io/MystenLabs/walrus-sites/benchmarks

With that quick fix this should be fine now. 