### PR TITLE
feat(portal): propagate requests to a fallback devnet portal

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   benchmarks:
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-22.04"
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   editorconfig:
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-22.04"
     name: Check editorconfig
     steps:
       - uses: actions/checkout@v4

--- a/portal/common/lib/constants.ts
+++ b/portal/common/lib/constants.ts
@@ -11,6 +11,6 @@ export const SITE_NAMES: { [key: string]: string } = {
     // landing: "0x1234..."
 };
 // The default portal to redirect to if the browser does not support service workers.
-export const FALLBACK_DEVNET_PORTAL = "blocksite.net";
+export const FALLBACK_PORTAL = "blob.store";
 // The string representing the ResourcePath struct in the walrus_site package.
 export const RESOURCE_PATH_MOVE_TYPE = SITE_PACKAGE + "::site::ResourcePath";

--- a/portal/common/lib/constants.ts
+++ b/portal/common/lib/constants.ts
@@ -11,6 +11,6 @@ export const SITE_NAMES: { [key: string]: string } = {
     // landing: "0x1234..."
 };
 // The default portal to redirect to if the browser does not support service workers.
-export const FALLBACK_PORTAL = "blob.store";
+export const FALLBACK_DEVNET_PORTAL = "blocksite.net";
 // The string representing the ResourcePath struct in the walrus_site package.
 export const RESOURCE_PATH_MOVE_TYPE = SITE_PACKAGE + "::site::ResourcePath";

--- a/portal/server/app/route.ts
+++ b/portal/server/app/route.ts
@@ -5,6 +5,7 @@ import { getDomain, getSubdomainAndPath } from '@lib/domain_parsing'
 import { redirectToAggregatorUrlResponse, redirectToPortalURLResponse } from '@lib/redirects'
 import { getBlobIdLink, getObjectIdLink } from '@lib/links'
 import { resolveAndFetchPage } from '@lib/page_fetching'
