### PR TITLE
feat(contract): add a burn function to destroy unused old sites

### DIFF
--- a/move/walrus_site/Move.lock
+++ b/move/walrus_site/Move.lock
@@ -22,7 +22,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.36.2"
+compiler-version = "1.37.3"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/move/walrus_site/Move.lock
+++ b/move/walrus_site/Move.lock
@@ -22,7 +22,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.35.1"
+compiler-version = "1.36.2"
 edition = "2024.beta"
 flavor = "sui"
 
@@ -36,6 +36,6 @@ published-version = "1"
 
 [env.testnet]
 chain-id = "4c78adac"
-original-published-id = "0xc5bebae319fc9d2a9dc858b7484cdbd6ef219decf4662dc81a11dc69bb7a5fa7"
-latest-published-id = "0xc5bebae319fc9d2a9dc858b7484cdbd6ef219decf4662dc81a11dc69bb7a5fa7"
+original-published-id = "0xbb6e248ef88d9e6d90612e6b714b5771fdcdd72b9889dcb8d4428fdf2a5db966"
+latest-published-id = "0xbb6e248ef88d9e6d90612e6b714b5771fdcdd72b9889dcb8d4428fdf2a5db966"
 published-version = "1"

--- a/move/walrus_site/Move.lock
+++ b/move/walrus_site/Move.lock
@@ -36,6 +36,6 @@ published-version = "1"
 
 [env.testnet]
 chain-id = "4c78adac"
-original-published-id = "0xbb6e248ef88d9e6d90612e6b714b5771fdcdd72b9889dcb8d4428fdf2a5db966"
-latest-published-id = "0xbb6e248ef88d9e6d90612e6b714b5771fdcdd72b9889dcb8d4428fdf2a5db966"
+original-published-id = "0xc5bebae319fc9d2a9dc858b7484cdbd6ef219decf4662dc81a11dc69bb7a5fa7"
+latest-published-id = "0xc5bebae319fc9d2a9dc858b7484cdbd6ef219decf4662dc81a11dc69bb7a5fa7"
 published-version = "1"

--- a/move/walrus_site/Move.lock
+++ b/move/walrus_site/Move.lock
@@ -22,7 +22,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.37.3"
+compiler-version = "1.35.1"
 edition = "2024.beta"
 flavor = "sui"
 
@@ -37,5 +37,5 @@ published-version = "1"
 [env.testnet]
 chain-id = "4c78adac"
 original-published-id = "0xc5bebae319fc9d2a9dc858b7484cdbd6ef219decf4662dc81a11dc69bb7a5fa7"
-latest-published-id = "0xc5bebae319fc9d2a9dc858b7484cdbd6ef219decf4662dc81a11dc69bb7a5fa7"
-published-version = "1"
+latest-published-id = "0xdf9033cac39b7a9b9f76fb6896c9fc5283ba730d6976a2b1d85ad1e6036c3272"
+published-version = "2"

--- a/move/walrus_site/sources/site.move
+++ b/move/walrus_site/sources/site.move
@@ -209,7 +209,7 @@ module walrus_site::site {
     public fun burn(site: Site) {
         let Site {
             id,
-            name: _
+            ..
         } = site;
         id.delete();
     }

--- a/move/walrus_site/sources/site.move
+++ b/move/walrus_site/sources/site.move
@@ -205,13 +205,14 @@ module walrus_site::site {
     }
 
     /// Deletes a site object.
-    /// Make sure to call this function only if there are no dynamic fields
+    /// Make sure to call this function after deleting all the Resource dynamic fields
     /// attached to the sites object.
     public fun burn(site: Site) {
         let Site {
             id,
             name: _
         } = site;
+        df::remove_if_exists(&mut site.id, ROUTES_FIELD);
         object::delete(id);
     }
 }

