### PR TITLE
feat(site-builder): new unchanged resource operation

### DIFF
--- a/site-builder/src/site/builder.rs
+++ b/site-builder/src/site/builder.rs
@@ -104,6 +104,7 @@ impl SitePtb<Argument> {
             match call {
                 ResourceOp::Deleted(resource) => self.remove_resource_if_exists(resource)?,
                 ResourceOp::Created(resource) => self.add_resource(resource)?,
+                ResourceOp::Unchanged(_) => (),
             }
         }
         Ok(())

--- a/site-builder/src/site/manager.rs
+++ b/site-builder/src/site/manager.rs
@@ -105,7 +105,7 @@ impl SiteManager {
     async fn publish_to_walrus<'b>(&self, updates: &[ResourceOp<'b>]) -> Result<()> {
         let to_update = updates
             .iter()
-            .filter(|u| matches!(u, ResourceOp::Created(_)))
+            .filter(|u| matches!(u, ResourceOp::Created(_)) | matches!(u, ResourceOp::Unchanged(_)))
             .collect::<Vec<_>>();
         tracing::debug!(resources=?to_update, "publishing new or updated resources to Walrus");
 

--- a/site-builder/src/site/manager.rs
+++ b/site-builder/src/site/manager.rs
@@ -105,7 +105,9 @@ impl SiteManager {
     async fn publish_to_walrus<'b>(&self, updates: &[ResourceOp<'b>]) -> Result<()> {
         let to_update = updates
             .iter()
-            .filter(|u| matches!(u, ResourceOp::Created(_)) | matches!(u, ResourceOp::Unchanged(_)))
+            .filter(|u| {
+                matches!(u, ResourceOp::Created(_)) || matches!(u, ResourceOp::Unchanged(_))
+            })
             .collect::<Vec<_>>();
         tracing::debug!(resources=?to_update, "publishing new or updated resources to Walrus");
 

--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -294,14 +294,8 @@ impl ResourceSet {
     /// that if two resources have the same path but different
     /// contents they are first deleted and then created anew.
     pub fn diff<'a>(&'a self, start: &'a ResourceSet) -> Vec<ResourceOp<'a>> {
-        let create = self
-            .inner
-            .difference(&start.inner)
-            .map(ResourceOp::Created);
-        let delete = start
-            .inner
-            .difference(&self.inner)
-            .map(ResourceOp::Deleted);
+        let create = self.inner.difference(&start.inner).map(ResourceOp::Created);
+        let delete = start.inner.difference(&self.inner).map(ResourceOp::Deleted);
         let unchanged = self
             .inner
             .intersection(&start.inner)

--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -293,18 +293,18 @@ impl ResourceSet {
     /// The deletions are always before the creation operations, such
     /// that if two resources have the same path but different
     /// contents they are first deleted and then created anew.
-    pub fn diff<'a>(&'a self, target: &'a ResourceSet) -> Vec<ResourceOp<'a>> {
+    pub fn diff<'a>(&'a self, start: &'a ResourceSet) -> Vec<ResourceOp<'a>> {
         let create = self
             .inner
-            .difference(&target.inner)
+            .difference(&start.inner)
             .map(ResourceOp::Created);
-        let delete = target
+        let delete = start
             .inner
             .difference(&self.inner)
             .map(ResourceOp::Deleted);
         let unchanged = self
             .inner
-            .intersection(&target.inner)
+            .intersection(&start.inner)
             .map(ResourceOp::Unchanged);
         delete.chain(create).chain(unchanged).collect()
     }

--- a/site-builder/src/summary.rs
+++ b/site-builder/src/summary.rs
@@ -24,6 +24,7 @@ impl From<&ResourceOp<'_>> for ResourceOpSummary {
         let (operation, info) = match value {
             ResourceOp::Deleted(resource) => ("deleted".to_owned(), &resource.info),
             ResourceOp::Created(resource) => ("created".to_owned(), &resource.info),
+            ResourceOp::Unchanged(resource) => ("unchanged".to_owned(), &resource.info),
         };
         ResourceOpSummary {
             operation,


### PR DESCRIPTION
In this PR, we address the issue of potential missing blobs on Walrus due to devnet wipes. We ensure that resources in the Sui object that appear unchanged are re-uploaded to Walrus if necessary, preventing discrepancies between on-chain data and Walrus storage.

**Changes:**
Unchanged Resource Operation:

-  Added ResourceOp::Unchanged to handle resources that appear unchanged but may still need re-uploading.
-  Calculate unchanged resources inside diff function.
-  Modified publish_to_walrus to process both Created and Unchanged resources.