### PR TITLE
chore(site-builder): small improvements and fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ dependencies = [
 [[package]]
 name = "anemo"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=26d415eb9aa6a2417be3c03c57d6e93c30bd1ad7#26d415eb9aa6a2417be3c03c57d6e93c30bd1ad7"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=e609f7697ed6169bf0760882a0b6c032a57e4f3b#e609f7697ed6169bf0760882a0b6c032a57e4f3b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -143,7 +143,7 @@ dependencies = [
  "ed25519",
  "futures",
  "hex",
- "http",
+ "http 1.1.0",
  "matchit 0.5.0",
  "pin-project-lite",
  "pkcs8 0.9.0",
@@ -151,8 +151,8 @@ dependencies = [
  "quinn-proto",
  "rand",
  "rcgen",
- "ring 0.16.20",
- "rustls 0.21.12",
+ "ring 0.17.8",
+ "rustls 0.23.13",
  "rustls-webpki",
  "serde",
  "serde_json",
@@ -161,7 +161,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.4.13",
  "tracing",
  "x509-parser",
 ]
@@ -222,18 +222,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 dependencies = [
  "backtrace",
-]
-
-[[package]]
-name = "ark-bls12-381"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
-dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-serialize",
- "ark-std",
 ]
 
 [[package]]
@@ -473,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.3.15"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
+checksum = "7e614738943d3f68c628ae3dbce7c3daffb196665f82f8c8ea6b65de73c79429"
 dependencies = [
  "brotli",
  "flate2",
@@ -483,6 +471,8 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -496,9 +486,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -507,25 +497,31 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.82"
+version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auto_ops"
@@ -535,26 +531,26 @@ checksum = "7460f7dd8e100147b82a63afca1a20eb6c231ee36b90ba7272e14951cb58af59"
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
-version = "0.6.20"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+checksum = "504e3947307ac8326a5437504c517c4b56716c9d98fac0028c2acc7ca47d70ae"
 dependencies = [
  "async-trait",
  "axum-core",
- "base64 0.21.7",
- "bitflags 1.3.2",
+ "base64 0.22.1",
  "bytes",
  "futures-util",
- "headers",
- "http",
- "http-body",
- "hyper",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
  "itoa",
  "matchit 0.7.3",
  "memchr",
@@ -567,27 +563,30 @@ dependencies = [
  "serde_path_to_error",
  "serde_urlencoded",
  "sha1",
- "sync_wrapper",
+ "sync_wrapper 1.0.1",
  "tokio",
  "tokio-tungstenite",
- "tower",
+ "tower 0.5.1",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.3.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
 dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
  "mime",
+ "pin-project-lite",
  "rustversion",
+ "sync_wrapper 1.0.1",
  "tower-layer",
  "tower-service",
 ]
@@ -720,8 +719,8 @@ dependencies = [
 
 [[package]]
 name = "bin-version"
-version = "1.27.2"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+version = "1.34.2"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "const-str",
  "git-version",
@@ -917,15 +916,15 @@ dependencies = [
 
 [[package]]
 name = "bnum"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56953345e39537a3e18bdaeba4cb0c58a78c1f61f361dc0fa7c5c7340ae87c5f"
+checksum = "3e31ea183f6ee62ac8b8a8cf7feddd766317adfb13ff469de57ce033efd6a790"
 
 [[package]]
 name = "brotli"
-version = "3.5.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
+checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -934,9 +933,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "2.5.1"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
+checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1002,9 +1001,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 dependencies = [
  "serde",
 ]
@@ -1020,10 +1019,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.20"
+version = "1.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45bcde016d64c21da4be18b655631e5ab6d3107607e71a73a9f53eb48aae23fb"
+checksum = "812acba72f0a070b003d3697490d2b55b837230ae7c6c6497f05cc2ddbb8d938"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -1049,6 +1050,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1060,9 +1088,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.17"
+version = "4.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+checksum = "7be5744db7978a28d9df86a214130d106a89ce49644cbc4e3f0c22c3fba30615"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1070,9 +1098,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.17"
+version = "4.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+checksum = "a5fbc17d3ef8278f55b282b2a2e75ae6f6c7d4bb70ed3d0382375104bfafdb4b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1083,14 +1111,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1139,9 +1167,9 @@ dependencies = [
 [[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=c101a5176799db3eb9c801b844e7add92153d291)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "mysten-network",
  "rand",
  "serde",
@@ -1207,6 +1235,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "coset"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8cc80f631f8307b887faca24dcc3abc427cd0367f6eb6188f6e8f5b7ad8fb"
+dependencies = [
+ "ciborium",
+ "ciborium-io",
 ]
 
 [[package]]
@@ -1396,7 +1434,7 @@ dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
  "strsim 0.11.1",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1418,7 +1456,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1538,7 +1576,7 @@ dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
  "rustc_version",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1617,7 +1655,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1742,18 +1780,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -1767,7 +1796,7 @@ dependencies = [
  "once_cell",
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1811,7 +1840,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto"
 version = "0.1.8"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=c101a5176799db3eb9c801b844e7add92153d291#c101a5176799db3eb9c801b844e7add92153d291"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2#3366c26a746b72707572c4f3f05915e20d5c16c2"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1834,7 +1863,7 @@ dependencies = [
  "ecdsa 0.16.9",
  "ed25519-consensus",
  "elliptic-curve 0.13.8",
- "fastcrypto-derive 0.1.3 (git+https://github.com/MystenLabs/fastcrypto?rev=c101a5176799db3eb9c801b844e7add92153d291)",
+ "fastcrypto-derive 0.1.3 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "generic-array",
  "hex",
  "hex-literal",
@@ -1851,7 +1880,7 @@ dependencies = [
  "secp256k1",
  "serde",
  "serde_json",
- "serde_with 2.3.3",
+ "serde_with",
  "sha2 0.10.8",
  "sha3",
  "signature 2.2.0",
@@ -1865,7 +1894,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto"
 version = "0.1.8"
-source = "git+https://github.com/MystenLabs/fastcrypto#3366c26a746b72707572c4f3f05915e20d5c16c2"
+source = "git+https://github.com/MystenLabs/fastcrypto#2f502fd8570fe4e9cff36eea5bbd6fef22002898"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -1901,7 +1930,7 @@ dependencies = [
  "secp256k1",
  "serde",
  "serde_json",
- "serde_with 3.9.0",
+ "serde_with",
  "sha2 0.10.8",
  "sha3",
  "signature 2.2.0",
@@ -1915,7 +1944,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-derive"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=c101a5176799db3eb9c801b844e7add92153d291#c101a5176799db3eb9c801b844e7add92153d291"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2#3366c26a746b72707572c4f3f05915e20d5c16c2"
 dependencies = [
  "quote 1.0.37",
  "syn 1.0.109",
@@ -1924,7 +1953,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-derive"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto#3366c26a746b72707572c4f3f05915e20d5c16c2"
+source = "git+https://github.com/MystenLabs/fastcrypto#2f502fd8570fe4e9cff36eea5bbd6fef22002898"
 dependencies = [
  "quote 1.0.37",
  "syn 1.0.109",
@@ -1933,11 +1962,11 @@ dependencies = [
 [[package]]
 name = "fastcrypto-tbls"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=c101a5176799db3eb9c801b844e7add92153d291#c101a5176799db3eb9c801b844e7add92153d291"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2#3366c26a746b72707572c4f3f05915e20d5c16c2"
 dependencies = [
  "bcs",
  "digest 0.10.7",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=c101a5176799db3eb9c801b844e7add92153d291)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "hex",
  "itertools 0.10.5",
  "rand",
@@ -1946,14 +1975,14 @@ dependencies = [
  "tap",
  "tracing",
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
 name = "fastcrypto-zkp"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=c101a5176799db3eb9c801b844e7add92153d291#c101a5176799db3eb9c801b844e7add92153d291"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2#3366c26a746b72707572c4f3f05915e20d5c16c2"
 dependencies = [
- "ark-bls12-381",
  "ark-bn254",
  "ark-ec",
  "ark-ff",
@@ -1961,10 +1990,10 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "ark-snark",
- "blst",
+ "bcs",
  "byte-slice-cast",
  "derive_more",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=c101a5176799db3eb9c801b844e7add92153d291)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "ff 0.13.0",
  "im",
  "itertools 0.12.1",
@@ -2057,9 +2086,9 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
+checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2157,7 +2186,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2252,7 +2281,7 @@ checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2309,12 +2338,41 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
- "indexmap 2.5.0",
+ "http 0.2.12",
+ "indexmap 2.6.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
+ "indexmap 2.6.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
 ]
 
 [[package]]
@@ -2342,6 +2400,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+
+[[package]]
 name = "hdrhistogram"
 version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2349,30 +2413,6 @@ checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
 dependencies = [
  "byteorder",
  "num-traits",
-]
-
-[[package]]
-name = "headers"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "headers-core",
- "http",
- "httpdate",
- "mime",
- "sha1",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
-dependencies = [
- "http",
 ]
 
 [[package]]
@@ -2453,27 +2493,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "http-range-header"
-version = "0.3.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
+checksum = "08a397c49fec283e3d6211adbe480be95aae5f304cfb923e9970e08956d5168a"
 
 [[package]]
 name = "httparse"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "httpdate"
@@ -2497,9 +2571,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -2512,16 +2586,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.6",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.30",
  "log",
  "rustls 0.20.9",
- "rustls-native-certs",
+ "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.23.4",
  "webpki-roots 0.22.6",
@@ -2529,28 +2624,53 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
- "rustls 0.21.12",
+ "http 1.1.0",
+ "hyper 1.4.1",
+ "hyper-util",
+ "rustls 0.23.13",
+ "rustls-native-certs 0.8.0",
+ "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls 0.26.0",
+ "tower-service",
+ "webpki-roots 0.26.6",
 ]
 
 [[package]]
 name = "hyper-timeout"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
 dependencies = [
- "hyper",
+ "hyper 1.4.1",
+ "hyper-util",
  "pin-project-lite",
  "tokio",
- "tokio-io-timeout",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "hyper 1.4.1",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2654,12 +2774,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.0",
  "serde",
 ]
 
@@ -2716,11 +2836,12 @@ checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
 
 [[package]]
 name = "iri-string"
-version = "0.4.1"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f0f7638c1e223529f1bfdc48c8b133b9e0b434094d1d28473161ee48b235f78"
+checksum = "44bd7eced44cfe2cebc674adb2a7124a754a4b5269288d22e9f39f8fada3562d"
 dependencies = [
- "nom",
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -2740,18 +2861,18 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -2761,6 +2882,15 @@ name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -2800,11 +2930,11 @@ version = "0.16.2"
 source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=b1b300784795f6a64d0fcdf8f03081a9bc38bde8#b1b300784795f6a64d0fcdf8f03081a9bc38bde8"
 dependencies = [
  "futures-util",
- "http",
+ "http 0.2.12",
  "jsonrpsee-core",
  "jsonrpsee-types",
  "pin-project",
- "rustls-native-certs",
+ "rustls-native-certs 0.6.3",
  "soketto",
  "thiserror",
  "tokio",
@@ -2828,11 +2958,11 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "globset",
- "hyper",
+ "hyper 0.14.30",
  "jsonrpsee-types",
  "parking_lot",
  "rand",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "serde",
  "serde_json",
  "soketto",
@@ -2847,11 +2977,11 @@ version = "0.16.2"
 source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=b1b300784795f6a64d0fcdf8f03081a9bc38bde8#b1b300784795f6a64d0fcdf8f03081a9bc38bde8"
 dependencies = [
  "async-trait",
- "hyper",
+ "hyper 0.14.30",
  "hyper-rustls 0.23.2",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -2878,8 +3008,8 @@ source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=b1b300784795f6a64d0fcd
 dependencies = [
  "futures-channel",
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.30",
  "jsonrpsee-core",
  "jsonrpsee-types",
  "serde",
@@ -2888,7 +3018,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tower",
+ "tower 0.4.13",
  "tracing",
 ]
 
@@ -2910,7 +3040,7 @@ name = "jsonrpsee-ws-client"
 version = "0.16.2"
 source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=b1b300784795f6a64d0fcdf8f03081a9bc38bde8#b1b300784795f6a64d0fcdf8f03081a9bc38bde8"
 dependencies = [
- "http",
+ "http 0.2.12",
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -2975,9 +3105,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libm"
@@ -3037,6 +3167,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "lsp-types"
+version = "0.95.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e34d33a8e9b006cd3fc4fe69a921affa097bae4bb65f76271f4644f9a334365"
+dependencies = [
+ "bitflags 1.3.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
+]
+
+[[package]]
 name = "match_opt"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3053,6 +3196,16 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "memchr"
@@ -3118,7 +3271,7 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "move-binary-format",
  "move-bytecode-verifier-meter",
@@ -3127,12 +3280,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -3146,12 +3299,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3166,9 +3319,10 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "anyhow",
+ "indexmap 2.6.0",
  "move-binary-format",
  "move-core-types",
  "petgraph",
@@ -3178,7 +3332,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -3193,7 +3347,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -3203,12 +3357,14 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "anyhow",
+ "bcs",
  "difference",
  "dirs-next",
  "hex",
+ "move-binary-format",
  "move-core-types",
  "num-bigint 0.4.6",
  "once_cell",
@@ -3221,7 +3377,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3229,6 +3385,7 @@ dependencies = [
  "codespan-reporting",
  "dunce",
  "hex",
+ "lsp-types",
  "move-binary-format",
  "move-borrow-graph",
  "move-bytecode-source-map",
@@ -3253,7 +3410,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3269,6 +3426,7 @@ dependencies = [
  "ref-cast",
  "serde",
  "serde_bytes",
+ "serde_with",
  "thiserror",
  "uint",
 ]
@@ -3276,7 +3434,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3296,7 +3454,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3316,7 +3474,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -3334,7 +3492,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "anyhow",
  "hex",
@@ -3347,7 +3505,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -3360,17 +3518,17 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "enum-compat-util",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "once_cell",
  "phf",
@@ -3380,7 +3538,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -3389,7 +3547,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "move-vm-config",
  "once_cell",
@@ -3401,7 +3559,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -3415,7 +3573,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -3428,7 +3586,7 @@ dependencies = [
 [[package]]
 name = "msim-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=077b735b484cf33e79f9d621db1d0c3a5827b81e#077b735b484cf33e79f9d621db1d0c3a5827b81e"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=b320996d8dfb99b273fe31c0222c659332283c99#b320996d8dfb99b273fe31c0222c659332283c99"
 dependencies = [
  "darling 0.14.4",
  "proc-macro2 1.0.86",
@@ -3494,7 +3652,7 @@ dependencies = [
 [[package]]
 name = "mysten-metrics"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "async-trait",
  "axum",
@@ -3505,6 +3663,7 @@ dependencies = [
  "prometheus",
  "prometheus-closure-metric",
  "scopeguard",
+ "simple-server-timing-header",
  "tap",
  "tokio",
  "tracing",
@@ -3514,15 +3673,17 @@ dependencies = [
 [[package]]
 name = "mysten-network"
 version = "0.2.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "anemo",
  "bcs",
  "bytes",
  "eyre",
  "futures",
- "http",
+ "http 1.1.0",
+ "hyper-util",
  "multiaddr",
+ "once_cell",
  "pin-project-lite",
  "serde",
  "snap",
@@ -3530,7 +3691,7 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tonic-health",
- "tower",
+ "tower 0.4.13",
  "tower-http",
  "tracing",
 ]
@@ -3538,15 +3699,15 @@ dependencies = [
 [[package]]
 name = "mysten-util-mem"
 version = "0.11.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "cfg-if",
  "ed25519-consensus",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=c101a5176799db3eb9c801b844e7add92153d291)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "fastcrypto-tbls",
  "hashbrown 0.12.3",
  "impl-trait-for-tuples",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "mysten-util-mem-derive",
  "once_cell",
  "parking_lot",
@@ -3557,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "mysten-util-mem-derive"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "proc-macro2 1.0.86",
  "syn 1.0.109",
@@ -3567,9 +3728,9 @@ dependencies = [
 [[package]]
 name = "narwhal-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=c101a5176799db3eb9c801b844e7add92153d291)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "match_opt",
  "mysten-network",
  "mysten-util-mem",
@@ -3584,10 +3745,10 @@ dependencies = [
 [[package]]
 name = "narwhal-crypto"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "bcs",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=c101a5176799db3eb9c801b844e7add92153d291)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "serde",
  "shared-crypto",
 ]
@@ -3793,7 +3954,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3807,25 +3968,26 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.7.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f930c88a43b1c3f6e776dfe495b4afab89882dbc81530c632db2ed65451ebcb4"
+checksum = "e6da452820c715ce78221e8202ccc599b4a52f3e1eb3eedb487b680c81a8e3f3"
 dependencies = [
  "async-trait",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "futures",
  "humantime",
- "hyper",
- "itertools 0.11.0",
+ "hyper 1.4.1",
+ "itertools 0.13.0",
+ "md-5",
  "parking_lot",
  "percent-encoding",
  "quick-xml",
  "rand",
  "reqwest",
- "ring 0.16.20",
- "rustls-pemfile",
+ "ring 0.17.8",
+ "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
  "snafu",
@@ -3846,15 +4008,29 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openapiv3"
+version = "2.0.0"
+source = "git+https://github.com/bmwill/openapiv3.git?rev=ca4b4845b7c159a39f5c68ad8f7f76cb6f4d6963#ca4b4845b7c159a39f5c68ad8f7f76cb6f4d6963"
+dependencies = [
+ "indexmap 2.6.0",
+ "schemars",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "openssl-probe"
@@ -3883,7 +4059,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3974,6 +4150,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "passkey-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "499cff8432e71c5f8784d9645aac0f9fca604d67f59b68a606170b5e229c6538"
+dependencies = [
+ "bitflags 2.6.0",
+ "ciborium",
+ "coset",
+ "data-encoding",
+ "indexmap 2.6.0",
+ "rand",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "strum 0.25.0",
+ "typeshare",
+]
+
+[[package]]
 name = "pasta_curves"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4007,11 +4202,12 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "1.1.1"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.22.1",
+ "serde",
 ]
 
 [[package]]
@@ -4040,9 +4236,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c73c26c01b8c87956cea613c907c9d6ecffd8d18a2a5908e5de0adfaa185cea"
+checksum = "fdbef9d1d47087a895abd220ed25eb4ad973a5e26f6a4367b038c25e28dfc2d9"
 dependencies = [
  "memchr",
  "thiserror",
@@ -4051,9 +4247,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664d22978e2815783adbdd2c588b455b1bd625299ce36b2a99881ac9627e6d8d"
+checksum = "4d3a6e3394ec80feb3b6393c725571754c6188490265c61aaf260810d6b95aa0"
 dependencies = [
  "pest",
  "pest_generator",
@@ -4061,22 +4257,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d5487022d5d33f4c30d91c22afa240ce2a644e87fe08caad974d4eab6badbe"
+checksum = "94429506bde1ca69d1b5601962c73f4172ab4726571a59ea95931218cb0e930e"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0091754bbd0ea592c4deb3a122ce8ecbb0753b738aa82bc055fcc2eccc8d8174"
+checksum = "ac8a071862e93690b6e34e9a5fb8e33ff3734473ac0245b27232222c4906a33f"
 dependencies = [
  "once_cell",
  "pest",
@@ -4123,7 +4319,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4152,7 +4348,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4200,6 +4396,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4210,6 +4412,12 @@ dependencies = [
  "opaque-debug",
  "universal-hash",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "powerfmt"
@@ -4317,7 +4525,7 @@ dependencies = [
 [[package]]
 name = "prometheus-closure-metric"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -4357,9 +4565,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.6"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -4367,15 +4575,15 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.6"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4404,9 +4612,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.30.0"
+version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
 dependencies = [
  "memchr",
  "serde",
@@ -4414,17 +4622,18 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.10.2"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cc2c5017e4b43d5995dcea317bc46c1e09404c0a9664d2908f7f02dfe943d75"
+checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
 dependencies = [
  "bytes",
  "futures-io",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
- "rustls 0.21.12",
+ "rustc-hash 2.0.0",
+ "rustls 0.23.13",
+ "socket2",
  "thiserror",
  "tokio",
  "tracing",
@@ -4432,15 +4641,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.10.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "141bf7dfde2fbc246bfd3fe12f2455aa24b0fbd9af535d8c86c7bd1381ff2b1a"
+checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
 dependencies = [
  "bytes",
  "rand",
- "ring 0.16.20",
- "rustc-hash",
- "rustls 0.21.12",
+ "ring 0.17.8",
+ "rustc-hash 2.0.0",
+ "rustls 0.23.13",
  "slab",
  "thiserror",
  "tinyvec",
@@ -4449,15 +4658,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.4.1"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "055b4e778e8feb9f93c4e439f71dc2156ef13360b432b799e179a8c4cdf0b1d7"
+checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
 dependencies = [
- "bytes",
  "libc",
+ "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4540,12 +4749,13 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.9.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6413f3de1edee53342e6138e75b56d32e7bc6e332b3bd62d497b1929d4cfbcdd"
+checksum = "54077e1872c46788540de1ea3d7f4ccb1983d12f9aa909b234468676c1a36779"
 dependencies = [
  "pem",
- "ring 0.16.20",
+ "ring 0.17.8",
+ "rustls-pki-types",
  "time",
  "yasna",
 ]
@@ -4558,14 +4768,14 @@ checksum = "a25d631e41bfb5fdcde1d4e2215f62f7f0afa3ff11e26563765bd6ea1d229aeb"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.4"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -4598,14 +4808,14 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4615,9 +4825,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4626,26 +4836,28 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
+version = "0.12.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+checksum = "f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
- "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-rustls 0.24.2",
+ "h2 0.4.6",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-rustls 0.27.3",
+ "hyper-util",
  "ipnet",
  "js-sys",
  "log",
@@ -4653,15 +4865,17 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.12",
- "rustls-pemfile",
+ "quinn",
+ "rustls 0.23.13",
+ "rustls-native-certs 0.8.0",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
- "system-configuration",
+ "sync_wrapper 1.0.1",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls 0.26.0",
  "tokio-util",
  "tower-service",
  "url",
@@ -4669,8 +4883,8 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.25.4",
- "winreg",
+ "webpki-roots 0.26.6",
+ "windows-registry",
 ]
 
 [[package]]
@@ -4735,9 +4949,9 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.10.3"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1c77081a55300e016cb86f2864415b7518741879db925b8d488a0ee0d2da6bf"
+checksum = "8f4b84ba6e838ceb47b41de5194a60244fac43d9fe03b71dbe8c5a201081d6d1"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -4775,6 +4989,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "rustc-hex"
@@ -4827,14 +5047,16 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
+version = "0.23.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
 dependencies = [
- "log",
+ "once_cell",
  "ring 0.17.8",
+ "rustls-pki-types",
  "rustls-webpki",
- "sct",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -4844,7 +5066,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
  "schannel",
  "security-framework",
 ]
@@ -4859,12 +5094,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-webpki"
-version = "0.101.7"
+name = "rustls-pemfile"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "ring 0.17.8",
+ "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
@@ -4932,7 +5183,7 @@ dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
  "serde_derive_internals",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5013,9 +5264,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.1"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5034,6 +5285,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-env"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d13536c0c431652192b75c7d5afa83dedae98f91d7e687ff30a009e9d15284fb"
+dependencies = [
+ "anyhow",
+ "serde",
 ]
 
 [[package]]
@@ -5074,7 +5335,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5085,7 +5346,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5094,7 +5355,7 @@ version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "itoa",
  "memchr",
  "ryu",
@@ -5119,14 +5380,14 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
@@ -5145,60 +5406,32 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "2.3.3"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
-dependencies = [
- "base64 0.13.1",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "serde",
- "serde_json",
- "serde_with_macros 2.3.3",
- "time",
-]
-
-[[package]]
-name = "serde_with"
-version = "3.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
+checksum = "9720086b3357bcb44fce40117d769a4d068c70ecfa190850a980a71755f66fcc"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "serde",
  "serde_derive",
  "serde_json",
- "serde_with_macros 3.9.0",
+ "serde_with_macros",
  "time",
 ]
 
 [[package]]
 name = "serde_with_macros"
-version = "2.3.3"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
+checksum = "5f1abbfe725f27678f4663bcacb75a83e829fd464c25d78dd038a3a29e307cec"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.77",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
-dependencies = [
- "darling 0.20.10",
- "proc-macro2 1.0.86",
- "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5219,7 +5452,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "itoa",
  "ryu",
  "serde",
@@ -5296,11 +5529,11 @@ dependencies = [
 [[package]]
 name = "shared-crypto"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "bcs",
  "eyre",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=c101a5176799db3eb9c801b844e7add92153d291)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "serde",
  "serde_repr",
 ]
@@ -5368,6 +5601,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
 
 [[package]]
+name = "simple-server-timing-header"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e78919e05c9b8e123d435a4ad104b488ad1585631830e413830985c214086e"
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5391,13 +5630,12 @@ dependencies = [
  "notify",
  "serde",
  "serde_json",
- "serde_with 3.9.0",
+ "serde_with",
  "serde_yaml 0.9.34+deprecated",
  "shared-crypto",
  "sui-keys",
- "sui-sdk 1.27.2",
+ "sui-sdk 1.34.2",
  "sui-types",
- "tempfile",
  "thiserror",
  "tokio",
  "toml 0.8.19",
@@ -5486,7 +5724,7 @@ dependencies = [
  "base64 0.13.1",
  "bytes",
  "futures",
- "http",
+ "http 0.2.12",
  "httparse",
  "log",
  "rand",
@@ -5562,7 +5800,16 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.24.3",
+]
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros 0.25.3",
 ]
 
 [[package]]
@@ -5576,6 +5823,19 @@ dependencies = [
  "quote 1.0.37",
  "rustversion",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
+ "rustversion",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5593,15 +5853,17 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 [[package]]
 name = "sui-config"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "anemo",
  "anyhow",
  "bcs",
  "clap",
+ "consensus-config",
  "csv",
  "dirs",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=c101a5176799db3eb9c801b844e7add92153d291)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "move-vm-config",
  "narwhal-config",
  "object_store",
  "once_cell",
@@ -5609,7 +5871,7 @@ dependencies = [
  "rand",
  "reqwest",
  "serde",
- "serde_with 2.3.3",
+ "serde_with",
  "serde_yaml 0.8.26",
  "sui-keys",
  "sui-protocol-config",
@@ -5620,7 +5882,7 @@ dependencies = [
 [[package]]
 name = "sui-enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -5628,11 +5890,11 @@ dependencies = [
 [[package]]
 name = "sui-json"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "anyhow",
  "bcs",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=c101a5176799db3eb9c801b844e7add92153d291)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "move-binary-format",
  "move-bytecode-utils",
  "move-core-types",
@@ -5645,10 +5907,10 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc-api"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "anyhow",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=c101a5176799db3eb9c801b844e7add92153d291)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "jsonrpsee",
  "mysten-metrics",
  "once_cell",
@@ -5665,14 +5927,14 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc-types"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "anyhow",
  "bcs",
  "colored",
  "enum_dispatch",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=c101a5176799db3eb9c801b844e7add92153d291)",
- "itertools 0.10.5",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "itertools 0.13.0",
  "json_to_table",
  "move-binary-format",
  "move-bytecode-utils",
@@ -5681,7 +5943,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "serde_with 2.3.3",
+ "serde_with",
  "sui-enum-compat-util",
  "sui-json",
  "sui-macros",
@@ -5695,11 +5957,11 @@ dependencies = [
 [[package]]
 name = "sui-keys"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "anyhow",
  "bip32",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=c101a5176799db3eb9c801b844e7add92153d291)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "rand",
  "regex",
  "serde",
@@ -5714,7 +5976,7 @@ dependencies = [
 [[package]]
 name = "sui-macros"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "futures",
  "once_cell",
@@ -5724,8 +5986,8 @@ dependencies = [
 
 [[package]]
 name = "sui-open-rpc"
-version = "1.27.2"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+version = "1.34.2"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "bcs",
  "schemars",
@@ -5737,10 +5999,10 @@ dependencies = [
 [[package]]
 name = "sui-open-rpc-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "derive-syn-parse",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2 1.0.86",
  "quote 1.0.37",
  "syn 1.0.109",
@@ -5750,7 +6012,7 @@ dependencies = [
 [[package]]
 name = "sui-package-resolver"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "async-trait",
  "bcs",
@@ -5769,26 +6031,27 @@ dependencies = [
 [[package]]
 name = "sui-proc-macros"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "msim-macros",
  "proc-macro2 1.0.86",
  "quote 1.0.37",
  "sui-enum-compat-util",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "sui-protocol-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "clap",
  "insta",
  "move-vm-config",
  "schemars",
  "serde",
- "serde_with 2.3.3",
+ "serde-env",
+ "serde_with",
  "sui-protocol-config-macros",
  "tracing",
 ]
@@ -5796,7 +6059,7 @@ dependencies = [
 [[package]]
 name = "sui-protocol-config-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
@@ -5806,49 +6069,58 @@ dependencies = [
 [[package]]
 name = "sui-rest-api"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "anyhow",
  "async-trait",
  "axum",
  "bcs",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=c101a5176799db3eb9c801b844e7add92153d291)",
- "itertools 0.10.5",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "itertools 0.13.0",
  "mime",
  "mysten-network",
+ "openapiv3",
  "prometheus",
  "rand",
  "reqwest",
+ "schemars",
  "serde",
  "serde_json",
- "serde_with 2.3.3",
+ "serde_with",
+ "serde_yaml 0.8.26",
+ "sui-protocol-config",
  "sui-sdk 0.0.0",
  "sui-types",
  "tap",
  "thiserror",
+ "tokio",
+ "url",
 ]
 
 [[package]]
 name = "sui-sdk"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/sui-rust-sdk.git?rev=bb224b9e6b6edf5eeedcdf71c750a30b68073057#bb224b9e6b6edf5eeedcdf71c750a30b68073057"
+source = "git+https://github.com/mystenlabs/sui-rust-sdk.git?rev=bd233b6879b917fb95e17f21927c198e7a60c924#bd233b6879b917fb95e17f21927c198e7a60c924"
 dependencies = [
  "base64ct",
  "bcs",
+ "blake2",
  "bnum",
  "bs58 0.5.1",
  "hex",
  "roaring",
+ "schemars",
  "serde",
  "serde_derive",
- "serde_with 3.9.0",
+ "serde_json",
+ "serde_with",
  "winnow",
 ]
 
 [[package]]
 name = "sui-sdk"
-version = "1.27.2"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+version = "1.34.2"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5856,7 +6128,7 @@ dependencies = [
  "bcs",
  "clap",
  "colored",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=c101a5176799db3eb9c801b844e7add92153d291)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "futures",
  "futures-core",
  "jsonrpsee",
@@ -5864,7 +6136,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serde_with 2.3.3",
+ "serde_with",
  "shared-crypto",
  "sui-config",
  "sui-json",
@@ -5881,7 +6153,7 @@ dependencies = [
 [[package]]
 name = "sui-transaction-builder"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5898,10 +6170,11 @@ dependencies = [
 [[package]]
 name = "sui-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "anemo",
  "anyhow",
+ "async-trait",
  "bcs",
  "better_any",
  "bincode",
@@ -5912,12 +6185,12 @@ dependencies = [
  "derive_more",
  "enum_dispatch",
  "eyre",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=c101a5176799db3eb9c801b844e7add92153d291)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "fastcrypto-tbls",
  "fastcrypto-zkp",
  "im",
- "indexmap 2.5.0",
- "itertools 0.10.5",
+ "indexmap 2.6.0",
+ "itertools 0.13.0",
  "jsonrpsee",
  "lru",
  "move-binary-format",
@@ -5931,14 +6204,13 @@ dependencies = [
  "move-vm-types",
  "mysten-metrics",
  "mysten-network",
- "narwhal-config",
- "narwhal-crypto",
  "nonempty",
  "num-bigint 0.4.6",
  "num-traits",
  "num_enum",
  "once_cell",
  "parking_lot",
+ "passkey-types",
  "prometheus",
  "proptest",
  "proptest-derive",
@@ -5948,12 +6220,12 @@ dependencies = [
  "serde",
  "serde-name",
  "serde_json",
- "serde_with 2.3.3",
+ "serde_with",
  "shared-crypto",
  "signature 1.6.4",
  "static_assertions",
- "strum",
- "strum_macros",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
  "sui-enum-compat-util",
  "sui-macros",
  "sui-protocol-config",
@@ -5989,9 +6261,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
@@ -6005,6 +6277,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6013,28 +6294,7 @@ dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
  "syn 1.0.109",
- "unicode-xid 0.2.5",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "unicode-xid 0.2.6",
 ]
 
 [[package]]
@@ -6069,9 +6329,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -6091,32 +6351,32 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+checksum = "4f599bd7ca042cfdf8f4512b277c02ba102247820f9d9d4a9f521f496751a6ef"
 dependencies = [
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -6180,7 +6440,7 @@ dependencies = [
  "once_cell",
  "pbkdf2",
  "rand",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "sha2 0.10.8",
  "thiserror",
  "unicode-normalization",
@@ -6220,16 +6480,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-io-timeout"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
-dependencies = [
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6237,7 +6487,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -6253,11 +6503,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.21.12",
+ "rustls 0.23.13",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -6275,9 +6526,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.20.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
 dependencies = [
  "futures-util",
  "log",
@@ -6331,11 +6582,11 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.21"
+version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b072cee73c449a636ffd6f32bd8de3a9f7119139aff882f44943ce2986dc5cf"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -6344,26 +6595,29 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.11.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.4.6",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
  "hyper-timeout",
+ "hyper-util",
  "percent-encoding",
  "pin-project",
  "prost",
+ "socket2",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -6371,9 +6625,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-health"
-version = "0.11.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cef6e24bc96871001a7e48e820ab240b3de2201e59b517cf52835df2f1d2350"
+checksum = "1eaf34ddb812120f5c601162d5429933c9b527d901ab0e7f930d3147e33a09b2"
 dependencies = [
  "async-stream",
  "prost",
@@ -6404,19 +6658,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-http"
-version = "0.3.5"
+name = "tower"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
+checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 0.1.2",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "async-compression",
- "base64 0.13.1",
- "bitflags 1.3.2",
+ "base64 0.21.7",
+ "bitflags 2.6.0",
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
  "http-range-header",
  "httpdate",
  "iri-string",
@@ -6426,7 +6696,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -6465,7 +6735,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -6522,27 +6792,26 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.20.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
 dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 1.1.0",
  "httparse",
  "log",
  "rand",
  "sha1",
  "thiserror",
- "url",
  "utf-8",
 ]
 
 [[package]]
 name = "typed-store-error"
 version = "0.4.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.27.2#9e2be6ad4185563ecd98bf35abfe92b86a0b280f"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.2#997fe35c4cd2880838c25343318441e58db7fee7"
 dependencies = [
  "serde",
  "thiserror",
@@ -6555,10 +6824,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
-name = "ucd-trie"
-version = "0.1.6"
+name = "typeshare"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+checksum = "04f17399b76c2e743d58eac0635d7686e9c00f48cd4776f00695d9882a7d3187"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "typeshare-annotation",
+]
+
+[[package]]
+name = "typeshare-annotation"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a615d6c2764852a2e88a4f16e9ce1ea49bb776b5872956309e170d63a042a34f"
+dependencies = [
+ "quote 1.0.37",
+ "syn 2.0.79",
+]
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uint"
@@ -6595,9 +6886,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
 
 [[package]]
 name = "unicode-ident"
@@ -6616,9 +6907,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"
@@ -6628,9 +6919,9 @@ checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
@@ -6675,6 +6966,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -6793,7 +7085,7 @@ dependencies = [
  "once_cell",
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.79",
  "wasm-bindgen-shared",
 ]
 
@@ -6827,7 +7119,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.79",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6840,9 +7132,9 @@ checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+checksum = "4e072d4e72f700fb3443d8fe94a39315df013eef1104903cdb0a2abd322bbecd"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -6882,9 +7174,12 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.4"
+version = "0.26.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "winapi"
@@ -6923,6 +7218,36 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
  "windows-targets 0.52.6",
 ]
 
@@ -7076,21 +7401,11 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7162,7 +7477,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -7182,5 +7497,33 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.79",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.13+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -12,6 +12,8 @@ ignore = [
     # We have a vulnerable version of `rustls` in our dependency tree through the old version of
     # jsonrpsee used by sui.
     "RUSTSEC-2024-0336",
+    # proc-macro-error is not maintained, but is a dependency in many of our packages.
+    "RUSTSEC-2024-0370",
 ]
 
 # This section is considered when running `cargo deny check licenses`
@@ -34,7 +36,7 @@ allow = [
     "MPL-2.0",
     "Unicode-DFS-2016",
     "Unlicense",
-    "Unicode-3.0",
+    # "Unicode-3.0",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
@@ -85,6 +87,8 @@ unknown-git = "deny"
 allow-git = [
     "https://github.com/wlmyng/jsonrpsee",
     "https://github.com/zhiburt/tabled",
+    "https://github.com/zhiburt/tabled",
+    "https://github.com/bmwill/openapiv3",
 ]
 
 [sources.allow-org]

--- a/deny.toml
+++ b/deny.toml
@@ -87,7 +87,6 @@ unknown-git = "deny"
 allow-git = [
     "https://github.com/wlmyng/jsonrpsee",
     "https://github.com/zhiburt/tabled",
-    "https://github.com/zhiburt/tabled",
     "https://github.com/bmwill/openapiv3",
 ]
 

--- a/move/walrus_site/sources/site.move
+++ b/move/walrus_site/sources/site.move
@@ -55,7 +55,7 @@ module walrus_site::site {
         }
     }
 
-    /// Adds a header to the Resource's headers vector
+    /// Adds a header to the Resource's headers vector.
     public fun add_header(resource: &mut Resource, name: String, value: String) {
         // Will throw an exception if duplicate key.
         vec_map::insert(

--- a/portal/common/lib/bcs_data_parsing.ts
+++ b/portal/common/lib/bcs_data_parsing.ts
@@ -20,7 +20,7 @@ const BLOB_ID = bcs.u256().transform({
 // otherwise, it will mess up with the checksum results.
 const DATA_HASH = bcs.u256().transform({
     input: (id: string) => id,
-    output: (id) => toHEX(bcs.u256().serialize(id).toBytes()),
+    output: (id) => toB64(bcs.u256().serialize(id).toBytes()),
 });
 
 export const ResourcePathStruct = bcs.struct("ResourcePath", {
@@ -31,7 +31,7 @@ export const ResourceStruct = bcs.struct("Resource", {
     path: bcs.string(),
     headers: bcs.map(bcs.string(), bcs.string()),
     blob_id: BLOB_ID,
-    blob_hash: DATA_HASH
+    blob_hash: DATA_HASH,
 });
 
 export function DynamicFieldStruct<K, V>(K: BcsType<K>, V: BcsType<V>) {

--- a/site-builder/Cargo.toml
+++ b/site-builder/Cargo.toml
@@ -9,24 +9,23 @@ license = "Apache-2.0"
 anyhow = "1.0.86"
 base64 = "0.22.1"
 bcs = "0.1.6"
-bin-version = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.27.2" }
+bin-version = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.34.2" }
 clap = { version = "4.5.7", features = ["derive"] }
 crossterm = "0.27.0"
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto" }
 flate2 = "1.0.30"
 futures = "0.3.30"
 home = "0.5.9"
-move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.27.2" }
+move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.34.2" }
 notify = "6.1.1"
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"
 serde_with = { version = "3.8.1", features = ["base64"] }
 serde_yaml = "0.9"
-shared-crypto = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.27.2" }
-sui-keys = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.27.2" }
-sui-sdk = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.27.2" }
-sui-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.27.2" }
-tempfile = "3.12.0"
+shared-crypto = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.34.2" }
+sui-keys = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.34.2" }
+sui-sdk = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.34.2" }
+sui-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.34.2" }
 thiserror = "1.0.61"
 tokio = { version = "1.38.0", features = ["rt", "rt-multi-thread", "macros"] }
 toml = "0.8.14"

--- a/site-builder/src/main.rs
+++ b/site-builder/src/main.rs
@@ -128,7 +128,7 @@ enum Commands {
         #[clap(short, long, default_value = "test site")]
         site_name: String,
     },
-    /// Update an existing site
+    /// Update an existing site.
     Update {
         #[clap(flatten)]
         publish_options: PublishOptions,

--- a/site-builder/src/main.rs
+++ b/site-builder/src/main.rs
@@ -12,8 +12,9 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use futures::TryFutureExt;
-use publish::{publish_site, update_site, PublishOptions};
+use publish::{ContinuousEditing, PublishOptions, SiteEditor, WhenWalrusUpload};
 use serde::Deserialize;
+use site::manager::SiteIdentifier;
 use sui_types::base_types::ObjectID;
 
 use crate::{
@@ -226,14 +227,32 @@ async fn run() -> Result<()> {
         Commands::Publish {
             publish_options,
             site_name,
-        } => publish_site(publish_options, site_name, &config).await?,
+        } => {
+            SiteEditor::new(
+                publish_options,
+                SiteIdentifier::NewSite(site_name),
+                config,
+                ContinuousEditing::Once,
+                WhenWalrusUpload::Modified,
+            )
+            .run()
+            .await?
+        }
         Commands::Update {
             publish_options,
             object_id,
             watch,
             force,
         } => {
-            update_site(publish_options, &object_id, &config, watch, force).await?;
+            SiteEditor::new(
+                publish_options,
+                SiteIdentifier::ExistingSite(object_id),
+                config,
+                ContinuousEditing::from_watch_flag(watch),
+                WhenWalrusUpload::from_force_flag(force),
+            )
+            .run()
+            .await?
         }
         // Add a path to be watched. All files and directories at that path and
         // below will be monitored for changes.

--- a/site-builder/src/publish.rs
+++ b/site-builder/src/publish.rs
@@ -164,6 +164,12 @@ impl SiteEditor {
 
         let (ws_resources, ws_resources_path) =
             load_ws_resources(&self.publish_options.ws_resources, self.directory())?;
+        if let Some(path) = ws_resources_path.as_ref() {
+            println!(
+                "Using the Walrus sites resources file: {}",
+                path.to_string_lossy()
+            );
+        }
 
         let mut resource_manager =
             ResourceManager::new(walrus.clone(), ws_resources, ws_resources_path)?;

--- a/site-builder/src/publish.rs
+++ b/site-builder/src/publish.rs
@@ -14,14 +14,14 @@ use sui_sdk::rpc_types::{
     SuiTransactionBlockEffects,
     SuiTransactionBlockResponse,
 };
-use sui_types::base_types::{ObjectID, SuiAddress};
+use sui_types::base_types::SuiAddress;
 
 use crate::{
     display,
     preprocessor::Preprocessor,
     site::{
+        config::WSResources,
         manager::{SiteIdentifier, SiteManager},
-        // manager::SiteManager,
         resource::{OperationsSummary, ResourceManager},
     },
     util::{get_site_id_from_response, id_to_base36, load_wallet_context},
@@ -46,156 +46,171 @@ pub struct PublishOptions {
     pub list_directory: bool,
 }
 
-pub async fn publish_site(
-    publish_options: PublishOptions,
-    site_name: String,
-    config: &Config,
-) -> Result<()> {
-    edit_site(
-        &publish_options.directory,
-        SiteIdentifier::NewSite(site_name),
-        config,
-        publish_options.epochs,
-        false,
-        publish_options.list_directory,
-        publish_options
-            .ws_resources
-            .expect("Please provide ws-resources.")
-            .as_path(),
-    )
-    .await
+/// The continuous editing options.
+#[derive(Debug, Clone)]
+pub(crate) enum ContinuousEditing {
+    /// Edit the site once and exit.
+    Once,
+    /// Watch the directory for changes and publish the site on change.
+    Watch,
 }
 
-pub async fn watch_edit_site(
-    directory: &Path,
-    site_id: SiteIdentifier,
-    config: &Config,
-    epochs: u64,
-    force: bool,
-    preprocess: bool,
-    ws_resources_path: &Path,
-) -> Result<()> {
-    let (tx, rx) = channel();
-    let mut watcher = notify::recommended_watcher(move |res| {
-        tx.send(res).expect("Error in sending the watch event")
-    })?;
-
-    // Add a path to be watched. All files and directories at that path and
-    // below will be monitored for changes.
-    watcher.watch(directory, RecursiveMode::Recursive)?;
-
-    loop {
-        match rx.recv() {
-            Ok(event) => {
-                tracing::info!("change detected: {:?}", event);
-                edit_site(
-                    directory,
-                    site_id.clone(),
-                    config,
-                    epochs,
-                    force,
-                    preprocess,
-                    ws_resources_path,
-                )
-                .await?;
-            }
-            Err(e) => println!("Watch error!: {}", e),
+impl ContinuousEditing {
+    /// Convert the flag to the enum.
+    pub fn from_watch_flag(flag: bool) -> Self {
+        if flag {
+            ContinuousEditing::Watch
+        } else {
+            ContinuousEditing::Once
         }
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-pub async fn update_site(
-    publish_options: PublishOptions,
-    site_object: &ObjectID,
-    config: &Config,
-    watch: bool,
-    force: bool,
-) -> Result<()> {
-    if watch {
-        watch_edit_site(
-            publish_options.directory.as_path(),
-            SiteIdentifier::ExistingSite(*site_object),
-            config,
-            publish_options.epochs,
-            force,
-            publish_options.list_directory,
-            &publish_options
-                .ws_resources
-                .expect("Please provide ws-resources."),
-        )
-        .await
-    } else {
-        edit_site(
-            publish_options.directory.as_path(),
-            SiteIdentifier::ExistingSite(*site_object),
-            config,
-            publish_options.epochs,
-            force,
-            publish_options.list_directory,
-            &publish_options
-                .ws_resources
-                .expect("Please provide ws-resources."),
-        )
-        .await
+/// Force the update of walrus blobs.
+#[derive(Debug, Clone)]
+pub(crate) enum WhenWalrusUpload {
+    /// Force the update of walrus blobs.
+    Always,
+    /// Only update modified
+    Modified,
+}
+
+impl WhenWalrusUpload {
+    pub fn is_always(&self) -> bool {
+        matches!(self, WhenWalrusUpload::Always)
     }
 }
 
-pub async fn edit_site(
-    directory: &Path,
-    site_id: SiteIdentifier,
-    config: &Config,
-    epochs: u64,
-    force: bool,
-    preprocess: bool,
-    ws_resources_path: &Path,
-) -> Result<()> {
-    tracing::debug!(?site_id, ?directory, ?epochs, ?force, "editing site");
+/// When to upload the resources to Walrus.
+impl WhenWalrusUpload {
+    pub fn from_force_flag(force: bool) -> Self {
+        if force {
+            WhenWalrusUpload::Always
+        } else {
+            WhenWalrusUpload::Modified
+        }
+    }
+}
 
-    if preprocess {
-        display::action(format!("Preprocessing: {}", directory.display()));
-        Preprocessor::preprocess(directory)?;
-        display::done();
+pub(crate) struct SiteEditor {
+    publish_options: PublishOptions,
+    site_id: SiteIdentifier,
+    config: Config,
+    continuous_editing: ContinuousEditing,
+    when_upload: WhenWalrusUpload,
+}
+
+impl SiteEditor {
+    pub fn new(
+        publish_options: PublishOptions,
+        site_id: SiteIdentifier,
+        config: Config,
+        continuous_editing: ContinuousEditing,
+        when_upload: WhenWalrusUpload,
+    ) -> Self {
+        SiteEditor {
+            publish_options,
+            site_id,
+            config,
+            continuous_editing,
+            when_upload,
+        }
     }
 
-    let wallet = load_wallet_context(&config.general.wallet)?;
+    /// The directory containing the site sources.
+    pub fn directory(&self) -> &Path {
+        &self.publish_options.directory
+    }
 
-    let walrus = Walrus::new(
-        config.walrus_binary(),
-        config.gas_budget(),
-        config.general.rpc_url.clone(),
-        config.general.walrus_config.clone(),
-        config.general.wallet.clone(),
-    );
+    /// Run the editing operations requested.
+    pub async fn run(&self) -> Result<()> {
+        match self.continuous_editing {
+            ContinuousEditing::Once => self.run_single_and_print_summary().await?,
+            ContinuousEditing::Watch => self.run_continuous().await?,
+        }
+        Ok(())
+    }
 
-    let mut resource_manager =
-        ResourceManager::new(walrus.clone(), ws_resources_path.to_path_buf())?;
-    display::action(format!(
-        "Parsing the directory {} and locally computing blob IDs",
-        directory.to_string_lossy()
-    ));
-    resource_manager.read_dir(directory)?;
-    display::done();
-    tracing::debug!(resources=%resource_manager.resources, "resources loaded from directory");
+    async fn run_single_edit(
+        &self,
+    ) -> Result<(SuiAddress, SuiTransactionBlockResponse, OperationsSummary)> {
+        if self.publish_options.list_directory {
+            display::action(format!("Preprocessing: {}", self.directory().display()));
+            Preprocessor::preprocess(self.directory())?;
+            display::done();
+        }
 
-    let site_manager = SiteManager::new(
-        config.clone(),
-        walrus,
-        wallet,
-        site_id.clone(),
-        epochs,
-        force,
-    )
-    .await?;
-    let (response, summary) = site_manager.update_site(&resource_manager).await?;
-    print_summary(
-        config,
-        &site_manager.active_address()?,
-        &site_id,
-        &response,
-        &summary,
-    )?;
-    Ok(())
+        let wallet = load_wallet_context(&self.config.general.wallet)?;
+
+        let walrus = Walrus::new(
+            self.config.walrus_binary(),
+            self.config.gas_budget(),
+            self.config.general.rpc_url.clone(),
+            self.config.general.walrus_config.clone(),
+            self.config.general.wallet.clone(),
+        );
+
+        let ws_resources = self
+            .publish_options
+            .ws_resources
+            .clone()
+            .map(WSResources::read)
+            .transpose()?;
+
+        let mut resource_manager = ResourceManager::new(walrus.clone(), ws_resources)?;
+        display::action(format!(
+            "Parsing the directory {} and locally computing blob IDs",
+            self.directory().to_string_lossy()
+        ));
+        resource_manager.read_dir(self.directory())?;
+        display::done();
+        tracing::debug!(resources=%resource_manager.resources, "resources loaded from directory");
+
+        let site_manager = SiteManager::new(
+            self.config.clone(),
+            walrus,
+            wallet,
+            self.site_id.clone(),
+            self.publish_options.epochs,
+            self.when_upload.clone(),
+        )
+        .await?;
+        let (response, summary) = site_manager.update_site(&resource_manager).await?;
+        Ok((site_manager.active_address()?, response, summary))
+    }
+
+    async fn run_single_and_print_summary(&self) -> Result<()> {
+        let (active_address, response, summary) = self.run_single_edit().await?;
+        print_summary(
+            &self.config,
+            &active_address,
+            &self.site_id,
+            &response,
+            &summary,
+        )?;
+        Ok(())
+    }
+
+    async fn run_continuous(&self) -> Result<()> {
+        let (tx, rx) = channel();
+        let mut watcher = notify::recommended_watcher(move |res| {
+            tx.send(res).expect("Error in sending the watch event")
+        })?;
+
+        // Add a path to be watched. All files and directories at that path and
+        // below will be monitored for changes.
+        watcher.watch(self.directory(), RecursiveMode::Recursive)?;
+
+        loop {
+            match rx.recv() {
+                Ok(event) => {
+                    tracing::info!("change detected: {:?}", event);
+                    self.run_single_and_print_summary().await?;
+                }
+                Err(e) => println!("Watch error!: {}", e),
+            }
+        }
+    }
 }
 
 fn print_summary(

--- a/site-builder/src/publish.rs
+++ b/site-builder/src/publish.rs
@@ -162,9 +162,11 @@ impl SiteEditor {
             self.config.general.wallet.clone(),
         );
 
-        let ws_resources = load_ws_resources(&self.publish_options.ws_resources, self.directory())?;
+        let (ws_resources, ws_resources_path) =
+            load_ws_resources(&self.publish_options.ws_resources, self.directory())?;
 
-        let mut resource_manager = ResourceManager::new(walrus.clone(), ws_resources)?;
+        let mut resource_manager =
+            ResourceManager::new(walrus.clone(), ws_resources, ws_resources_path)?;
         display::action(format!(
             "Parsing the directory {} and locally computing blob IDs",
             self.directory().to_string_lossy()
@@ -265,8 +267,11 @@ fn print_summary(
 }
 
 /// Gets the configuration from the provided file, or looks in the default directory.
-fn load_ws_resources(path: &Option<PathBuf>, site_dir: &Path) -> Result<Option<WSResources>> {
+fn load_ws_resources(
+    path: &Option<PathBuf>,
+    site_dir: &Path,
+) -> Result<(Option<WSResources>, Option<PathBuf>)> {
     let default_paths = vec![site_dir.join(DEFAULT_WS_RESOURCES_FILE)];
     let path = path_or_defaults_if_exist(path, &default_paths);
-    path.map(WSResources::read).transpose()
+    Ok((path.as_ref().map(WSResources::read).transpose()?, path))
 }

--- a/site-builder/src/site/builder.rs
+++ b/site-builder/src/site/builder.rs
@@ -11,7 +11,7 @@ use sui_types::{
     TypeTag,
 };
 
-use super::resource::{HttpHeader, Resource, ResourceOp};
+use super::resource::{Resource, ResourceOp};
 
 pub struct SitePtb<T = ()> {
     pt_builder: ProgrammableTransactionBuilder,
@@ -129,13 +129,7 @@ impl SitePtb<Argument> {
 
         // Add the headers to the resource.
         for header in resource.info.headers.0.iter() {
-            self.add_header(
-                new_resource_arg,
-                &HttpHeader {
-                    name: header.0.clone(),
-                    value: header.1.clone(),
-                },
-            )?;
+            self.add_header(new_resource_arg, header.0, header.1)?;
         }
 
         // Add the resource to the site.
@@ -165,9 +159,9 @@ impl SitePtb<Argument> {
     }
 
     /// Adds the header to the given resource argument.
-    fn add_header(&mut self, resource_arg: Argument, header: &HttpHeader) -> Result<()> {
-        let name_input = self.pt_builder.input(pure_call_arg(&header.name)?)?;
-        let value_input = self.pt_builder.input(pure_call_arg(&header.value)?)?;
+    fn add_header(&mut self, resource_arg: Argument, name: &str, value: &str) -> Result<()> {
+        let name_input = self.pt_builder.input(pure_call_arg(&name.to_owned())?)?;
+        let value_input = self.pt_builder.input(pure_call_arg(&value.to_owned())?)?;
         self.add_programmable_move_call(
             Identifier::new("add_header")?,
             vec![],

--- a/site-builder/src/site/config.rs
+++ b/site-builder/src/site/config.rs
@@ -23,7 +23,7 @@ impl WSResources {
             std::fs::read_to_string(path).context("Failed to read ws_config.json")?;
         // Read the JSON contents of the file as an instance of `WSResources`.
         let ws_config: WSResources = serde_json::from_str(&file_contents)?;
-        println!("ws-resources.json loaded! contents: {:?}", ws_config);
+        tracing::info!(?ws_config, "ws resources configuration loaded");
         Ok(ws_config)
     }
 }

--- a/site-builder/src/site/config.rs
+++ b/site-builder/src/site/config.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashMap, path::Path};
+use std::{collections::BTreeMap, path::Path};
 
 use anyhow::{Context, Result};
 use serde::Deserialize;
@@ -11,7 +11,9 @@ use super::resource::HttpHeaders;
 /// Deserialized object of the file's `ws-resource.json` contents.
 #[derive(Deserialize, Debug)]
 pub struct WSResources {
-    pub headers: Option<HashMap<String, HttpHeaders>>,
+    /// The HTTP headers to be set for the resources.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub headers: Option<BTreeMap<String, HttpHeaders>>,
     // TODO: "routes"" for client-side routing.
 }
 

--- a/site-builder/src/site/config.rs
+++ b/site-builder/src/site/config.rs
@@ -6,10 +6,12 @@ use std::{collections::HashMap, path::Path};
 use anyhow::{Context, Result};
 use serde::Deserialize;
 
+use super::resource::HttpHeaders;
+
 /// Deserialized object of the file's `ws-resource.json` contents.
 #[derive(Deserialize, Debug)]
 pub struct WSResources {
-    pub headers: Option<HashMap<String, HashMap<String, String>>>,
+    pub headers: Option<HashMap<String, HttpHeaders>>,
     // TODO: "routes"" for client-side routing.
 }
 
@@ -28,9 +30,6 @@ impl WSResources {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Write;
-
-    use tempfile::NamedTempFile;
 
     use super::*;
 
@@ -47,13 +46,6 @@ mod tests {
             }
         }
         "#;
-
-        // Create a temporary file and write the test data to it.
-        let mut temp_file = NamedTempFile::new().unwrap();
-        write!(temp_file, "{}", data).unwrap();
-
-        // Read the configuration from the temporary file.
-        let result = WSResources::read(temp_file.path()).unwrap();
-        println!("{:#?}", result);
+        serde_json::from_str::<WSResources>(data).expect("parsing should succeed");
     }
 }

--- a/site-builder/src/site/content.rs
+++ b/site-builder/src/site/content.rs
@@ -43,9 +43,10 @@ impl TryFrom<String> for ContentEncoding {
     }
 }
 
-/// Content types for content of a page
+/// Content types for content of a page.
+///
 /// The list is generated starting from
-/// <https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types>
+/// <https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types>.
 #[derive(Debug, PartialEq, Eq, Clone, Ord, PartialOrd)]
 pub enum ContentType {
     AudioAac,

--- a/site-builder/src/site/manager.rs
+++ b/site-builder/src/site/manager.rs
@@ -193,7 +193,7 @@ impl SiteManager {
         Ok(ResourceSet::from_iter(resources))
     }
 
-    /// Get the resources already published to the site
+    /// Get the resources already published to the site.
     async fn get_existing_resource_ids(&self, site_id: ObjectID) -> Result<Vec<ObjectID>> {
         Ok(
             util::get_existing_resource_ids(&self.sui_client().await?, site_id)
@@ -203,7 +203,7 @@ impl SiteManager {
         )
     }
 
-    /// Get the resource that is hosted on chain at the given object ID
+    /// Get the resource that is hosted on chain at the given object ID.
     async fn get_remote_resource_info(&self, object_id: ObjectID) -> Result<ResourceInfo> {
         let object = get_struct_from_object_response(
             &self

--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -391,17 +391,14 @@ pub(crate) struct ResourceManager {
     pub resources: ResourceSet,
     /// The ws-resources.json contents.
     pub ws_resources: Option<WSResources>,
-    /// The location of the ws-resources.json.
-    pub ws_resources_path: PathBuf,
 }
 
 impl ResourceManager {
-    pub fn new(walrus: Walrus, ws_resources_path: PathBuf) -> Result<Self> {
+    pub fn new(walrus: Walrus, ws_resources: Option<WSResources>) -> Result<Self> {
         Ok(ResourceManager {
             walrus,
             resources: ResourceSet::default(),
-            ws_resources: None,
-            ws_resources_path,
+            ws_resources,
         })
     }
 
@@ -480,16 +477,6 @@ impl ResourceManager {
 
     /// Recursively iterate a directory and load all [`Resources`][Resource] within.
     pub fn read_dir(&mut self, root: &Path) -> Result<()> {
-        let cli_path = self.ws_resources_path.as_path();
-        if !cli_path.exists() {
-            eprintln!(
-                "Warning: The specified ws-resources.json path does not exist: {}.
-                Continuing without it...",
-                cli_path.display()
-            );
-            self.ws_resources = None;
-        }
-        self.ws_resources = WSResources::read(cli_path).ok();
         self.resources = ResourceSet::from_iter(self.iter_dir(root, root)?);
         Ok(())
     }

--- a/site-builder/src/util.rs
+++ b/site-builder/src/util.rs
@@ -67,7 +67,7 @@ where
     Ok(iterators.into_iter().flatten())
 }
 
-/// Convert the hex representation of an object id to base36
+/// Convert the hex representation of an object id to base36.
 pub fn id_to_base36(id: &ObjectID) -> Result<String> {
     const BASE36: &[u8] = "0123456789abcdefghijklmnopqrstuvwxyz".as_bytes();
     let source = id.into_bytes();
@@ -98,7 +98,7 @@ pub fn id_to_base36(id: &ObjectID) -> Result<String> {
     Ok(string)
 }
 
-/// Get the object id of the site that was published in the transaction
+/// Get the object id of the site that was published in the transaction.
 #[allow(dead_code)]
 pub fn get_site_id_from_response(
     address: SuiAddress,


### PR DESCRIPTION
A list of many small changes:

* Cleans up some unused structs, removes unused dependencies.
* Bumps the sui versions, prevents cargo deny from complaining.
* Uniforms comments.
* Fetches the correct configuration file from the root site directory, and does not upload it with the site.
* **Does not reupload unchanged resources** - there was a bug in the comparison of the headers.
