### PR TITLE
feat(site-builder): parallelize calls to the walrus cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6474,6 +6474,7 @@ dependencies = [
  "libc",
  "mio 1.0.2",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",

--- a/site-builder/Cargo.toml
+++ b/site-builder/Cargo.toml
@@ -27,7 +27,7 @@ sui-keys = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.34.2" 
 sui-sdk = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.34.2" }
 sui-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.34.2" }
 thiserror = "1.0.61"
-tokio = { version = "1.38.0", features = ["rt", "rt-multi-thread", "macros"] }
+tokio = { version = "1.38.0", features = ["rt", "rt-multi-thread", "macros", "process"] }
 toml = "0.8.14"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"

--- a/site-builder/assets/builder-example.yaml
+++ b/site-builder/assets/builder-example.yaml
@@ -1,6 +1,6 @@
 # module: site
 # portal: walrus.site
-package: 0xa9076d22049380d96607e3cc851ed591136c49aa0d9f3ddeac02d3841b3f27f7
+package: 0xee40a3dddc38e3c9f594f74f85ae3bda75b0ed05c6f2359554126409cf7e8e9d
 # general:
 #   rpc_url: https://fullnode.testnet.sui.io:443
 #   wallet: /path/to/.sui/sui_config/client.yaml

--- a/site-builder/src/publish.rs
+++ b/site-builder/src/publish.rs
@@ -173,16 +173,16 @@ impl SiteEditor {
         }
 
         let mut resource_manager =
-            ResourceManager::new(walrus.clone(), ws_resources, ws_resources_path)?;
+            ResourceManager::new(walrus.clone(), ws_resources, ws_resources_path).await?;
         display::action(format!(
             "Parsing the directory {} and locally computing blob IDs",
             self.directory().to_string_lossy()
         ));
-        let local_site_data = resource_manager.read_dir(self.directory())?;
+        let local_site_data = resource_manager.read_dir(self.directory()).await?;
         display::done();
         tracing::debug!(?local_site_data, "resources loaded from directory");
 
-        let site_manager = SiteManager::new(
+        let mut site_manager = SiteManager::new(
             self.config.clone(),
             walrus,
             wallet,

--- a/site-builder/src/site.rs
+++ b/site-builder/src/site.rs
@@ -14,7 +14,7 @@ use std::{
     str::FromStr,
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use resource::{MapWrapper, ResourceInfo, ResourceOp, ResourceSet};
 use serde::{Deserialize, Serialize};
 use sui_sdk::{
@@ -173,6 +173,7 @@ impl RemoteSiteFactory<'_> {
     }
 
     async fn get_routes(&self, site_id: ObjectID) -> Result<Option<Routes>> {
+        tracing::debug!(?site_id, "getting routes");
         let response = self
             .sui_client
             .read_api()
@@ -184,7 +185,13 @@ impl RemoteSiteFactory<'_> {
                 },
             )
             .await?;
-        let dynamic_field = get_struct_from_object_response(&response)?;
+
+        let Ok(dynamic_field) = get_struct_from_object_response(&response) else {
+            // TODO: improve error matching: check that it is dynamic field not found.
+            tracing::info!("no routes found for site {}", site_id);
+            return Ok(None);
+        };
+
         let routes =
             get_dynamic_field!(dynamic_field, "value", SuiMoveValue::Struct)?.try_into()?;
         Ok(Some(routes))
@@ -212,14 +219,17 @@ impl RemoteSiteFactory<'_> {
 
     /// Get the resource that is hosted on chain at the given object ID.
     async fn get_remote_resource_info(&self, object_id: ObjectID) -> Result<ResourceInfo> {
-        let object = get_struct_from_object_response(
-            &self
-                .sui_client
-                .read_api()
-                .get_object_with_options(object_id, SuiObjectDataOptions::new().with_content())
-                .await?,
-        )?;
-        get_dynamic_field!(object, "value", SuiMoveValue::Struct)?.try_into()
+        let object = &self
+            .sui_client
+            .read_api()
+            .get_object_with_options(object_id, SuiObjectDataOptions::new().with_content())
+            .await?;
+        let move_struct = get_struct_from_object_response(object).context(format!(
+            "error in getting the struct for object id: {}",
+            object_id
+        ))?;
+
+        get_dynamic_field!(move_struct, "value", SuiMoveValue::Struct)?.try_into()
     }
 
     /// Filters the dynamic fields to get the resource object IDs.

--- a/site-builder/src/site/manager.rs
+++ b/site-builder/src/site/manager.rs
@@ -92,27 +92,22 @@ impl SiteManager {
         };
         tracing::debug!(operations=?site_updates, "list of operations computed");
 
-        if site_updates.has_updates() {
-            self.publish_to_walrus(&site_updates.resource_ops).await?;
+        let walrus_updates = site_updates.get_walrus_updates(&self.when_upload);
+        let result = if !walrus_updates.is_empty() {
+            self.publish_to_walrus(&walrus_updates).await?;
             display::action("Updating the Walrus Site object on Sui");
             let result = self.execute_sui_updates(&site_updates).await?;
             display::done();
-            return Ok((result, site_updates.into()));
-        }
-        Ok((SuiTransactionBlockResponse::default(), site_updates.into()))
+            result
+        } else {
+            SuiTransactionBlockResponse::default()
+        };
+        Ok((result, site_updates.summary(&self.when_upload)))
     }
 
     /// Publishes the resources to Walrus.
-    async fn publish_to_walrus<'b>(&mut self, updates: &[ResourceOp<'b>]) -> Result<()> {
-        let to_update = updates
-            .iter()
-            .filter(|u| {
-                matches!(u, ResourceOp::Created(_)) || matches!(u, ResourceOp::Unchanged(_))
-            })
-            .collect::<Vec<_>>();
-        tracing::debug!(resources=?to_update, "publishing new or updated resources to Walrus");
-
-        for update in to_update.iter() {
+    async fn publish_to_walrus<'b>(&mut self, updates: &[&ResourceOp<'b>]) -> Result<()> {
+        for update in updates.iter() {
             let resource = update.inner();
             tracing::debug!(
                 resource=?resource.full_path,

--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -8,12 +8,14 @@ use std::{
     fmt::{self, Display},
     fs,
     io::Write,
+    num::NonZeroU16,
     path::{Path, PathBuf},
 };
 
 use anyhow::{anyhow, Context, Result};
 use fastcrypto::hash::{HashFunction, Sha256};
 use flate2::{write::GzEncoder, Compression};
+use futures::future::try_join_all;
 use move_core_types::u256::U256;
 use serde::{Deserialize, Serialize};
 use sui_sdk::rpc_types::{SuiMoveStruct, SuiMoveValue};
@@ -361,25 +363,29 @@ pub(crate) struct ResourceManager {
     pub ws_resources: Option<WSResources>,
     /// The ws-resource file path.
     pub ws_resources_path: Option<PathBuf>,
+    /// The number of shards of the Walrus system.
+    pub n_shards: NonZeroU16,
 }
 
 impl ResourceManager {
-    pub fn new(
+    pub async fn new(
         walrus: Walrus,
         ws_resources: Option<WSResources>,
         ws_resources_path: Option<PathBuf>,
     ) -> Result<Self> {
+        let n_shards = walrus.info(false).await?.n_shards;
         Ok(ResourceManager {
             walrus,
             ws_resources,
             ws_resources_path,
+            n_shards,
         })
     }
 
     /// Read a resource at a path.
     ///
     /// Ignores empty files.
-    pub fn read_resource(&self, full_path: &Path, root: &Path) -> Result<Option<Resource>> {
+    pub async fn read_resource(&self, full_path: &Path, root: &Path) -> Result<Option<Resource>> {
         if let Some(ws_path) = &self.ws_resources_path {
             if full_path == ws_path {
                 tracing::debug!(?full_path, "ignoring the ws-resources config file");
@@ -436,9 +442,14 @@ impl ResourceManager {
             .or_insert(content_type.to_string());
 
         let plain_content: Vec<u8> = std::fs::read(full_path)?;
-        // TODO(giac): this could be (i) async; (ii) pre configured with the number of shards to
-        //     avoid chain interaction (maybe after adding `info` to the JSON commands).
-        let output = self.walrus.blob_id(full_path.to_owned(), None)?;
+        let output = self
+            .walrus
+            .blob_id(full_path.to_owned(), Some(self.n_shards))
+            .await
+            .context(format!(
+                "error while computing the blob id for path: {}",
+                full_path.to_string_lossy()
+            ))?;
 
         // Hash the contents of the file - this will be contained in the site::Resource
         // to verify the integrity of the blob when fetched from an aggregator.
@@ -452,41 +463,48 @@ impl ResourceManager {
             HttpHeaders(http_headers),
             output.blob_id,
             U256::from_le_bytes(&blob_hash),
-            // TODO(giac): Change to `content.len()` when the problem with content encoding is
-            // fixed.
             plain_content.len(),
         )))
     }
 
     /// Recursively iterate a directory and load all [`Resources`][Resource] within.
-    pub fn read_dir(&mut self, root: &Path) -> Result<SiteData> {
+    pub async fn read_dir(&mut self, root: &Path) -> Result<SiteData> {
+        let resource_paths = Self::iter_dir(root, root)?;
+        let resources = ResourceSet::from_iter(
+            try_join_all(
+                resource_paths
+                    .iter()
+                    .map(|(full_path, root)| self.read_resource(full_path, root)),
+            )
+            .await
+            .context("error in loading one of the resources")?
+            .into_iter()
+            .flatten(),
+        );
+
         Ok(SiteData::new(
-            ResourceSet::from_iter(self.iter_dir(root, root)?),
+            resources,
             self.ws_resources
                 .as_ref()
                 .and_then(|config| config.routes.clone()),
         ))
     }
 
-    fn iter_dir(&self, start: &Path, root: &Path) -> Result<Vec<Resource>> {
-        let mut resources: Vec<Resource> = vec![];
+    fn iter_dir(start: &Path, root: &Path) -> Result<Vec<(PathBuf, PathBuf)>> {
+        let mut resources = vec![];
         let entries = fs::read_dir(start)?;
         for entry in entries.flatten() {
             let path = entry.path();
             if path.is_dir() {
-                resources.extend(self.iter_dir(&path, root)?);
-            } else if let Some(res) = self.read_resource(&path, root).context(format!(
-                "error while reading resource `{}`",
-                path.to_string_lossy()
-            ))? {
-                resources.push(res);
+                resources.extend(Self::iter_dir(&path, root)?);
+            } else {
+                resources.push((path.to_owned(), root.to_owned()));
             }
         }
         Ok(resources)
     }
 }
 
-// TODO(giac): remove allow after getting compression back.
 #[allow(dead_code)]
 fn compress(content: &[u8]) -> Result<Vec<u8>> {
     if content.is_empty() {

--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -22,6 +22,7 @@ use sui_sdk::rpc_types::{SuiMoveStruct, SuiMoveValue};
 
 use super::SiteData;
 use crate::{
+    publish::WhenWalrusUpload,
     site::{config::WSResources, content::ContentType},
     walrus::{types::BlobId, Walrus},
 };
@@ -210,6 +211,17 @@ impl<'a> ResourceOp<'a> {
             ResourceOp::Created(resource) => resource,
             ResourceOp::Unchanged(resource) => resource,
         }
+    }
+
+    /// Returns if the operation needs to be uploaded to Walrus.
+    pub fn is_walrus_update(&self, when_upload: &WhenWalrusUpload) -> bool {
+        matches!(self, ResourceOp::Created(_))
+            || (when_upload.is_always() && !matches!(self, ResourceOp::Unchanged(_)))
+    }
+
+    /// Returns true if the operation modifies a resource.
+    pub fn is_change(&self) -> bool {
+        matches!(self, ResourceOp::Created(_) | ResourceOp::Deleted(_))
     }
 }
 

--- a/site-builder/src/summary.rs
+++ b/site-builder/src/summary.rs
@@ -63,8 +63,8 @@ impl Summarizable for Vec<ResourceOpSummary> {
 }
 
 pub struct SiteDataDiffSummary {
-    resource_ops: Vec<ResourceOpSummary>,
-    route_ops: RouteOps,
+    pub resource_ops: Vec<ResourceOpSummary>,
+    pub route_ops: RouteOps,
 }
 
 impl From<&SiteDataDiff<'_>> for SiteDataDiffSummary {

--- a/site-builder/src/walrus.rs
+++ b/site-builder/src/walrus.rs
@@ -48,6 +48,7 @@ macro_rules! create_command {
                 )
             )?;
         try_from_output(output)
+            .inspect(|output| tracing::debug!(?output, "Walrus CLI parsed output"))
     }};
 }
 

--- a/site-builder/src/walrus/command.rs
+++ b/site-builder/src/walrus/command.rs
@@ -82,6 +82,14 @@ pub enum Command {
         #[serde(skip_serializing_if = "RpcArg::is_none")]
         rpc_arg: RpcArg,
     },
+    Info {
+        /// The URL of the Sui RPC node to use.
+        #[serde(default)]
+        rpc_arg: RpcArg,
+        /// Print extended information for developers.
+        #[serde(default)]
+        dev: bool,
+    },
 }
 
 /// Represents the Sui RPC endpoint argument.
@@ -184,6 +192,12 @@ impl WalrusCmdBuilder {
             n_shards,
             rpc_arg,
         };
+        self.with_command(command)
+    }
+
+    /// Adds a [`Command::Info`] command to the builder.
+    pub fn info(self, rpc_arg: RpcArg, dev: bool) -> WalrusCmdBuilder<Command> {
+        let command = Command::Info { rpc_arg, dev };
         self.with_command(command)
     }
 }

--- a/site-builder/src/walrus/output.rs
+++ b/site-builder/src/walrus/output.rs
@@ -3,7 +3,7 @@
 
 //! The output of running commands on the Walrus CLI.
 
-use std::{path::PathBuf, process::Output};
+use std::{num::NonZeroU16, path::PathBuf, process::Output};
 
 use anyhow::{anyhow, Context, Result};
 use serde::{de::DeserializeOwned, Deserialize};
@@ -138,6 +138,26 @@ pub struct BlobIdOutput {
     pub blob_id: BlobId,
     pub file: PathBuf,
     pub unencoded_length: u64,
+}
+
+/// The output of the `info` command.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+pub(crate) struct InfoOutput {
+    pub(crate) current_epoch: Epoch,
+    pub(crate) n_shards: NonZeroU16,
+    pub(crate) n_nodes: usize,
+    pub(crate) storage_unit_size: u64,
+    pub(crate) price_per_unit_size: u64,
+    pub(crate) max_blob_size: u64,
+    pub(crate) marginal_size: u64,
+    pub(crate) metadata_price: u64,
+    pub(crate) marginal_price: u64,
+    #[serde(skip_deserializing)]
+    pub(crate) example_blobs: String,
+    #[serde(skip_deserializing)]
+    pub(crate) dev_info: String,
 }
 
 pub fn try_from_output<T: DeserializeOwned>(output: Output) -> Result<T> {


### PR DESCRIPTION
Makes calling the site builder on large sites (tens/hundreds of files) much faster, especially in the case of small site updates. 

* parallelizes calls to the walrus CLI that can be made safely without locking objects.
* reduces the number of calls to the fullnodes by keeping the number of shards.
* only performs update checks when the command is a `--force`.

Example of improvement: a site with 50 files of 1KB each (`before -> after`):
- publish operation: `157s -> 102s`
- update with no changes: `67s -> 5s`
- update with 1-file change `70s -> 15s`
