### PR TITLE
feat(site-builder): Add --version support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -719,6 +719,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bin-version"
+version = "1.27.2"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+dependencies = [
+ "const-str",
+ "git-version",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1156,6 +1165,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-str"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3618cccc083bb987a415d85c02ca6c9994ea5b44731ec28b9ecf09658655fba9"
 
 [[package]]
 name = "constant_time_eq"
@@ -2219,6 +2234,26 @@ name = "gimli"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
+
+[[package]]
+name = "git-version"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19"
+dependencies = [
+ "git-version-macro",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
+dependencies = [
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
+ "syn 2.0.77",
+]
 
 [[package]]
 name = "glob"
@@ -5345,6 +5380,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "bcs",
+ "bin-version",
  "clap",
  "crossterm",
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto)",

--- a/site-builder/Cargo.toml
+++ b/site-builder/Cargo.toml
@@ -25,6 +25,7 @@ shared-crypto = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.2
 sui-keys = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.27.2" }
 sui-sdk = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.27.2" }
 sui-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.27.2" }
+bin-version = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.27.2" }
 thiserror = "1.0.61"
 tokio = { version = "1.38.0", features = ["rt", "rt-multi-thread", "macros"] }
 toml = "0.8.14"

--- a/site-builder/src/main.rs
+++ b/site-builder/src/main.rs
@@ -21,7 +21,7 @@ use crate::{
     util::{get_existing_resource_ids, id_to_base36, load_wallet_context},
 };
 
-// Define the `GIT_REVISION` and `VERSION` consts
+// Define the `GIT_REVISION` and `VERSION` consts.
 bin_version::bin_version!();
 
 #[derive(Parser, Debug)]

--- a/site-builder/src/main.rs
+++ b/site-builder/src/main.rs
@@ -21,8 +21,11 @@ use crate::{
     util::{get_existing_resource_ids, id_to_base36, load_wallet_context},
 };
 
+// Define the `GIT_REVISION` and `VERSION` consts
+bin_version::bin_version!();
+
 #[derive(Parser, Debug)]
-#[clap(rename_all = "kebab-case")]
+#[clap(rename_all = "kebab-case", version = VERSION, propagate_version = true)]
 struct Args {
     /// The path to the configuration file for the site builder.
     #[clap(short, long, default_value = "builder.yaml")]


### PR DESCRIPTION
**Goal**
Have the following to work same as the way the sui binary works:
```
site-builder --version 
site-builder -V
```

**Why?**
Help Suibase scripts to maintain latest binary versions for its devs.

**Implementation**
Trivial cut&paste of how sui binary already handles this (using Mysten Labs bin-version crate).

**Tests**
![image](https://github.com/user-attachments/assets/c08ffb75-bb3a-406f-b8e8-5e419212842d)
