### PR TITLE
feat(portal): parse HTTP headers from resource

### DIFF
--- a/portal/common/lib/bcs_data_parsing.ts
+++ b/portal/common/lib/bcs_data_parsing.ts
@@ -29,8 +29,7 @@ export const ResourcePathStruct = bcs.struct("ResourcePath", {
 
 export const ResourceStruct = bcs.struct("Resource", {
     path: bcs.string(),
-    content_type: bcs.string(),
-    content_encoding: bcs.string(),
+    headers: bcs.map(bcs.string(), bcs.string()),
     blob_id: BLOB_ID,
     blob_hash: DATA_HASH
 });

--- a/portal/common/lib/constants.ts
+++ b/portal/common/lib/constants.ts
@@ -3,7 +3,7 @@
 
 export const NETWORK = "testnet"
 export const AGGREGATOR = "https://aggregator-devnet.walrus.space:443"
-export const SITE_PACKAGE = "0x1ba588fd10c79e11a032e0947f454ced0a52f1a83c7fc4b1006bff548845e6c1"
+export const SITE_PACKAGE = "0xe15cd956d3f54ad0b6608b01b96e9999d66552dfd025e698ac16cd0df1787a25"
 export const MAX_REDIRECT_DEPTH = 3
 export const SITE_NAMES: { [key: string]: string } = {
     // Any hardcoded (non suins) name -> object_id mappings go here

--- a/portal/common/lib/constants.ts
+++ b/portal/common/lib/constants.ts
@@ -16,8 +16,8 @@ export const FALLBACK_PORTAL = "blob.store"
 export const RESOURCE_PATH_MOVE_TYPE = SITE_PACKAGE + "::site::ResourcePath";
 
 const LANDING_PAGE_OID = '0x2d9414edc309535bfd4cd7e80ccbc09fee18bf86b449a185b81e914096059a67';
-const FLATLAND_OID = '0xf60797491f9303de69856b7d2fc1109daf63450ec8cd7fb49f1bd4a0e7d26ae6';
-const FLATLANDER_OID = '0xd2de62949d832aea46b0eac830d9837885d419ba5b2baa7f2b95d10059573ddf';
+const FLATLAND_OID = '0xc62fae899d75705d88ef282678d17abc08a3363293def8841f0113aabd053fbb';
+const FLATLANDER_OID = '0xabf413f36aa8ba984f81f4d3e334070b351c800dacb5ea5e02d49a7621b02d96';
 export const SITES_USED_FOR_BENCHING = [
     [LANDING_PAGE_OID, "landing page"],
     [FLATLAND_OID, "flatland"],

--- a/portal/common/lib/types/index.ts
+++ b/portal/common/lib/types/index.ts
@@ -22,8 +22,7 @@ export type UrlExtract = {
  */
 export type Resource = {
     path: string;
-    content_type: string;
-    content_encoding: string;
+    headers: Map<string, string>;
     blob_id: string;
     blob_hash: string;
 };
@@ -40,8 +39,7 @@ export function isResource(obj: any): obj is Resource {
     return (
         obj &&
         typeof obj.path === 'string' &&
-        typeof obj.content_type === 'string' &&
-        typeof obj.content_encoding === 'string' &&
+        typeof obj.headers === 'object' &&
         typeof obj.blob_id === 'string' &&
         typeof obj.blob_hash === 'string'
     );


### PR DESCRIPTION
Updates the portal to align with the changes in #210.

In detail, parse the resource headers, replacing the hard-coded content-type and content-encoding with the ones parsed from the contract. 

Also, redeploy the landing page and flatland, to align with the new walrus sites contract. 