+import { HttpStatusCodes } from '@lib/http/http_status_codes'
 
 export async function GET(req: Request) {
     const originalUrl = req.headers.get('x-original-url')
@@ -30,8 +31,18 @@ export async function GET(req: Request) {
     const requestDomain = getDomain(url)
 
     if (requestDomain == portalDomain && parsedUrl && parsedUrl.subdomain) {
-        console.log('fetching from the service worker')
-        return resolveAndFetchPage(parsedUrl)
+        const forwardToFallback = async () => {
+            return fetch(`${parsedUrl.subdomain}.${process.env.FALLBACK_DEVNET_PORTAL}`)
+        };
+        try {
+            const fetchPageResponse = await resolveAndFetchPage(parsedUrl)
+            if (fetchPageResponse.status==HttpStatusCodes.NOT_FOUND) {
+                return forwardToFallback()
+            }
+            return fetchPageResponse
+        } catch (error) {
+            return forwardToFallback()
+        }
     }
 
     const atBaseUrl = portalDomain == url.host.split(':')[0]

--- a/portal/server/app/route.ts
+++ b/portal/server/app/route.ts
@@ -32,7 +32,7 @@ export async function GET(req: Request) {
 
     if (requestDomain == portalDomain && parsedUrl && parsedUrl.subdomain) {
         const forwardToFallback = async () => {
-            return fetch(`${parsedUrl.subdomain}.${process.env.FALLBACK_DEVNET_PORTAL}`)
+            return fetch(`https://${parsedUrl.subdomain}.${process.env.FALLBACK_DEVNET_PORTAL}`)
         };
         try {
             const fetchPageResponse = await resolveAndFetchPage(parsedUrl)

--- a/portal/server/app/route.ts
+++ b/portal/server/app/route.ts
@@ -32,7 +32,9 @@ export async function GET(req: Request) {
 
     if (requestDomain == portalDomain && parsedUrl && parsedUrl.subdomain) {
         const forwardToFallback = async () => {
-            return fetch(`https://${parsedUrl.subdomain}.${process.env.FALLBACK_DEVNET_PORTAL}`)
+            const subdomain = parsedUrl.subdomain;
+            const fallbackDomain = process.env.FALLBACK_DEVNET_PORTAL;
+            return fetch(`https://${subdomain}.${fallbackDomain}${parsedUrl.path}`)
         };
         try {
             const fetchPageResponse = await resolveAndFetchPage(parsedUrl)

--- a/portal/server/next-env.d.ts
+++ b/portal/server/next-env.d.ts
@@ -5,5 +5,3 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript
-// for more information.

--- a/portal/worker/src/walrus-sites-sw.ts
+++ b/portal/worker/src/walrus-sites-sw.ts
@@ -6,6 +6,7 @@ import { redirectToAggregatorUrlResponse, redirectToPortalURLResponse } from "@l
 import { getBlobIdLink, getObjectIdLink } from "@lib/links";
 import resolveWithCache from "./caching";
 import { resolveAndFetchPage } from "@lib/page_fetching";
+import { HttpStatusCodes } from "@lib/http/http_status_codes";
 
 // This is to get TypeScript to recognize `clients` and `self` Default type of `self` is
 // `WorkerGlobalScope & typeof globalThis` https://github.com/microsoft/TypeScript/issues/14877
@@ -69,7 +70,7 @@ self.addEventListener("fetch", async (event) => {
         event.respondWith(
             handleFetchRequest()
                 .then(response =>
-                    response.status === 400 ? forwardToFallback() : response
+                    response.status === HttpStatusCodes.NOT_FOUND ? forwardToFallback() : response
                 )
         );
         return;

--- a/portal/worker/src/walrus-sites-sw.ts
+++ b/portal/worker/src/walrus-sites-sw.ts
@@ -6,7 +6,6 @@ import { redirectToAggregatorUrlResponse, redirectToPortalURLResponse } from "@l
 import { getBlobIdLink, getObjectIdLink } from "@lib/links";
 import resolveWithCache from "./caching";
 import { resolveAndFetchPage } from "@lib/page_fetching";
-import { FALLBACK_DEVNET_PORTAL } from "@lib/constants";
 
 // This is to get TypeScript to recognize `clients` and `self` Default type of `self` is
 // `WorkerGlobalScope & typeof globalThis` https://github.com/microsoft/TypeScript/issues/14877
@@ -65,7 +64,7 @@ self.addEventListener("fetch", async (event) => {
         };
         // If the original request fails, forward to the fallback portal.
         const forwardToFallback = async () => {
-            return fetch(`${parsedUrl.subdomain}.${FALLBACK_DEVNET_PORTAL}`)
+            return fetch(`${parsedUrl.subdomain}.${process.env.FALLBACK_DEVNET_PORTAL}`)
         };
         event.respondWith(
             handleFetchRequest()

--- a/portal/worker/src/walrus-sites-sw.ts
+++ b/portal/worker/src/walrus-sites-sw.ts
@@ -6,6 +6,7 @@ import { redirectToAggregatorUrlResponse, redirectToPortalURLResponse } from "@l
 import { getBlobIdLink, getObjectIdLink } from "@lib/links";
 import resolveWithCache from "./caching";
 import { resolveAndFetchPage } from "@lib/page_fetching";
+import { FALLBACK_DEVNET_PORTAL } from "@lib/constants";
 
 // This is to get TypeScript to recognize `clients` and `self` Default type of `self` is
 // `WorkerGlobalScope & typeof globalThis` https://github.com/microsoft/TypeScript/issues/14877
@@ -64,9 +65,7 @@ self.addEventListener("fetch", async (event) => {
         };
         // If the original request fails, forward to the fallback portal.
         const forwardToFallback = async () => {
-            // Fallback portal that supports walrus devnet deployments.
-            const fallbackDevnetPortal = "blocksite.net"
-            return fetch(`${parsedUrl.subdomain}.${fallbackDevnetPortal}`)
+            return fetch(`${parsedUrl.subdomain}.${FALLBACK_DEVNET_PORTAL}`)
         };
         event.respondWith(
             handleFetchRequest()

--- a/portal/worker/src/walrus-sites-sw.ts
+++ b/portal/worker/src/walrus-sites-sw.ts
@@ -65,7 +65,9 @@ self.addEventListener("fetch", async (event) => {
         };
         // If the original request fails, forward to the fallback portal.
         const forwardToFallback = async () => {
-            return fetch(`${parsedUrl.subdomain}.${process.env.FALLBACK_DEVNET_PORTAL}`)
+            const fallbackportaldomain = "blocksite.net"
+            const forwarded = await fetch(`https://${parsedUrl.subdomain}.${fallbackportaldomain}`)
+            return forwarded;
         };
         event.respondWith(
             handleFetchRequest()


### PR DESCRIPTION
Makes possible requests that are made on testnet, to be forwarded and retried on a portal that supports devnet. 
This way we can support old deployments that still have not migrated to testnet.

The [fallback devnet portal](https://vercel.com/mysten-labs/walrus-sites-sp-devnet-fallback) is a server side portal running the code of commit 3e693ad09d2670472e9d921b1dfab17166b6a9f6 (deployed using the branch [temp/devnet](https://github.com/MystenLabs/walrus-sites/tree/temp/devnet)). 

This is the state of our old walrus sites version (before reaching v.1.0.0), i.e. supporting only the devnet deployments, anything prior to the current date (2024/10/11). 