### PR TITLE
feat(portal): remove devnet fallback

### DIFF
--- a/portal/server/app/route.ts
+++ b/portal/server/app/route.ts
@@ -31,28 +31,11 @@ export async function GET(req: Request) {
     const requestDomain = getDomain(url);
 
     if (requestDomain == portalDomain && parsedUrl && parsedUrl.subdomain) {
-        const forwardToFallback = async () => {
-            const subdomain = parsedUrl.subdomain;
-            const fallbackDomain = process.env.FALLBACK_DEVNET_PORTAL;
-            const fallbackUrl = `https://${subdomain}.${fallbackDomain}${parsedUrl.path}`;
-            // We need to add the Accept-Encoding header to ensure that the fall back domain does
-            // not reply with a compressed response.
-            console.info(`Falling back to the devnet portal! ${fallbackUrl}`);
-            return fetch(fallbackUrl, {
-                headers: {
-                    "Accept-Encoding": "identity",
-                },
-            });
-        };
-
         try {
             const fetchPageResponse = await resolveAndFetchPage(parsedUrl, null);
-            if (fetchPageResponse.status == HttpStatusCodes.NOT_FOUND) {
-                return forwardToFallback();
-            }
             return fetchPageResponse;
         } catch (error) {
-            return forwardToFallback();
+            return new Response("Error resolving request", { status: HttpStatusCodes.NOT_FOUND });
         }
     }
 

--- a/portal/server/app/route.ts
+++ b/portal/server/app/route.ts
@@ -30,8 +30,7 @@ export async function GET(req: Request) {
     const requestDomain = getDomain(url);
 
     if (requestDomain == portalDomain && parsedUrl && parsedUrl.subdomain) {
-        const fetchPageResponse = await resolveAndFetchPage(parsedUrl, null);
-        return fetchPageResponse;
+        return await resolveAndFetchPage(parsedUrl, null);
     }
 
     const atBaseUrl = portalDomain == url.host.split(":")[0];

--- a/portal/server/app/route.ts
+++ b/portal/server/app/route.ts
@@ -5,7 +5,6 @@ import { getDomain, getSubdomainAndPath } from "@lib/domain_parsing";
 import { redirectToAggregatorUrlResponse, redirectToPortalURLResponse } from "@lib/redirects";
 import { getBlobIdLink, getObjectIdLink } from "@lib/links";
 import { resolveAndFetchPage } from "@lib/page_fetching";
-import { HttpStatusCodes } from "@lib/http/http_status_codes";
 
 export async function GET(req: Request) {
     const originalUrl = req.headers.get("x-original-url");
@@ -31,12 +30,8 @@ export async function GET(req: Request) {
     const requestDomain = getDomain(url);
 
     if (requestDomain == portalDomain && parsedUrl && parsedUrl.subdomain) {
-        try {
-            const fetchPageResponse = await resolveAndFetchPage(parsedUrl, null);
-            return fetchPageResponse;
-        } catch (error) {
-            return new Response("Error resolving request", { status: HttpStatusCodes.NOT_FOUND });
-        }
+        const fetchPageResponse = await resolveAndFetchPage(parsedUrl, null);
+        return fetchPageResponse;
     }
 
     const atBaseUrl = portalDomain == url.host.split(":")[0];

--- a/portal/worker/src/walrus-sites-sw.ts
+++ b/portal/worker/src/walrus-sites-sw.ts
@@ -50,7 +50,7 @@ self.addEventListener("fetch", async (event) => {
 
     if (requestDomain === portalDomain && parsedUrl && parsedUrl.subdomain) {
 
-        // Handle caching and fetching based on cache availability
+        // Fetches the page resources and handles the cache if it exists
         const handleFetchRequest = async (): Promise<Response> => {
             if ("caches" in self) {
                 return await fetchFromCache();

--- a/portal/worker/src/walrus-sites-sw.ts
+++ b/portal/worker/src/walrus-sites-sw.ts
@@ -1,13 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { NETWORK } from "@lib/constants";
 import { getDomain, getSubdomainAndPath } from "@lib/domain_parsing";
 import { redirectToAggregatorUrlResponse, redirectToPortalURLResponse } from "@lib/redirects";
 import { getBlobIdLink, getObjectIdLink } from "@lib/links";
 import resolveWithCache from "./caching";
 import { resolveAndFetchPage, resolveObjectId } from "@lib/page_fetching";
-import { HttpStatusCodes } from "@lib/http/http_status_codes";
 
 // This is to get TypeScript to recognize `clients` and `self` Default type of `self` is
 // `WorkerGlobalScope & typeof globalThis` https://github.com/microsoft/TypeScript/issues/14877
@@ -53,11 +51,7 @@ self.addEventListener("fetch", async (event) => {
     if (requestDomain === portalDomain && parsedUrl && parsedUrl.subdomain) {
         // Fetches the page resources.
         const handleFetchRequest = async (): Promise<Response> => {
-            try {
-                return await fetchWithCacheSupport();
-            } catch (error) {
-                return handleFetchError(error);
-            }
+            return await fetchWithCacheSupport();
         };
 
         // Handle caching and fetching based on cache availability
@@ -85,12 +79,6 @@ self.addEventListener("fetch", async (event) => {
         const fetchDirectly = async (): Promise<Response> => {
             const response = await resolveAndFetchPage(parsedUrl, null);
             return response;
-        };
-
-        // Handle error during fetching
-        const handleFetchError = (error: any): Response => {
-            console.error("Error resolving request:", error);
-            return new Response("Error resolving request", { status: HttpStatusCodes.NOT_FOUND });
         };
 
         event.respondWith(handleFetchRequest());

--- a/portal/worker/src/walrus-sites-sw.ts
+++ b/portal/worker/src/walrus-sites-sw.ts
@@ -49,18 +49,14 @@ self.addEventListener("fetch", async (event) => {
     console.log("Parsed URL: ", parsedUrl);
 
     if (requestDomain === portalDomain && parsedUrl && parsedUrl.subdomain) {
-        // Fetches the page resources.
-        const handleFetchRequest = async (): Promise<Response> => {
-            return await fetchWithCacheSupport();
-        };
 
         // Handle caching and fetching based on cache availability
-        const fetchWithCacheSupport = async (): Promise<Response> => {
+        const handleFetchRequest = async (): Promise<Response> => {
             if ("caches" in self) {
                 return await fetchFromCache();
             } else {
                 console.warn("Cache API not available");
-                return await fetchDirectly();
+                return await resolveAndFetchPage(parsedUrl, null);
             }
         };
 
@@ -71,14 +67,7 @@ self.addEventListener("fetch", async (event) => {
             if (typeof resolvedObjectId !== "string") {
                 return resolvedObjectId;
             }
-            const cachedResponse = await resolveWithCache(resolvedObjectId, parsedUrl, urlString);
-            return cachedResponse;
-        };
-
-        // Fetch directly and fallback if necessary
-        const fetchDirectly = async (): Promise<Response> => {
-            const response = await resolveAndFetchPage(parsedUrl, null);
-            return response;
+            return await resolveWithCache(resolvedObjectId, parsedUrl, urlString);
         };
 
         event.respondWith(handleFetchRequest());


### PR DESCRIPTION
The portal previously included a mechanism to redirect requests to devnet as a fallback in the event of a failure or a 404 (Not Found) response. **This pull request removes that fallback functionality**.

**Changes** 

- Removed the fallback to FALLBACK_DEVNET_PORTAL in the main routing logic.
- Simplified the fetch process by eliminating proxyFetch and fallback handling.
- Streamlined code to directly return responses or appropriate errors without devnet fallback references.