### PR TITLE
feat: support wildcards in http headers

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -122,7 +122,7 @@ jobs:
         with:
           save-if: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
       - name: Run tests
-        run: cargo test
+        run: cargo test -- --include-ignored
   check-all:
     name: Check if all code checks succeeded
     if: always()

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -122,7 +122,7 @@ jobs:
         with:
           save-if: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
       - name: Run tests
-        run: cargo test -- --include-ignored
+        run: cargo test
   check-all:
     name: Check if all code checks succeeded
     if: always()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5619,6 +5619,7 @@ dependencies = [
  "home",
  "move-core-types",
  "notify",
+ "regex",
  "serde",
  "serde_json",
  "serde_with",

--- a/examples/snake/ws-resources.json
+++ b/examples/snake/ws-resources.json
@@ -3,6 +3,10 @@
     "/index.html": {
       "Content-Type": "text/html; charset=utf-8",
       "Cache-Control": "max-age=3500"
+    },
+    "/*.svg": {
+        "Cache-Control": "public, max-age=86400",
+        "ETag": "\"abc123\""
     }
   },
   "routes": {

--- a/site-builder/Cargo.toml
+++ b/site-builder/Cargo.toml
@@ -18,6 +18,7 @@ futures = "0.3.30"
 home = "0.5.9"
 move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.34.2" }
 notify = "6.1.1"
+regex = "1.11.0"
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"
 serde_with = { version = "3.8.1", features = ["base64"] }

--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -548,9 +548,24 @@ mod tests {
     }
 
     #[ignore = "The test depends on the file system containing a walrus binary.
-        Until we find a way to mock the walrus binary, this test will be ignored."]
+        // Until we find a way to mock the walrus binary, this test will be ignored."]
     #[tokio::test]
     async fn test_derive_http_headers() {
+        let resource_manager = setup_resource_manager_mock().await;
+
+        let resource_path = "/foo/bar/baz/image.svg";
+        let result = resource_manager.derive_http_headers(resource_path);
+
+        println!("Result: {:?}", result.keys());
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.get("etag"), Some(&"\"abc123\"".to_string()));
+    }
+
+    /// Sets up a mock resource manager with the given headers configuration and resource path.
+    ///
+    /// Helper function for testing the `derive_http_headers` method.
+    async fn setup_resource_manager_mock() -> ResourceManager {
+        let walrus_mock = Walrus::new("walrus".to_string(), 1234, None, None, None);
         // Define the headers configuration for mocking the resource manager.
         let mut headers: BTreeMap<String, HttpHeaders> = BTreeMap::new();
         headers.insert(
@@ -567,23 +582,6 @@ mod tests {
                 "\"abc123\"".to_string(),
             )])),
         );
-        let resource_manager = setup_resource_manager_mock(headers).await;
-
-        let resource_path = "/foo/bar/baz/image.svg";
-        let result = resource_manager.derive_http_headers(resource_path);
-
-        println!("Result: {:?}", result.keys());
-        assert_eq!(result.len(), 1);
-        assert_eq!(result.get("etag"), Some(&"\"abc123\"".to_string()));
-    }
-
-    /// Sets up a mock resource manager with the given headers configuration and resource path.
-    ///
-    /// Helper function for testing the `derive_http_headers` method.
-    async fn setup_resource_manager_mock(
-        headers: BTreeMap<String, HttpHeaders>,
-    ) -> ResourceManager {
-        let walrus_mock = Walrus::new("walrus".to_string(), 1234, None, None, None);
         let ws_resources = Some(WSResources {
             headers: Some(headers),
             routes: None,

--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -567,10 +567,9 @@ mod tests {
                 "\"abc123\"".to_string(),
             )])),
         );
+        let resource_manager = setup_resource_manager_mock(headers).await;
 
         let resource_path = "/foo/bar/baz/image.svg";
-        let resource_manager = setup_resource_manager_mock(headers, resource_path).await;
-
         let result = resource_manager.derive_http_headers(resource_path);
 
         println!("Result: {:?}", result.keys());
