### PR TITLE
feat(portal): Improve fetchResource performance

### DIFF
--- a/portal/common/lib/resource.ts
+++ b/portal/common/lib/resource.ts
@@ -45,6 +45,10 @@ export async function fetchResource(
         return HttpStatusCodes.TOO_MANY_REDIRECTS;
     }
 
+    // Initiate a pre-fetch for the checkRedirect operation without resolving it.
+    // We don't need the result yet, but it's useful if we will need
+    // it later, so we don't have to loose time.
+    const checkRedirectPromise = checkRedirect(client, objectId);
     seenResources.add(objectId);
 
     // Attempt to fetch dynamic field object.
@@ -58,7 +62,8 @@ export async function fetchResource(
     // If no dynamic fields found, only then attempt redirect.
     if (!dynamicFields || !dynamicFields.data) {
         console.log("No dynamic field found");
-        let redirectId = await checkRedirect(client, objectId);
+        // Resolve the checkRedirect to get the results.
+        let redirectId = await checkRedirectPromise;
         return redirectId ?
             fetchResource(client, redirectId, path, seenResources, depth + 1) :
             HttpStatusCodes.NOT_FOUND;


### PR DESCRIPTION
Performance improvement! 🏁

`Promise.all` is as slow as it is the slowest of
the Promises it contains.

So far we have been combining `checkRedirect` and `dynamicFieldObject` fetching
in the same `Promise.all` clause. But `checkRedirect` is quite slow, and it's a case
that is not that frequent (currently only flatland makes use of it).

Given the above, we could start by fetching the dynamicFieldObject first. 

If an object has `dynamicFields` of `RESOURCE_PATH_MOVE_TYPE` it means it's a resource,
which also means that **there won't be any redirect**.

On the other hand, if the "dynamicField fetching" flow fails, then an error will be thrown in order to be caught by the `checkRedirect` and check if it's really a "redirect-able" object.

**Bonus changes**
+ refactored the fetchResource a bit
+ updated the fetchResource tests