--- a/move/walrus_site/sources/site.move
+++ b/move/walrus_site/sources/site.move
@@ -11,6 +11,7 @@ module walrus_site::site {
     const EResourceDoesNotExist: u64 = 0;
     const ERangeStartGreaterThanRangeEnd: u64 = 1;
     const EStartAndEndRangeAreNone: u64 = 2;
+    const ESiteHasDynamicFields: u64 = 3;
 
     /// The site published on Sui.
     public struct Site has key, store {
@@ -201,5 +202,16 @@ module walrus_site::site {
     public fun remove_route(site: &mut Site, route: &String): (String, String) {
         let routes = df::borrow_mut(&mut site.id, ROUTES_FIELD);
         routes_remove(routes, route)
+    }
+
+    /// Deletes a site object.
+    /// Make sure to call this function only if there are no dynamic fields
+    /// attached to the sites object.
+    public fun burn(site: Site) {
+        let Site {
+            id,
+            name: _
+        } = site;
+        object::delete(id);
     }
 }

--- a/move/walrus_site/sources/site.move
+++ b/move/walrus_site/sources/site.move
@@ -211,6 +211,6 @@ module walrus_site::site {
             id,
             name: _
         } = site;
-        object::delete(id);
+        id.delete();
     }
 }

--- a/move/walrus_site/sources/site.move
+++ b/move/walrus_site/sources/site.move
@@ -11,7 +11,6 @@ module walrus_site::site {
     const EResourceDoesNotExist: u64 = 0;
     const ERangeStartGreaterThanRangeEnd: u64 = 1;
     const EStartAndEndRangeAreNone: u64 = 2;
-    const ESiteHasDynamicFields: u64 = 3;
 
     /// The site published on Sui.
     public struct Site has key, store {
@@ -205,14 +204,13 @@ module walrus_site::site {
     }
 
     /// Deletes a site object.
-    /// Make sure to call this function after deleting all the Resource dynamic fields
+    /// Make sure to call this function after deleting all the dynamic fields
     /// attached to the sites object.
     public fun burn(site: Site) {
         let Site {
             id,
             name: _
         } = site;
-        df::remove_if_exists(&mut site.id, ROUTES_FIELD);
         object::delete(id);
     }
 }

--- a/move/walrus_site/sources/site.move
+++ b/move/walrus_site/sources/site.move
@@ -204,8 +204,11 @@ module walrus_site::site {
     }
 
     /// Deletes a site object.
-    /// Make sure to call this function after deleting all the dynamic fields
-    /// attached to the sites object.
+    /// WARNING: This function does **NOT** delete the dynamic fields!
+    /// Make sure to call this function after deleting manually
+    /// all the dynamic fields attached to the sites object.
+    /// If you don't delete the dynamic fields, they will become
+    /// unaccessible and you will not be able to delete them in the future.
     public fun burn(site: Site) {
         let Site {
             id,

--- a/move/walrus_site/tests/site_tests.move
+++ b/move/walrus_site/tests/site_tests.move
@@ -1,9 +1,11 @@
 #[test_only]
 module walrus_site::site_tests {
     use walrus_site::site::{
-        ERangeStartGreaterThanRangeEnd
+        ERangeStartGreaterThanRangeEnd,
+        EStartAndEndRangeAreNone
     };
     #[test]
+    #[expected_failure(abort_code = EStartAndEndRangeAreNone)]
     fun test_new_range_no_bounds_defined() {
         walrus_site::site::new_range(
             option::none(),

--- a/sites-config.yaml
+++ b/sites-config.yaml
@@ -1,6 +1,6 @@
 # module: site
 # portal: walrus.site
-package: 0xc5bebae319fc9d2a9dc858b7484cdbd6ef219decf4662dc81a11dc69bb7a5fa7
+package: 0xdf9033cac39b7a9b9f76fb6896c9fc5283ba730d6976a2b1d85ad1e6036c3272
 # general:
 #   rpc_url: https://fullnode.testnet.sui.io:443
 #   wallet: /path/to/.sui/sui_config/client.yaml


### PR DESCRIPTION
- Add a burn function to the contract. 
- Fix: The `test_new_range_no_bounds_defined` should fail since at least one range bound should have been defined.

The `site-builder` will be updated when there will also be a `delete` argument support where both the blobs on walrus and the sui objects of a site will be deleted. 

_Warning: The burn function should be called after the `site-builder` has deleted all dynamic fields (resources and routes) attached to the site! Otherwise, deleting an object that has dynamic fields still defined on it [renders them all inaccessible](https://docs.sui.io/concepts/dynamic-fields#deleting-an-object-with-dynamic-fields) to future transactions!_