@@ -583,7 +582,6 @@ mod tests {
     /// Helper function for testing the `derive_http_headers` method.
     async fn setup_resource_manager_mock(
         headers: BTreeMap<String, HttpHeaders>,
-        ws_resources_path: &str,
     ) -> ResourceManager {
         let walrus_mock = Walrus::new("walrus".to_string(), 1234, None, None, None);
         let ws_resources = Some(WSResources {
@@ -593,7 +591,7 @@ mod tests {
         ResourceManager::new(
             walrus_mock.clone(),
             ws_resources,
-            Some(PathBuf::from(ws_resources_path)),
+            Some(PathBuf::from(&"mock/path/to/ws-resources")),
         )
         .await
         .unwrap()

--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -397,11 +397,9 @@ impl ResourceManager {
                     .filter(|(path, _)| {
                         // Replace the wildcard with a regex wildcard.
                         let path_regex = path.replace('*', ".*");
-                        // Check if the resource_path matches the path_regex.
-                        match Regex::new(&path_regex) {
-                            Ok(re) => re.is_match(resource_path),
-                            Err(_) => false,
-                        }
+                        Regex::new(&path_regex)
+                            .map(|re| re.is_match(resource_path))
+                            .unwrap_or(false)
                     })
                     .max_by_key(|(path, _)| path.len())
                     .map(|(_, header_map)| header_map)

--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -552,13 +552,17 @@ mod tests {
 Until we find a way to mock the walrus binary, this test will be ignored."]
     async fn test_derive_http_headers() {
         let resource_manager = setup_resource_manager_mock().await;
+        let test_paths = vec![
+            ("/foo/bar/baz/image.svg", 1),
+            ("/very_long_name_that_should_not_be_matched.svg", 1),
+        ];
 
-        let resource_path = "/foo/bar/baz/image.svg";
-        let result = resource_manager.derive_http_headers(resource_path);
-
-        println!("Result: {:?}", result.keys());
-        assert_eq!(result.len(), 1);
-        assert_eq!(result.get("etag"), Some(&"\"abc123\"".to_string()));
+        for (path, expected_len) in test_paths {
+            let result = resource_manager.derive_http_headers(path);
+            println!("Result for {}: {:?}", path, result.keys());
+            assert_eq!(result.len(), expected_len);
+            assert!(result.contains_key("etag"));
+        }
     }
 
     /// Sets up a mock resource manager with the given headers configuration and resource path.

--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -330,7 +330,16 @@ impl ResourceManager {
             .ws_resources
             .as_ref()
             .and_then(|config| config.headers.as_ref())
-            .and_then(|headers| headers.get(&resource_path))
+            .and_then(|headers| {
+                headers
+                    .iter()
+                    .filter(|(path, _)| {
+                        // TODO: replace with Regex
+                        *path == &resource_path
+                    })
+                    .map(|(_, header_map)| header_map)
+                    .next() // Why are we using next here? Reduce instead based on the length.
+            })
             .cloned()
             // Cast the keys to lowercase because http headers
             //  are case-insensitive: RFC7230 sec. 2.7.3

--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -402,16 +402,12 @@ impl ResourceManager {
                             .unwrap_or(false)
                     })
                     .max_by_key(|(path, _)| path.len())
-                    .map(|(_, header_map)| header_map)
-                    .into_iter()
-                    .reduce(|_, header_map| header_map)
+                    .map(|(_, header_map)| header_map.0.clone())
             })
-            .cloned()
             // Cast the keys to lowercase because http headers
             //  are case-insensitive: RFC7230 sec. 2.7.3
             .map(|headers| {
                 headers
-                    .0
                     .into_iter()
                     .map(|(k, v)| (k.to_lowercase(), v))
                     .collect()

--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -547,9 +547,9 @@ mod tests {
         }
     }
 
-    #[ignore = "The test depends on the file system containing a walrus binary.
-        // Until we find a way to mock the walrus binary, this test will be ignored."]
     #[tokio::test]
+    #[ignore = "The test depends on the file system containing a walrus binary.
+Until we find a way to mock the walrus binary, this test will be ignored."]
     async fn test_derive_http_headers() {
         let resource_manager = setup_resource_manager_mock().await;
 

--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -504,38 +504,38 @@ mod tests {
     fn test_is_pattern_match() {
         let tests = vec![
             PatternMatchTestCase {
-                pattern: "*.txt",
-                path: "file.txt",
+                pattern: "/*.txt",
+                path: "/file.txt",
                 expected: true,
             },
             PatternMatchTestCase {
                 pattern: "*.txt",
-                path: "file.doc",
+                path: "/file.doc",
                 expected: false,
             },
             PatternMatchTestCase {
-                pattern: "test/*",
-                path: "test/file",
+                pattern: "/test/*",
+                path: "/test/file",
                 expected: true,
             },
             PatternMatchTestCase {
-                pattern: "test/*",
-                path: "test/file.extension",
+                pattern: "/test/*",
+                path: "/test/file.extension",
                 expected: true,
             },
             PatternMatchTestCase {
-                pattern: "test/*",
-                path: "test/foo.bar.extension",
+                pattern: "/test/*",
+                path: "/test/foo.bar.extension",
                 expected: true,
             },
             PatternMatchTestCase {
-                pattern: "test/*",
-                path: "test/foo-bar_baz.extension",
+                pattern: "/test/*",
+                path: "/test/foo-bar_baz.extension",
                 expected: true,
             },
             PatternMatchTestCase {
                 pattern: "[invalid",
-                path: "file",
+                path: "/file",
                 expected: false,
             },
         ];

--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -399,9 +399,10 @@ impl ResourceManager {
         )))
     }
 
-    /// Based on the ws-resources.yaml definition, this function derives the HTTP headers
-    /// based on wildcard matching, the headers that should be added to the HTTP response
-    /// of the resource defined by the resource_path.
+    ///  Derives the HTTP headers for a resource based on the ws-resources.yaml.
+    ///
+    ///  Matches the path of the resource to the wildcard paths in the configuration to
+    ///  determine the headers to be added to the HTTP response.
     fn derive_http_headers(&self, resource_path: &str) -> BTreeMap<String, String> {
         self.ws_resources
             .as_ref()

--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -547,6 +547,8 @@ mod tests {
         }
     }
 
+    #[ignore = "The test depends on the file system containing a walrus binary.
+        Until we find a way to mock the walrus binary, this test will be ignored."]
     #[tokio::test]
     async fn test_derive_http_headers() {
         // Define the headers configuration for mocking the resource manager.
@@ -566,9 +568,10 @@ mod tests {
             )])),
         );
 
-        let resource_manager = setup_resource_manager_mock(headers, "/foo/bar/baz/image.svg").await;
+        let resource_path = "/foo/bar/baz/image.svg";
+        let resource_manager = setup_resource_manager_mock(headers, resource_path).await;
 
-        let result = resource_manager.derive_http_headers("/foo/bar/baz/image.svg");
+        let result = resource_manager.derive_http_headers(resource_path);
 
         println!("Result: {:?}", result.keys());
         assert_eq!(result.len(), 1);

--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -573,22 +573,15 @@ mod tests {
 
     /// Helper function for testing the `derive_http_headers` method.
     fn mock_ws_resources() -> Option<WSResources> {
-        // Define the headers configuration for mocking the resource manager.
-        let mut headers: BTreeMap<String, HttpHeaders> = BTreeMap::new();
-        headers.insert(
-            "/*.svg".to_string(),
-            HttpHeaders(BTreeMap::from([(
-                "cache-control".to_string(),
-                "public, max-age=86400".to_string(),
-            )])),
-        );
-        headers.insert(
-            "/foo/bar/baz/*.svg".to_string(),
-            HttpHeaders(BTreeMap::from([(
-                "etag".to_string(),
-                "\"abc123\"".to_string(),
-            )])),
-        );
+        let headers_json = r#"{
+                    "/*.svg": {
+                        "cache-control": "public, max-age=86400"
+                    },
+                    "/foo/bar/baz/*.svg": {
+                        "etag": "\"abc123\""
+                    }
+                }"#;
+        let headers: BTreeMap<String, HttpHeaders> = serde_json::from_str(headers_json).unwrap();
 
         Some(WSResources {
             headers: Some(headers),

--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -420,7 +420,7 @@ impl ResourceManager {
     /// Matches a pattern to a resource path.
     ///
     /// The pattern can contain a wildcard `*` which matches any sequence of characters.
-    /// e.g. `foo/*` will match `foo/bar` and `foo/bar/baz`.
+    /// e.g. `/foo/*` will match `/foo/bar` and `/foo/bar/baz`.
     fn is_pattern_match(pattern: &str, resource_path: &str) -> bool {
         let path_regex = pattern.replace('*', ".*");
         Regex::new(&path_regex)

--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -395,7 +395,9 @@ impl ResourceManager {
                 headers
                     .iter()
                     .filter(|(path, _)| {
+                        // Replace the wildcard with a regex wildcard.
                         let path_regex = path.replace('*', ".*");
+                        // Check if the resource_path matches the path_regex.
                         match Regex::new(&path_regex) {
                             Ok(re) => re.is_match(resource_path),
                             Err(_) => false,

--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -553,14 +553,14 @@ Until we find a way to mock the walrus binary, this test will be ignored."]
     async fn test_derive_http_headers() {
         let resource_manager = setup_resource_manager_mock().await;
         let test_paths = vec![
-            ("/foo/bar/baz/image.svg", 1),
-            ("/very_long_name_that_should_not_be_matched.svg", 1),
+            ("/foo/bar/baz/image.svg"), // Only this should be matched, as it is the longest path.
+            ("/very_long_name_that_should_not_be_matched.svg"),
         ];
 
-        for (path, expected_len) in test_paths {
+        for path in test_paths {
             let result = resource_manager.derive_http_headers(path);
             println!("Result for {}: {:?}", path, result.keys());
-            assert_eq!(result.len(), expected_len);
+            assert_eq!(result.len(), 1);
             assert!(result.contains_key("etag"));
         }
     }

--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -549,7 +549,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_derive_http_headers() {
-        // Define the headers configuration for mocking the Walrus object.
+        // Define the headers configuration for mocking the resource manager.
         let mut headers: BTreeMap<String, HttpHeaders> = BTreeMap::new();
         headers.insert(
             "/*.svg".to_string(),
@@ -575,6 +575,9 @@ mod tests {
         assert_eq!(result.get("etag"), Some(&"\"abc123\"".to_string()));
     }
 
+    /// Sets up a mock resource manager with the given headers configuration and resource path.
+    ///
+    /// Helper function for testing the `derive_http_headers` method.
     async fn setup_resource_manager_mock(
         headers: BTreeMap<String, HttpHeaders>,
         ws_resources_path: &str,


### PR DESCRIPTION
Checks the paths defined in `ws-resources.yaml` and if the resource path matches the pattern defined in the yaml, it adds the corresponding http headers to the `Resource::headers` vecmap. 