### PR TITLE
fix: ensure the fallback returns uncompressed responses 

### DIFF
--- a/portal/server/app/route.ts
+++ b/portal/server/app/route.ts
@@ -37,6 +37,7 @@ export async function GET(req: Request) {
             const fallbackUrl = `https://${subdomain}.${fallbackDomain}${parsedUrl.path}`;
             // We need to add the Accept-Encoding header to ensure that the fall back domain does
             // not reply with a compressed response.
+            console.info(`Falling back to the devnet portal! ${fallbackUrl}`);
             return fetch(fallbackUrl, {
                 headers: {
                     "Accept-Encoding": "identity",

--- a/portal/server/app/route.ts
+++ b/portal/server/app/route.ts
@@ -34,8 +34,16 @@ export async function GET(req: Request) {
         const forwardToFallback = async () => {
             const subdomain = parsedUrl.subdomain;
             const fallbackDomain = process.env.FALLBACK_DEVNET_PORTAL;
-            return fetch(`https://${subdomain}.${fallbackDomain}${parsedUrl.path}`);
+            const fallbackUrl = `https://${subdomain}.${fallbackDomain}${parsedUrl.path}`;
+            // We need to add the Accept-Encoding header to ensure that the fall back domain does
+            // not reply with a compressed response.
+            return fetch(fallbackUrl, {
+                headers: {
+                    "Accept-Encoding": "identity",
+                },
+            });
         };
+
         try {
             const fetchPageResponse = await resolveAndFetchPage(parsedUrl, null);
             if (fetchPageResponse.status == HttpStatusCodes.NOT_FOUND) {

--- a/portal/worker/src/walrus-sites-sw.ts
+++ b/portal/worker/src/walrus-sites-sw.ts
@@ -103,7 +103,7 @@ self.addEventListener("fetch", async (event) => {
         const proxyFetch = async (): Promise<Response> => {
             const fallbackDomain = "blocksite.net";
             const fallbackUrl = `https://${parsedUrl.subdomain}.${fallbackDomain}${parsedUrl.path}`;
-            console.log("Proxy fetching from fallback URL:", fallbackUrl);
+            console.info(`Falling back to the devnet portal! ${fallbackUrl}`);
             return fetch(fallbackUrl);
         };
         event.respondWith(handleFetchRequest());

--- a/portal/worker/webpack.config.prod.js
+++ b/portal/worker/webpack.config.prod.js
@@ -17,7 +17,7 @@ module.exports = merge(common, {
             terserOptions: {
                 compress: {
                     // Remove console logs
-                    drop_console: true,
+                    drop_console: ["log"],
                 },
             },
         }),


### PR DESCRIPTION
Additionally, show when the fallback is used also in prod.
Useful for checking if a site has been updated or not.