### PR TITLE
feat(portal)!: Add full-node fallback list by instantiating a sui client for each rpc node

### DIFF
--- a/portal/common/lib/constants.ts
+++ b/portal/common/lib/constants.ts
@@ -20,3 +20,5 @@ export const TESTNET_RPC_LIST = [
     'https://sui-testnet.public.blastapi.io',
     'https://sui-testnet-endpoint.blockvision.org'
 ];
+
+export const RPC_REQUEST_TIMEOUT_MS = 7000;

--- a/portal/common/lib/constants.ts
+++ b/portal/common/lib/constants.ts
@@ -14,3 +14,15 @@ export const SITE_NAMES: { [key: string]: string } = {
 export const FALLBACK_PORTAL = "blob.store";
 // The string representing the ResourcePath struct in the walrus_site package.
 export const RESOURCE_PATH_MOVE_TYPE = SITE_PACKAGE + "::site::ResourcePath";
+
+export const testnetRPCUrls = [
+    'https://fullnode.testnet.sui.io:443',
+    'https://sui-testnet.public.blastapi.io/',
+    'https://sui-testnet-endpoint.blockvision.org/',
+    'https://rpc.ankr.com/sui_testnet',
+];
+
+export const prodRPCUrls = [
+    'https://sui-mainnet-endpoint.blockvision.org/',
+    'https://sui-mainnet.public.blastapi.io/'
+];

--- a/portal/common/lib/constants.ts
+++ b/portal/common/lib/constants.ts
@@ -18,7 +18,5 @@ export const RESOURCE_PATH_MOVE_TYPE = SITE_PACKAGE + "::site::ResourcePath";
 export const TESTNET_RPC_LIST = [
     'https://fullnode.testnet.sui.io',
     'https://sui-testnet.public.blastapi.io',
-    'https://sui-testnet-endpoint.blockvision.org',
-    'https://rpc.ankr.com/sui_testnet',
-    'https://sui.blockpi.network/v1/rpc/public'
+    'https://sui-testnet-endpoint.blockvision.org'
 ];

--- a/portal/common/lib/constants.ts
+++ b/portal/common/lib/constants.ts
@@ -16,9 +16,9 @@ export const FALLBACK_PORTAL = "blob.store";
 export const RESOURCE_PATH_MOVE_TYPE = SITE_PACKAGE + "::site::ResourcePath";
 
 export const TESTNET_RPC_LIST = [
-    'https://fullnode.testnet.sui.io:443',
-    'https://sui-testnet.public.blastapi.io/',
-    'https://sui-testnet-endpoint.blockvision.org/',
+    'https://fullnode.testnet.sui.io',
+    'https://sui-testnet.public.blastapi.io',
+    'https://sui-testnet-endpoint.blockvision.org',
     'https://rpc.ankr.com/sui_testnet',
     'https://sui.blockpi.network/v1/rpc/public'
 ];

--- a/portal/common/lib/constants.ts
+++ b/portal/common/lib/constants.ts
@@ -15,14 +15,10 @@ export const FALLBACK_PORTAL = "blob.store";
 // The string representing the ResourcePath struct in the walrus_site package.
 export const RESOURCE_PATH_MOVE_TYPE = SITE_PACKAGE + "::site::ResourcePath";
 
-export const testnetRPCUrls = [
+export const TESTNET_RPC_LIST = [
     'https://fullnode.testnet.sui.io:443',
     'https://sui-testnet.public.blastapi.io/',
     'https://sui-testnet-endpoint.blockvision.org/',
     'https://rpc.ankr.com/sui_testnet',
-];
-
-export const prodRPCUrls = [
-    'https://sui-mainnet-endpoint.blockvision.org/',
-    'https://sui-mainnet.public.blastapi.io/'
+    'https://sui.blockpi.network/v1/rpc/public'
 ];

--- a/portal/common/lib/node_selector.ts
+++ b/portal/common/lib/node_selector.ts
@@ -1,0 +1,134 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+    GetDynamicFieldObjectParams,
+    GetObjectParams,
+    MultiGetObjectsParams,
+    SuiClient,
+    SuiObjectResponse,
+} from "@mysten/sui/client";
+import { testnetRPCUrls } from "./constants";
+
+// Interface defining the RPC selector methods.
+interface RPCSelectorInterface {
+    getObject(input: GetObjectParams): Promise<SuiObjectResponse>;
+    multiGetObjects(input: MultiGetObjectsParams): Promise<SuiObjectResponse>;
+    getDynamicFieldObject(
+        input: GetDynamicFieldObjectParams,
+    ): Promise<SuiObjectResponse>;
+    call<T>(method: string, args: any[]): Promise<T>;
+}
+
+// Singleton RPC Selector class.
+class RPCSelector implements RPCSelectorInterface {
+    private static instance: RPCSelector;
+    private clients: SuiClient[];
+    private clientScores: Map<SuiClient, number>;
+
+    private constructor(rpcURLs: string[]) {
+        // Initialize clients immediately without blocking.
+        this.clients = rpcURLs.map((rpcUrl) => new SuiClient({ url: rpcUrl }));
+        // this.clientScores = new Map(this.clients.map((client) => [client, 0]));
+    }
+
+    // Get the singleton instance.
+    public static getInstance(): RPCSelector {
+        if (!RPCSelector.instance) {
+        RPCSelector.instance = new RPCSelector(testnetRPCUrls);
+        }
+        return RPCSelector.instance;
+    }
+
+    // Update client's score based on success or failure.
+    // private updateClientScore(client: SuiClient, success: boolean): void {
+    //   const currentScore = this.clientScores.get(client) || 0;
+    //   const newScore = success ? currentScore + 1 : currentScore - 1;
+    //   this.clientScores.set(client, newScore);
+    // }
+
+    // Get clients sorted by their scores in descending order.
+    // private getClientsByScore(): SuiClient[] {
+    //   return [...this.clients]
+    //     .filter((client) => this.clientHealth.get(client) !== false) // Exclude unhealthy clients
+    //     .sort((a, b) => {
+    //       const scoreA = this.clientScores.get(a) || 0;
+    //       const scoreB = this.clientScores.get(b) || 0;
+    //       return scoreB - scoreA;
+    //     });
+    // }
+
+    // General method to call clients and return the first successful response.
+    private async callClients<T>(methodName: string, args: any[]): Promise<T> {
+        if (this.clients.length === 0) {
+        throw new Error("No available clients to handle the request.");
+        }
+
+        const clientPromises = this.clients.map((client) =>
+            new Promise<T>(async (resolve, reject) => {
+            try {
+                const method = (client as any)[methodName] as Function;
+                if (!method) {
+                reject(new Error(`Method ${methodName} not found on client`));
+                return;
+                }
+                // TODO - verify that await is needed here
+                // TODO => i.e. client.method(args)(?)
+                const result = await method.apply(client, args);
+                if (this.isValidResponse(result)) { // does this work?
+                // this.updateClientScore(client, true);  - COMMENT a bit premature
+                resolve(result);
+                } else {
+                // this.updateClientScore(client, false); - COMMENT a bit premature
+                reject(new Error("Invalid response"));
+                }
+            } catch (error: any) {
+                // Decrease score on any error, assuming node is down or unreachable.
+                // this.updateClientScore(client, false); // COMMENT a bit premature
+                reject(error);
+            }
+            }),
+        );
+
+        try {
+        const result = await Promise.any(clientPromises);
+        return result;
+        } catch (errors) {
+        throw new Error("All clients failed");
+        }
+    }
+
+    // Check if the response is valid. -- FIXME
+    private isValidResponse(result: any): boolean {
+        console.log("res:", result);
+        return result !== null && result !== undefined;
+    }
+
+    // Implementing getObject method.
+    public async getObject(input: GetObjectParams): Promise<SuiObjectResponse> {
+        return this.callClients<SuiObjectResponse>("getObject", [input]);
+    }
+    // Implementing multiGetObjects method.
+    public async multiGetObjects(
+        input: MultiGetObjectsParams,
+    ): Promise<SuiObjectResponse> {
+        return this.callClients<SuiObjectResponse>("multiGetObjects", [input]);
+    }
+
+    // Implementing getDynamicFieldObject method.
+    public async getDynamicFieldObject(
+        input: GetDynamicFieldObjectParams,
+    ): Promise<SuiObjectResponse> {
+        return this.callClients<SuiObjectResponse>("getDynamicFieldObject", [
+        input,
+        ]);
+    }
+
+    // Implementing generic call method.
+    public async call<T>(method: string, args: any[]): Promise<T> {
+        return this.callClients<T>(method, args);
+    }
+}
+
+const rpcSelectorInstance = RPCSelector.getInstance();
+export default rpcSelectorInstance;

--- a/portal/common/lib/page_fetching.ts
+++ b/portal/common/lib/page_fetching.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { getFullnodeUrl, SuiClient } from "@mysten/sui/client";
-import { NETWORK } from "./constants";
 import {
     DomainDetails,
     isResource,

--- a/portal/common/lib/page_fetching.ts
+++ b/portal/common/lib/page_fetching.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { getFullnodeUrl, SuiClient } from "@mysten/sui/client";
+import { NETWORK } from "./constants";
 import {
     DomainDetails,
     isResource,
@@ -21,49 +23,55 @@ import { sha256 } from "./crypto";
 import { getRoutes, matchPathToRoute } from "./routing";
 import { HttpStatusCodes } from "./http/http_status_codes";
 
-// Create an instance of NodeSelector
 /**
  * Resolves the subdomain to an object ID, and gets the corresponding resources.
  *
  * The `resolvedObjectId` variable is the object ID of the site that was previously resolved. If
  * `null`, the object ID is resolved again.
  */
-export async function resolveAndFetchPage(parsedUrl: DomainDetails): Promise<Response> {
+export async function resolveAndFetchPage(
+    parsedUrl: DomainDetails,
+    resolvedObjectId: string | null,
+): Promise<Response> {
 
-    const resolveObjectResult = await resolveObjectId(parsedUrl);
-    const isObjectId = typeof resolveObjectResult == "string";
-    if (isObjectId) {
-        console.log("Object ID: ", resolveObjectResult);
-        console.log("Base36 version of the object ID: ", HEXtoBase36(resolveObjectResult));
-        // Rerouting based on the contents of the routes object,
-        // constructed using the ws-resource.json.
-
-        // Initiate a fetch request to get the Routes object in case the request
-        // to the initial unfiltered path fails.
-        const routesPromise = getRoutes(resolveObjectResult);
-
-        // Fetch the page using the initial path.
-        const fetchPromise = await fetchPage(resolveObjectResult, parsedUrl.path);
-
-        // If the fetch fails, check if the path can be matched using
-        // the Routes DF and fetch the redirected path.
-        if (fetchPromise.status == HttpStatusCodes.NOT_FOUND) {
-            const routes = await routesPromise;
-            if (!routes) {
-                console.warn("No routes found for the object ID");
-                return siteNotFound();
-            }
-            let matchingRoute: string | undefined;
-            matchingRoute = matchPathToRoute(parsedUrl.path, routes);
-            if (!matchingRoute) {
-                console.warn(`No matching route found for ${parsedUrl.path}`);
-                return siteNotFound();
-            }
-            return fetchPage(resolveObjectResult, matchingRoute);
+    if (!resolvedObjectId) {
+        const resolveObjectResult = await resolveObjectId(parsedUrl);
+        const isObjectId = typeof resolveObjectResult == "string";
+        if (!isObjectId) {
+            return resolveObjectResult;
         }
-        return fetchPromise;
+        resolvedObjectId = resolveObjectResult;
     }
-    return resolveObjectResult;
+
+    console.log("Object ID: ", resolvedObjectId);
+    console.log("Base36 version of the object ID: ", HEXtoBase36(resolvedObjectId));
+    // Rerouting based on the contents of the routes object,
+    // constructed using the ws-resource.json.
+
+    // Initiate a fetch request to get the Routes object in case the request
+    // to the initial unfiltered path fails.
+    const routesPromise = getRoutes(resolvedObjectId);
+
+    // Fetch the page using the initial path.
+    const fetchPromise = await fetchPage(resolvedObjectId, parsedUrl.path);
+
+    // If the fetch fails, check if the path can be matched using
+    // the Routes DF and fetch the redirected path.
+    if (fetchPromise.status == HttpStatusCodes.NOT_FOUND) {
+        const routes = await routesPromise;
+        if (!routes) {
+            console.warn("No routes found for the object ID");
+            return siteNotFound();
+        }
+        let matchingRoute: string | undefined;
+        matchingRoute = matchPathToRoute(parsedUrl.path, routes);
+        if (!matchingRoute) {
+            console.warn(`No matching route found for ${parsedUrl.path}`);
+            return siteNotFound();
+        }
+        return fetchPage(resolvedObjectId, matchingRoute);
+    }
+    return fetchPromise;
 }
 
 export async function resolveObjectId(

--- a/portal/common/lib/resource.test.ts
+++ b/portal/common/lib/resource.test.ts
@@ -10,9 +10,6 @@ import { fromBase64 } from "@mysten/bcs";
 
 // Mock SuiClient methods
 const multiGetObjects = vi.fn();
-// const mockClient = {
-//     multiGetObjects,
-// } as unknown as SuiClient;
 
 vi.mock("@mysten/sui/utils", () => ({
     deriveDynamicFieldID: vi.fn(() => "0xdynamicFieldId"),

--- a/portal/common/lib/resource.test.ts
+++ b/portal/common/lib/resource.test.ts
@@ -4,16 +4,15 @@
 // Import necessary functions and types
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { fetchResource } from "./resource";
-import { SuiClient } from "@mysten/sui/client";
 import { HttpStatusCodes } from "./http/http_status_codes";
 import { checkRedirect } from "./redirects";
 import { fromBase64 } from "@mysten/bcs";
 
 // Mock SuiClient methods
 const multiGetObjects = vi.fn();
-const mockClient = {
-    multiGetObjects,
-} as unknown as SuiClient;
+// const mockClient = {
+//     multiGetObjects,
+// } as unknown as SuiClient;
 
 vi.mock("@mysten/sui/utils", () => ({
     deriveDynamicFieldID: vi.fn(() => "0xdynamicFieldId"),
@@ -51,14 +50,14 @@ describe("fetchResource", () => {
     test("should return LOOP_DETECTED if objectId is already in seenResources", async () => {
         const seenResources = new Set<string>(["0xParentId"]);
 
-        const result = await fetchResource(mockClient, "0xParentId", "/path", seenResources);
+        const result = await fetchResource("0xParentId", "/path", seenResources);
         expect(result).toBe(HttpStatusCodes.LOOP_DETECTED);
     });
 
     test("TOO_MANY_REDIRECTS if recursion depth exceeds MAX_REDIRECT_DEPTH", async () => {
         const seenResources = new Set<string>();
         // Assuming MAX_REDIRECT_DEPTH is 3
-        const result = await fetchResource(mockClient, "0xParentId", "/path", seenResources, 4);
+        const result = await fetchResource("0xParentId", "/path", seenResources, 4);
         expect(result).toBe(HttpStatusCodes.TOO_MANY_REDIRECTS);
     });
 
@@ -84,7 +83,7 @@ describe("fetchResource", () => {
         ]);
         (fromBase64 as any).mockReturnValueOnce("decodedBcsBytes");
 
-        const result = await fetchResource(mockClient, "0x1", "/path", new Set());
+        const result = await fetchResource("0x1", "/path", new Set());
         expect(result).toEqual({
             blob_id: "0xresourceBlobId",
             objectId: "0xdynamicFieldId",
@@ -128,7 +127,6 @@ describe("fetchResource", () => {
             .mockResolvedValueOnce([mockObject, mockResource]);
 
         const result = await fetchResource(
-            mockClient,
             "0x26dc2460093a9d6d31b58cb0ed1e72b19d140542a49be7472a6f25d542cb5cc3",
             "/path",
             new Set());
@@ -157,7 +155,7 @@ describe("fetchResource", () => {
         ]);
         (fromBase64 as any).mockReturnValueOnce(undefined);
 
-        const result = await fetchResource(mockClient, "0x1", "/path", seenResources);
+        const result = await fetchResource("0x1", "/path", seenResources);
 
         // Since the resource does not have a blob_id, the function should return NOT_FOUND
         expect(result).toBe(HttpStatusCodes.NOT_FOUND);
@@ -175,7 +173,7 @@ describe("fetchResource", () => {
             {},
         ]);
 
-        const result = await fetchResource(mockClient, "0x1", "/path", seenResources);
+        const result = await fetchResource("0x1", "/path", seenResources);
 
         // Check that the function returns NOT_FOUND
         expect(result).toBe(HttpStatusCodes.NOT_FOUND);

--- a/portal/common/lib/resource.ts
+++ b/portal/common/lib/resource.ts
@@ -10,7 +10,7 @@ import { fromBase64 } from "@mysten/bcs";
 import { ResourcePathStruct, DynamicFieldStruct, ResourceStruct } from "./bcs_data_parsing";
 import { deriveDynamicFieldID } from "@mysten/sui/utils";
 import { bcs } from "@mysten/bcs";
-import rpcSelectorInstance from "./node_selector";
+import rpcSelectorInstance from "./rpc_selector";
 
 /**
  * Fetches a resource of a site.

--- a/portal/common/lib/resource.ts
+++ b/portal/common/lib/resource.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { HttpStatusCodes } from "./http/http_status_codes";
-import { SuiClient, SuiObjectData, SuiObjectResponse } from "@mysten/sui/client";
+import { SuiObjectData, SuiObjectResponse } from "@mysten/sui/client";
 import { Resource, VersionedResource } from "./types";
 import { MAX_REDIRECT_DEPTH, RESOURCE_PATH_MOVE_TYPE } from "./constants";
 import { checkRedirect } from "./redirects";
@@ -10,7 +10,7 @@ import { fromBase64 } from "@mysten/bcs";
 import { ResourcePathStruct, DynamicFieldStruct, ResourceStruct } from "./bcs_data_parsing";
 import { deriveDynamicFieldID } from "@mysten/sui/utils";
 import { bcs } from "@mysten/bcs";
-import rpcSelectorInstance from "./rpc_selector";
+import rpcSelectorSingleton from "./rpc_selector";
 
 /**
  * Fetches a resource of a site.
@@ -74,7 +74,7 @@ async function fetchObjectPairData(
     dynamicFieldId: string
 ): Promise<SuiObjectResponse[]> {
     // MultiGetObjects returns the objects *always* in the order they were requested.
-    const pageData = await rpcSelectorInstance.multiGetObjects(
+    const pageData = await rpcSelectorSingleton.multiGetObjects(
         {
             ids: [
                 objectId,

--- a/portal/common/lib/resource.ts
+++ b/portal/common/lib/resource.ts
@@ -10,6 +10,7 @@ import { fromBase64 } from "@mysten/bcs";
 import { ResourcePathStruct, DynamicFieldStruct, ResourceStruct } from "./bcs_data_parsing";
 import { deriveDynamicFieldID } from "@mysten/sui/utils";
 import { bcs } from "@mysten/bcs";
+import rpcSelectorInstance from "./node_selector";
 
 /**
  * Fetches a resource of a site.
@@ -30,7 +31,6 @@ import { bcs } from "@mysten/bcs";
  * This is done by using the `seenResources` set.
  */
 export async function fetchResource(
-    client: SuiClient,
     objectId: string,
     path: string,
     seenResources: Set<string>,
@@ -50,13 +50,13 @@ export async function fetchResource(
     const [
         primaryObjectResponse,
         dynamicFieldResponse
-    ] = await fetchObjectPairData(client, objectId, dynamicFieldId);
+    ] = await fetchObjectPairData(objectId, dynamicFieldId);
 
     seenResources.add(objectId);
 
     const redirectId = checkRedirect(primaryObjectResponse);
     if (redirectId) {
-        return fetchResource(client, redirectId, path, seenResources, depth + 1);
+        return fetchResource(redirectId, path, seenResources, depth + 1);
     }
 
     return extractResource(dynamicFieldResponse, dynamicFieldId);
@@ -70,12 +70,11 @@ export async function fetchResource(
 * @returns A tuple of SuiObjectResponse[] or an HttpStatusCode in case of an error.
 */
 async function fetchObjectPairData(
-    client: SuiClient,
     objectId: string,
     dynamicFieldId: string
 ): Promise<SuiObjectResponse[]> {
     // MultiGetObjects returns the objects *always* in the order they were requested.
-    const pageData = await client.multiGetObjects(
+    const pageData = await rpcSelectorInstance.multiGetObjects(
         {
             ids: [
                 objectId,

--- a/portal/common/lib/routing.test.ts
+++ b/portal/common/lib/routing.test.ts
@@ -8,7 +8,6 @@ const snakeSiteObjectId = "0x7a95e4be3948415b852fb287d455166a276d7a52f1a567b4a26
 test.skip("getRoutes", async () => {
     // TODO: when you make sure get_routes fetches
     // the Routes dynamic field, mock the request.
-    // const rpcUrl = getFullnodeUrl(NETWORK);
     const routes = await getRoutes(snakeSiteObjectId);
     console.log(routes);
 });

--- a/portal/common/lib/routing.test.ts
+++ b/portal/common/lib/routing.test.ts
@@ -3,16 +3,13 @@
 
 import { getRoutes, matchPathToRoute } from "./routing";
 import { test, expect } from "vitest";
-import { SuiClient, getFullnodeUrl } from "@mysten/sui/client";
-import { NETWORK } from "./constants";
 
 const snakeSiteObjectId = "0x7a95e4be3948415b852fb287d455166a276d7a52f1a567b4a26b6b5e9c753158";
 test.skip("getRoutes", async () => {
     // TODO: when you make sure get_routes fetches
     // the Routes dynamic field, mock the request.
-    const rpcUrl = getFullnodeUrl(NETWORK);
-    const client = new SuiClient({ url: rpcUrl });
-    const routes = await getRoutes(client, snakeSiteObjectId);
+    // const rpcUrl = getFullnodeUrl(NETWORK);
+    const routes = await getRoutes(snakeSiteObjectId);
     console.log(routes);
 });
 

--- a/portal/common/lib/routing.ts
+++ b/portal/common/lib/routing.ts
@@ -5,6 +5,7 @@ import { getFullnodeUrl, SuiClient, SuiObjectResponse } from "@mysten/sui/client
 import { Routes } from "./types";
 import { DynamicFieldStruct, RoutesStruct } from "./bcs_data_parsing";
 import { bcs, fromBase64 } from "@mysten/bcs";
+import rpcSelectorInstance from "./node_selector";
 
 /**
  * Gets the Routes dynamic field of the site object.
@@ -15,15 +16,14 @@ import { bcs, fromBase64 } from "@mysten/bcs";
  * @returns The routes list.
  */
 export async function getRoutes(
-    client: SuiClient,
     siteObjectId: string,
 ): Promise<Routes | undefined> {
-    const routesDF = await fetchRoutesDynamicField(client, siteObjectId);
+    const routesDF = await fetchRoutesDynamicField(siteObjectId);
     if (!routesDF.data) {
         console.warn("No routes dynamic field found for site object.");
         return;
     }
-    const routesObj = await fetchRoutesObject(client, routesDF.data.objectId);
+    const routesObj = await fetchRoutesObject(routesDF.data.objectId);
     const objectData = routesObj.data;
     if (objectData && objectData.bcs && objectData.bcs.dataType === "moveObject") {
         return parseRoutesData(objectData.bcs.bcsBytes);
@@ -39,10 +39,9 @@ export async function getRoutes(
  * @returns The dynamic field object for routes.
  */
 async function fetchRoutesDynamicField(
-    client: SuiClient,
     siteObjectId: string,
 ): Promise<SuiObjectResponse> {
-    return await client.getDynamicFieldObject({
+    return await rpcSelectorInstance.getDynamicFieldObject({
         parentId: siteObjectId,
         name: { type: "vector<u8>", value: "routes" },
     });
@@ -55,8 +54,8 @@ async function fetchRoutesDynamicField(
  * @param objectId - The ID of the dynamic field object.
  * @returns The routes object.
  */
-async function fetchRoutesObject(client: SuiClient, objectId: string): Promise<SuiObjectResponse> {
-    return await client.getObject({
+async function fetchRoutesObject(objectId: string): Promise<SuiObjectResponse> {
+    return await rpcSelectorInstance.getObject({
         id: objectId,
         options: { showBcs: true },
     });

--- a/portal/common/lib/routing.ts
+++ b/portal/common/lib/routing.ts
@@ -5,7 +5,7 @@ import { getFullnodeUrl, SuiClient, SuiObjectResponse } from "@mysten/sui/client
 import { Routes } from "./types";
 import { DynamicFieldStruct, RoutesStruct } from "./bcs_data_parsing";
 import { bcs, fromBase64 } from "@mysten/bcs";
-import rpcSelectorInstance from "./node_selector";
+import rpcSelectorInstance from "./rpc_selector";
 
 /**
  * Gets the Routes dynamic field of the site object.

--- a/portal/common/lib/routing.ts
+++ b/portal/common/lib/routing.ts
@@ -5,7 +5,7 @@ import { getFullnodeUrl, SuiClient, SuiObjectResponse } from "@mysten/sui/client
 import { Routes } from "./types";
 import { DynamicFieldStruct, RoutesStruct } from "./bcs_data_parsing";
 import { bcs, fromBase64 } from "@mysten/bcs";
-import rpcSelectorInstance from "./rpc_selector";
+import rpcSelectorSingleton from "./rpc_selector";
 
 /**
  * Gets the Routes dynamic field of the site object.
@@ -41,7 +41,7 @@ export async function getRoutes(
 async function fetchRoutesDynamicField(
     siteObjectId: string,
 ): Promise<SuiObjectResponse> {
-    return await rpcSelectorInstance.getDynamicFieldObject({
+    return await rpcSelectorSingleton.getDynamicFieldObject({
         parentId: siteObjectId,
         name: { type: "vector<u8>", value: "routes" },
     });
@@ -55,7 +55,7 @@ async function fetchRoutesDynamicField(
  * @returns The routes object.
  */
 async function fetchRoutesObject(objectId: string): Promise<SuiObjectResponse> {
-    return await rpcSelectorInstance.getObject({
+    return await rpcSelectorSingleton.getObject({
         id: objectId,
         options: { showBcs: true },
     });

--- a/portal/common/lib/routing.ts
+++ b/portal/common/lib/routing.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { getFullnodeUrl, SuiClient, SuiObjectResponse } from "@mysten/sui/client";
+import { SuiObjectResponse } from "@mysten/sui/client";
 import { Routes } from "./types";
 import { DynamicFieldStruct, RoutesStruct } from "./bcs_data_parsing";
 import { bcs, fromBase64 } from "@mysten/bcs";

--- a/portal/common/lib/rpc_selector.ts
+++ b/portal/common/lib/rpc_selector.ts
@@ -110,19 +110,22 @@ class RPCSelector implements RPCSelectorInterface {
             this.selectedClient = client;
             return result;
         } catch {
-            return null;
+            throw new Error(`Failed to contact fallback RPC clients.`);
         }
     }
 
     private isValidResponse(result: SuiObjectResponse | SuiObjectResponse[] | string): boolean {
+        // GetObject or getDynamicFieldObject
         if (result == null) {
             return false;
         }
 
+        // SuiNS
         if (typeof result === 'string') {
             return result.trim().length > 0;
         }
 
+        // MultiGetObject
         if (Array.isArray(result)) {
             return result.some((item) => item != null);
         }

--- a/portal/common/lib/rpc_selector.ts
+++ b/portal/common/lib/rpc_selector.ts
@@ -8,7 +8,7 @@ import {
     SuiClient,
     SuiObjectResponse,
 } from "@mysten/sui/client";
-import { TESTNET_RPC_LIST } from "./constants";
+import { TESTNET_RPC_LIST, RPC_REQUEST_TIMEOUT_MS } from "./constants";
 
 interface RPCSelectorInterface {
     getObject(input: GetObjectParams): Promise<SuiObjectResponse>;
@@ -76,7 +76,7 @@ class RPCSelector implements RPCSelectorInterface {
         if (!method) {
             throw new Error(`Method ${methodName} not found on selected client`);
         }
-        const timeoutDuration = 5000;
+        const timeoutDuration = RPC_REQUEST_TIMEOUT_MS;
         const timeoutPromise = new Promise<never>((_, reject) =>
             setTimeout(() => reject(new Error("Request timed out")), timeoutDuration),
         );

--- a/portal/common/lib/rpc_selector.ts
+++ b/portal/common/lib/rpc_selector.ts
@@ -76,9 +76,9 @@ class RPCSelector implements RPCSelectorInterface {
         if (!method) {
             throw new Error(`Method ${methodName} not found on selected client`);
         }
-        const timeoutDuration = RPC_REQUEST_TIMEOUT_MS;
+
         const timeoutPromise = new Promise<never>((_, reject) =>
-            setTimeout(() => reject(new Error("Request timed out")), timeoutDuration),
+            setTimeout(() => reject(new Error("Request timed out")), RPC_REQUEST_TIMEOUT_MS),
         );
 
         const result = await Promise.race([

--- a/portal/common/lib/rpc_selector.ts
+++ b/portal/common/lib/rpc_selector.ts
@@ -52,7 +52,6 @@ class RPCSelector implements RPCSelectorInterface {
         try {
             return await this.callSelectedClient<T>(methodName, args);
         } catch (error) {
-            console.error(`Selected client failed: ${error}`);
             this.selectedClient = undefined;
             return await this.callFallbackClients<T>(methodName, args);
         }

--- a/portal/common/lib/rpc_selector.ts
+++ b/portal/common/lib/rpc_selector.ts
@@ -37,8 +37,9 @@ class RPCSelector implements RPCSelectorInterface {
     }
     return RPCSelector.instance;
     }
+
     // General method to call clients and return the first successful response.
-    private async callClients<T>(methodName: string, args: any[]): Promise<T> {
+    private async invokeWithFailover<T>(methodName: string, args: any[]): Promise<T> {
         if (this.clients.length === 0) {
             throw new Error("No available clients to handle the request.");
         }
@@ -132,6 +133,7 @@ class RPCSelector implements RPCSelectorInterface {
 
     private validateSuiObjectResponse(response: SuiObjectResponse): boolean {
         if (response.error) {
+            if(response.error.code === "notExists")
             return false;
         }
         if (response.data) {
@@ -141,25 +143,25 @@ class RPCSelector implements RPCSelectorInterface {
     }
 
     public async getObject(input: GetObjectParams): Promise<SuiObjectResponse> {
-        return this.callClients<SuiObjectResponse>("getObject", [input]);
+        return this.invokeWithFailover<SuiObjectResponse>("getObject", [input]);
     }
 
     public async multiGetObjects(
         input: MultiGetObjectsParams,
     ): Promise<SuiObjectResponse[]> {
-        return this.callClients<SuiObjectResponse[]>("multiGetObjects", [input]);
+        return this.invokeWithFailover<SuiObjectResponse[]>("multiGetObjects", [input]);
     }
 
     public async getDynamicFieldObject(
         input: GetDynamicFieldObjectParams,
     ): Promise<SuiObjectResponse> {
-        return this.callClients<SuiObjectResponse>("getDynamicFieldObject", [
-        input,
+        return this.invokeWithFailover<SuiObjectResponse>("getDynamicFieldObject", [
+            input,
         ]);
     }
 
     public async call<T>(method: string, args: any[]): Promise<T> {
-        return this.callClients<T>(method, args);
+        return this.invokeWithFailover<T>(method, args);
     }
 }
 

--- a/portal/common/lib/rpc_selector.ts
+++ b/portal/common/lib/rpc_selector.ts
@@ -8,7 +8,7 @@ import {
     SuiClient,
     SuiObjectResponse,
 } from "@mysten/sui/client";
-import { testnetRPCUrls } from "./constants";
+import { TESTNET_RPC_LIST } from "./constants";
 
 interface RPCSelectorInterface {
     getObject(input: GetObjectParams): Promise<SuiObjectResponse>;
@@ -33,7 +33,7 @@ class RPCSelector implements RPCSelectorInterface {
     // Get the singleton instance.
     public static getInstance(): RPCSelector {
     if (!RPCSelector.instance) {
-        RPCSelector.instance = new RPCSelector(testnetRPCUrls);
+        RPCSelector.instance = new RPCSelector(TESTNET_RPC_LIST);
     }
     return RPCSelector.instance;
     }
@@ -110,36 +110,23 @@ class RPCSelector implements RPCSelectorInterface {
             this.selectedClient = client;
             return result;
         } catch {
-            throw new Error("All clients failed");
+            return null;
         }
     }
 
-    private isString(result: any): result is string {
-        return typeof result === 'string';
-    }
-
-    private isValidResponse(result: SuiObjectResponse | SuiObjectResponse[]): boolean {
-        if (!result) {
+    private isValidResponse(result: SuiObjectResponse | SuiObjectResponse[] | string): boolean {
+        if (result == null) {
             return false;
         }
-        if (this.isString(result)) {
+
+        if (typeof result === 'string') {
             return result.trim().length > 0;
-        } else if (Array.isArray(result)) {
-            return result.some((item) => this.validateSuiObjectResponse(item));
-        } else {
-            return this.validateSuiObjectResponse(result);
         }
-    }
 
-    private validateSuiObjectResponse(response: SuiObjectResponse): boolean {
-        if (response.error) {
-            if(response.error.code === "notExists")
-            return false;
+        if (Array.isArray(result)) {
+            return result.some((item) => item != null);
         }
-        if (response.data) {
-            return true;
-        }
-        return false;
+        return true;
     }
 
     public async getObject(input: GetObjectParams): Promise<SuiObjectResponse> {
@@ -165,5 +152,5 @@ class RPCSelector implements RPCSelectorInterface {
     }
 }
 
-const rpcSelectorInstance = RPCSelector.getInstance();
-export default rpcSelectorInstance;
+const rpcSelectorSingleton = RPCSelector.getInstance();
+export default rpcSelectorSingleton;

--- a/portal/common/lib/suins.test.ts
+++ b/portal/common/lib/suins.test.ts
@@ -1,15 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { beforeEach, describe, expect, Mock, test, vi } from 'vitest';
+// resolveSuiNsAddress.test.ts
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { resolveSuiNsAddress } from './suins';
-import { SuiClient } from "@mysten/sui/client";
+import rpcSelectorSingleton from './rpc_selector';
 
 describe('resolveSuiNsAddress', () => {
-    const mockClient = {
-        call: vi.fn()
-    } as unknown as SuiClient;
-
     beforeEach(() => {
         vi.clearAllMocks();
     });
@@ -21,19 +19,29 @@ describe('resolveSuiNsAddress', () => {
         ];
 
         for (const [input, expected] of cases) {
-            (mockClient.call as Mock).mockResolvedValueOnce(expected);
+            // Mock the rpcSelectorSingleton.call method
+            vi.spyOn(rpcSelectorSingleton, 'call').mockResolvedValueOnce(expected);
+
             const result = await resolveSuiNsAddress(input);
+
             expect(result).toBe(expected);
-            expect(mockClient.call).toHaveBeenCalledWith("suix_resolveNameServiceAddress",
-                [`${input}.sui`]);
+            expect(rpcSelectorSingleton.call).toHaveBeenCalledWith(
+                "suix_resolveNameServiceAddress",
+                [`${input}.sui`]
+            );
         }
     });
 
     test('should return null for an unknown SuiNS address', async () => {
-        (mockClient.call as Mock).mockResolvedValueOnce(null);
+        // Mock the rpcSelectorSingleton.call method to return null
+        vi.spyOn(rpcSelectorSingleton, 'call').mockResolvedValueOnce(null);
+
         const result = await resolveSuiNsAddress("unknown");
+
         expect(result).toBeNull();
-        expect(mockClient.call).toHaveBeenCalledWith("suix_resolveNameServiceAddress",
-            ["unknown.sui"]);
+        expect(rpcSelectorSingleton.call).toHaveBeenCalledWith(
+            "suix_resolveNameServiceAddress",
+            ["unknown.sui"]
+        );
     });
 });

--- a/portal/common/lib/suins.test.ts
+++ b/portal/common/lib/suins.test.ts
@@ -22,7 +22,7 @@ describe('resolveSuiNsAddress', () => {
 
         for (const [input, expected] of cases) {
             (mockClient.call as Mock).mockResolvedValueOnce(expected);
-            const result = await resolveSuiNsAddress(mockClient, input);
+            const result = await resolveSuiNsAddress(input);
             expect(result).toBe(expected);
             expect(mockClient.call).toHaveBeenCalledWith("suix_resolveNameServiceAddress",
                 [`${input}.sui`]);
@@ -31,7 +31,7 @@ describe('resolveSuiNsAddress', () => {
 
     test('should return null for an unknown SuiNS address', async () => {
         (mockClient.call as Mock).mockResolvedValueOnce(null);
-        const result = await resolveSuiNsAddress(mockClient, "unknown");
+        const result = await resolveSuiNsAddress("unknown");
         expect(result).toBeNull();
         expect(mockClient.call).toHaveBeenCalledWith("suix_resolveNameServiceAddress",
             ["unknown.sui"]);

--- a/portal/common/lib/suins.ts
+++ b/portal/common/lib/suins.ts
@@ -1,17 +1,16 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-import { SuiClient } from "@mysten/sui/client";
 import { SITE_NAMES } from "./constants";
+import rpcSelectorInstance from "./node_selector";
 
 /**
  * Resolves the subdomain to an object ID using SuiNS.
  *
  * The subdomain `example` will look up `example.sui` and return the object ID if found.
  */
-export async function resolveSuiNsAddress(
-    client: SuiClient, subdomain: string
+export async function resolveSuiNsAddress(subdomain: string
 ): Promise<string | null> {
-    const suiObjectId: string = await client.call("suix_resolveNameServiceAddress", [
+    const suiObjectId: string = await rpcSelectorInstance.call("suix_resolveNameServiceAddress", [
         subdomain + ".sui",
     ]);
     console.log("resolved suins name: ", subdomain, suiObjectId);

--- a/portal/common/lib/suins.ts
+++ b/portal/common/lib/suins.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 import { SITE_NAMES } from "./constants";
-import rpcSelectorInstance from "./rpc_selector";
+import rpcSelectorSingleton from "./rpc_selector";
 
 /**
  * Resolves the subdomain to an object ID using SuiNS.
@@ -10,7 +10,7 @@ import rpcSelectorInstance from "./rpc_selector";
  */
 export async function resolveSuiNsAddress(subdomain: string
 ): Promise<string | null> {
-    const suiObjectId: string = await rpcSelectorInstance.call("suix_resolveNameServiceAddress", [
+    const suiObjectId: string = await rpcSelectorSingleton.call("suix_resolveNameServiceAddress", [
         subdomain + ".sui",
     ]);
     console.log("resolved suins name: ", subdomain, suiObjectId);

--- a/portal/common/lib/suins.ts
+++ b/portal/common/lib/suins.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 import { SITE_NAMES } from "./constants";
-import rpcSelectorInstance from "./node_selector";
+import rpcSelectorInstance from "./rpc_selector";
 
 /**
  * Resolves the subdomain to an object ID using SuiNS.

--- a/portal/server/app/route.ts
+++ b/portal/server/app/route.ts
@@ -5,7 +5,6 @@ import { getDomain, getSubdomainAndPath } from "@lib/domain_parsing";
 import { redirectToAggregatorUrlResponse, redirectToPortalURLResponse } from "@lib/redirects";
 import { getBlobIdLink, getObjectIdLink } from "@lib/links";
 import { resolveAndFetchPage } from "@lib/page_fetching";
-import { HttpStatusCodes } from "@lib/http/http_status_codes";
 
 export async function GET(req: Request) {
     const originalUrl = req.headers.get("x-original-url");
@@ -31,29 +30,7 @@ export async function GET(req: Request) {
     const requestDomain = getDomain(url);
 
     if (requestDomain == portalDomain && parsedUrl && parsedUrl.subdomain) {
-        const forwardToFallback = async () => {
-            const subdomain = parsedUrl.subdomain;
-            const fallbackDomain = process.env.FALLBACK_DEVNET_PORTAL;
-            const fallbackUrl = `https://${subdomain}.${fallbackDomain}${parsedUrl.path}`;
-            // We need to add the Accept-Encoding header to ensure that the fall back domain does
-            // not reply with a compressed response.
-            console.info(`Falling back to the devnet portal! ${fallbackUrl}`);
-            return fetch(fallbackUrl, {
-                headers: {
-                    "Accept-Encoding": "identity",
-                },
-            });
-        };
-
-        try {
-            const fetchPageResponse = await resolveAndFetchPage(parsedUrl, null);
-            if (fetchPageResponse.status == HttpStatusCodes.NOT_FOUND) {
-                return forwardToFallback();
-            }
-            return fetchPageResponse;
-        } catch (error) {
-            return forwardToFallback();
-        }
+        return await resolveAndFetchPage(parsedUrl, null);
     }
 
     const atBaseUrl = portalDomain == url.host.split(":")[0];

--- a/portal/server/app/route.ts
+++ b/portal/server/app/route.ts
@@ -46,7 +46,7 @@ export async function GET(req: Request) {
         };
 
         try {
-            const fetchPageResponse = await resolveAndFetchPage(parsedUrl, null);
+            const fetchPageResponse = await resolveAndFetchPage(parsedUrl);
             if (fetchPageResponse.status == HttpStatusCodes.NOT_FOUND) {
                 return forwardToFallback();
             }
@@ -65,7 +65,6 @@ export async function GET(req: Request) {
                 subdomain: blobId,
                 path: parsedUrl?.path ?? "/index.html",
             },
-            null,
         );
         return response;
     }

--- a/portal/server/app/route.ts
+++ b/portal/server/app/route.ts
@@ -46,7 +46,7 @@ export async function GET(req: Request) {
         };
 
         try {
-            const fetchPageResponse = await resolveAndFetchPage(parsedUrl);
+            const fetchPageResponse = await resolveAndFetchPage(parsedUrl, null);
             if (fetchPageResponse.status == HttpStatusCodes.NOT_FOUND) {
                 return forwardToFallback();
             }
@@ -65,6 +65,7 @@ export async function GET(req: Request) {
                 subdomain: blobId,
                 path: parsedUrl?.path ?? "/index.html",
             },
+            null,
         );
         return response;
     }

--- a/portal/worker/src/caching.ts
+++ b/portal/worker/src/caching.ts
@@ -5,6 +5,7 @@ import { resolveAndFetchPage } from "@lib/page_fetching";
 import { SuiClient, getFullnodeUrl } from "@mysten/sui/client";
 import { NETWORK } from "@lib/constants";
 import { DomainDetails } from "@lib/types";
+import rpcSelectorInstance from "@lib/node_selector";
 
 const CACHE_NAME = "walrus-sites-cache";
 const CACHE_EXPIRATION_TIME = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
@@ -35,7 +36,7 @@ export default async function resolveWithCache(
         }
     }
     console.log("Cache miss!", urlString);
-    const resolvedPage = await resolveAndFetchPage(parsedUrl, resolvedObjectId);
+    const resolvedPage = await resolveAndFetchPage(parsedUrl);
 
     await tryCachePut(cache, urlString, resolvedPage);
 
@@ -117,8 +118,7 @@ async function checkCachedVersionMatchesOnChain(
     if (!cachedResponse) {
         throw new Error("Cached response is null!");
     }
-    const rpcUrl = getFullnodeUrl(NETWORK);
-    const client = new SuiClient({ url: rpcUrl });
+    // const rpcUrl = getFullnodeUrl(NETWORK);
     const cachedVersion = cachedResponse.headers.get("x-resource-sui-object-version");
     const objectId = cachedResponse.headers.get("x-resource-sui-object-id");
     if (!cachedVersion || !objectId) {
@@ -130,7 +130,7 @@ async function checkCachedVersionMatchesOnChain(
         return false;
     }
 
-    const resourceObject = await client.getObject({ id: objectId });
+    const resourceObject = await rpcSelectorInstance.getObject({ id: objectId });
     if (!resourceObject.data) {
         throw new Error("Could not retrieve Resource object.");
     }

--- a/portal/worker/src/caching.ts
+++ b/portal/worker/src/caching.ts
@@ -36,7 +36,7 @@ export default async function resolveWithCache(
         }
     }
     console.log("Cache miss!", urlString);
-    const resolvedPage = await resolveAndFetchPage(parsedUrl);
+    const resolvedPage = await resolveAndFetchPage(parsedUrl, resolvedObjectId);
 
     await tryCachePut(cache, urlString, resolvedPage);
 

--- a/portal/worker/src/caching.ts
+++ b/portal/worker/src/caching.ts
@@ -5,7 +5,7 @@ import { resolveAndFetchPage } from "@lib/page_fetching";
 import { SuiClient, getFullnodeUrl } from "@mysten/sui/client";
 import { NETWORK } from "@lib/constants";
 import { DomainDetails } from "@lib/types";
-import rpcSelectorInstance from "@lib/node_selector";
+import rpcSelectorInstance from "@lib/rpc_selector";
 
 const CACHE_NAME = "walrus-sites-cache";
 const CACHE_EXPIRATION_TIME = 24 * 60 * 60 * 1000; // 24 hours in milliseconds

--- a/portal/worker/src/caching.ts
+++ b/portal/worker/src/caching.ts
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { resolveAndFetchPage } from "@lib/page_fetching";
-import { SuiClient, getFullnodeUrl } from "@mysten/sui/client";
-import { NETWORK } from "@lib/constants";
 import { DomainDetails } from "@lib/types";
 import rpcSelectorSingleton from "@lib/rpc_selector";
 

--- a/portal/worker/src/caching.ts
+++ b/portal/worker/src/caching.ts
@@ -5,7 +5,7 @@ import { resolveAndFetchPage } from "@lib/page_fetching";
 import { SuiClient, getFullnodeUrl } from "@mysten/sui/client";
 import { NETWORK } from "@lib/constants";
 import { DomainDetails } from "@lib/types";
-import rpcSelectorInstance from "@lib/rpc_selector";
+import rpcSelectorSingleton from "@lib/rpc_selector";
 
 const CACHE_NAME = "walrus-sites-cache";
 const CACHE_EXPIRATION_TIME = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
@@ -130,7 +130,7 @@ async function checkCachedVersionMatchesOnChain(
         return false;
     }
 
-    const resourceObject = await rpcSelectorInstance.getObject({ id: objectId });
+    const resourceObject = await rpcSelectorSingleton.getObject({ id: objectId });
     if (!resourceObject.data) {
         throw new Error("Could not retrieve Resource object.");
     }

--- a/portal/worker/src/caching.ts
+++ b/portal/worker/src/caching.ts
@@ -118,7 +118,6 @@ async function checkCachedVersionMatchesOnChain(
     if (!cachedResponse) {
         throw new Error("Cached response is null!");
     }
-    // const rpcUrl = getFullnodeUrl(NETWORK);
     const cachedVersion = cachedResponse.headers.get("x-resource-sui-object-version");
     const objectId = cachedResponse.headers.get("x-resource-sui-object-id");
     if (!cachedVersion || !objectId) {

--- a/portal/worker/src/walrus-sites-sw.ts
+++ b/portal/worker/src/walrus-sites-sw.ts
@@ -78,13 +78,17 @@ self.addEventListener("fetch", async (event) => {
                 return resolvedObjectId;
             }
             const cachedResponse = await resolveWithCache(resolvedObjectId, parsedUrl, urlString);
-            return cachedResponse;
+            return cachedResponse.status === HttpStatusCodes.NOT_FOUND
+                ? proxyFetch()
+                : cachedResponse;
         };
 
         // Fetch directly and fallback if necessary
         const fetchDirectlyOrProxy = async (): Promise<Response> => {
             const response = await resolveAndFetchPage(parsedUrl);
-            return response;
+            return response.status === HttpStatusCodes.NOT_FOUND
+            ? proxyFetch()
+            : response;
         };
 
         // Handle error during fetching

--- a/portal/worker/src/walrus-sites-sw.ts
+++ b/portal/worker/src/walrus-sites-sw.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { NETWORK } from "@lib/constants";
 import { getDomain, getSubdomainAndPath } from "@lib/domain_parsing";
 import { redirectToAggregatorUrlResponse, redirectToPortalURLResponse } from "@lib/redirects";
 import { getBlobIdLink, getObjectIdLink } from "@lib/links";

--- a/portal/worker/src/walrus-sites-sw.ts
+++ b/portal/worker/src/walrus-sites-sw.ts
@@ -56,7 +56,7 @@ self.addEventListener("fetch", async (event) => {
             try {
                 return await fetchWithCacheSupport();
             } catch (error) {
-                return;
+                return handleFetchError(error);
             }
         };
 
@@ -85,7 +85,7 @@ self.addEventListener("fetch", async (event) => {
 
         // Fetch directly and fallback if necessary
         const fetchDirectlyOrProxy = async (): Promise<Response> => {
-            const response = await resolveAndFetchPage(parsedUrl);
+            const response = await resolveAndFetchPage(parsedUrl, null);
             return response.status === HttpStatusCodes.NOT_FOUND
             ? proxyFetch()
             : response;


### PR DESCRIPTION
This PR for Issue #211 adds a full-node fallback list to improve node reliability, enabling portal support for fallback nodes. It includes a fallback mechanism that creates a SuiClient instance for each RPC URL, ensuring resilience during network issues or rate limits.

**Changes:**
- RPC Selector: Introduced a singleton RPCSelector class that manages multiple SuiClient instances for efficient request handling across nodes.
- Fallback URLs: Added lists for testnetRPCUrls and prodRPCUrls to support testnet and mainnet failovers.
- API Refactor: Routed all SuiClient calls through RPCSelector to ensure reliable node selection during network issues or rate limiting.

Current RPC List:
  1. fullnode.testnet.sui.io
  2. sui-testnet.public.blastapi.io
  3. sui-testnet-endpoint.blockvision.org

  Not added due to a CORS error response in localhost tests:
   1. rpc.ankr.com/sui_testnet
   2. sui.blockpi.network/v1/rpc/public
    