### PR TITLE
fix(service-worker): sw PORTAL_DOMAIN_NAME_LENGTH unavailable

### DIFF
--- a/portal/common/lib/domain_parsing.test.ts
+++ b/portal/common/lib/domain_parsing.test.ts
@@ -28,6 +28,20 @@ describe('getDomain', () => {
     })
 })
 
+const getDomainWithPortalNameLengthTestCases: [string, string][] = [
+    ['https://sw-tnet.blocksite.net', 'sw-tnet.blocksite.net'],
+    ['https://subname.sw-tnet.blocksite.net', 'sw-tnet.blocksite.net']
+]
+
+describe('getDomain with portal name length', () => {
+    getDomainWithPortalNameLengthTestCases.forEach(([input, expected]) => {
+        test(`${input} -> ${expected}`, () => {
+            const domain = getDomain(new URL(input), 21)
+                expect(domain).toEqual(expected)
+        })
+    })
+})
+
 const getSubdomainAndPathTestCases: [string, DomainDetails][] = [
     ['https://subname.name.walrus.site/', {subdomain: 'subname.name', path: '/index.html' }],
     ['https://name.walrus.site/', { subdomain: 'name', path: '/index.html' }],
@@ -50,6 +64,23 @@ describe('getSubdomainAndPath', () => {
                 path: ${path.path ?? "null"}`,
                 () => {
                     expect(getSubdomainAndPath(new URL(input))).toEqual(path);
+                });
+        });
+})
+
+
+const getSubdomainAndPathWithPortalLengthTestCases: [string, DomainDetails][] = [
+    ['https://subname.name.sw-tnet.blocksite.net/', {subdomain: 'subname.name', path: '/index.html' }],
+    ['https://name.sw-tnet.blocksite.net/', { subdomain: 'name', path: '/index.html' }],
+]
+describe('getSubdomainAndPath', () => {
+    getSubdomainAndPathWithPortalLengthTestCases.forEach(
+        ([input, path]) => {
+            test(`${input} ->
+                subdomain: ${path.subdomain ?? "null"},
+                path: ${path.path ?? "null"}`,
+                () => {
+                    expect(getSubdomainAndPath(new URL(input), 21)).toEqual(path);
                 });
         });
 })

--- a/portal/common/lib/domain_parsing.test.ts
+++ b/portal/common/lib/domain_parsing.test.ts
@@ -5,6 +5,8 @@ import { describe, expect, test } from 'vitest'
 import { getDomain, getSubdomainAndPath } from './domain_parsing'
 import { DomainDetails } from './types'
 
+const PORTAL_DOMAIN_NAME_LENGTH = 21
+
 const getDomainTestCases: [string, string][] = [
     ['https://example.com', 'example.com'],
     ['https://suinsname.localhost:8080', 'localhost'],
@@ -36,7 +38,7 @@ const getDomainWithPortalNameLengthTestCases: [string, string][] = [
 describe('getDomain with portal name length', () => {
     getDomainWithPortalNameLengthTestCases.forEach(([input, expected]) => {
         test(`${input} -> ${expected}`, () => {
-            const domain = getDomain(new URL(input), 21)
+            const domain = getDomain(new URL(input), PORTAL_DOMAIN_NAME_LENGTH)
                 expect(domain).toEqual(expected)
         })
     })
@@ -70,8 +72,10 @@ describe('getSubdomainAndPath', () => {
 
 
 const getSubdomainAndPathWithPortalLengthTestCases: [string, DomainDetails][] = [
-    ['https://subname.name.sw-tnet.blocksite.net/', {subdomain: 'subname.name', path: '/index.html' }],
-    ['https://name.sw-tnet.blocksite.net/', { subdomain: 'name', path: '/index.html' }],
+    ['https://subname.name.sw-tnet.blocksite.net/',
+        {subdomain: 'subname.name', path: '/index.html' }],
+    ['https://name.sw-tnet.blocksite.net/',
+        { subdomain: 'name', path: '/index.html' }],
 ]
 describe('getSubdomainAndPath', () => {
     getSubdomainAndPathWithPortalLengthTestCases.forEach(
@@ -80,7 +84,9 @@ describe('getSubdomainAndPath', () => {
                 subdomain: ${path.subdomain ?? "null"},
                 path: ${path.path ?? "null"}`,
                 () => {
-                    expect(getSubdomainAndPath(new URL(input), 21)).toEqual(path);
+                    expect(getSubdomainAndPath(
+                        new URL(input), PORTAL_DOMAIN_NAME_LENGTH
+                    )).toEqual(path);
                 });
         });
 })

--- a/portal/common/lib/domain_parsing.ts
+++ b/portal/common/lib/domain_parsing.ts
@@ -9,8 +9,8 @@ import { UrlExtract, DomainDetails } from "./types/index";
  * @param orig_url The URL to extract the domain from. e.g. "https://example.com"
  * @returns The domain of the URL. e.g. "example.com"
  */
-export function getDomain(url: URL): string | null {
-    return splitUrl(url).domain;
+export function getDomain(url: URL, portalNameLength?: Number): string | null {
+    return splitUrl(url, portalNameLength).domain;
 }
 
 /**
@@ -18,8 +18,8 @@ export function getDomain(url: URL): string | null {
 * @param url e.g. "https://subname.name.walrus.site/"
 * @returns domain details e.g. { subdomain: "subname", path: "/index.html"}
 */
-export function getSubdomainAndPath(url: URL): DomainDetails | null {
-    return splitUrl(url).details;
+export function getSubdomainAndPath(url: URL, portalNameLength?: Number): DomainDetails | null {
+    return splitUrl(url, portalNameLength).details;
 }
 
 /**
@@ -29,13 +29,18 @@ export function getSubdomainAndPath(url: URL): DomainDetails | null {
     {domain: name.walrus.site,
     { subdomain: "subname", path: "/index.html"}}
 */
-function splitUrl(url: URL): UrlExtract {
+function splitUrl(url: URL, portalNameLength?: Number): UrlExtract {
     const parsed = parseDomain(url.hostname);
     let domain: string | null = null;
     let subdomain: string | null = null;
     if (parsed.type === ParseResultType.Listed) {
-        domain = domain = parsed.domain + "." + parsed.topLevelDomains.join(".")
-        subdomain = parsed.subDomains.join(".")
+        if (portalNameLength) {
+            domain = parsed.hostname.slice(-portalNameLength)
+            subdomain = parsed.hostname.slice(0, -portalNameLength - 1)
+        } else {
+            domain = parsed.domain + "." + parsed.topLevelDomains.join(".")
+            subdomain = parsed.subDomains.join(".")
+        }
     } else if (parsed.type === ParseResultType.Reserved) {
         domain = parsed.labels[parsed.labels.length - 1];
         subdomain = parsed.labels.slice(0, parsed.labels.length - 1).join('.');

--- a/portal/common/lib/redirects.ts
+++ b/portal/common/lib/redirects.ts
@@ -9,9 +9,11 @@ import { SuiObjectResponse } from "@mysten/sui/client";
 /**
  * Redirects to the portal URL.
  */
-export function redirectToPortalURLResponse(scope: URL, path: DomainDetails): Response {
+export function redirectToPortalURLResponse(
+    scope: URL, path: DomainDetails, portalDomainNameLength?: number
+): Response {
     // Redirect to the walrus site for the specified domain and path
-    const redirectUrl = getPortalUrl(path, scope.href);
+    const redirectUrl = getPortalUrl(path, scope.href, portalDomainNameLength);
     console.log("Redirecting to the Walrus Site link: ", path, redirectUrl);
     return makeRedirectResponse(redirectUrl);
 }
@@ -52,9 +54,12 @@ function makeRedirectResponse(url: string): Response {
 /**
  * Returns the url for the Portal, given a subdomain and a path.
  */
-function getPortalUrl(path: DomainDetails, scope: string): string {
+function getPortalUrl(path: DomainDetails,
+    scope: string,
+    portalDomainNameLength?: number
+): string {
     const scopeUrl = new URL(scope);
-    const portalDomain = getDomain(scopeUrl);
+    const portalDomain = getDomain(scopeUrl, portalDomainNameLength);
     let portString = "";
     if (scopeUrl.port) {
         portString = ":" + scopeUrl.port;

--- a/portal/server/app/route.ts
+++ b/portal/server/app/route.ts
@@ -14,10 +14,17 @@ export async function GET(req: Request) {
     }
     const url = new URL(originalUrl);
 
+    // Check if the request is for a site.
+    let portalDomainNameLengthString = process.env.PORTAL_DOMAIN_NAME_LENGTH;
+    let portalDomainNameLength: number | undefined;
+    if (process.env.PORTAL_DOMAIN_NAME_LENGTH) {
+        portalDomainNameLength = Number(portalDomainNameLengthString);
+    }
+
     const objectIdPath = getObjectIdLink(url.toString());
     if (objectIdPath) {
         console.log(`Redirecting to portal url response: ${url.toString()} from ${objectIdPath}`);
-        return redirectToPortalURLResponse(url, objectIdPath);
+        return redirectToPortalURLResponse(url, objectIdPath, portalDomainNameLength);
     }
     const walrusPath: string | null = getBlobIdLink(url.toString());
     if (walrusPath) {
@@ -25,12 +32,6 @@ export async function GET(req: Request) {
         return redirectToAggregatorUrlResponse(url, walrusPath);
     }
 
-    // Check if the request is for a site.
-    let portalDomainNameLengthString = process.env.PORTAL_DOMAIN_NAME_LENGTH;
-    let portalDomainNameLength: Number | undefined;
-    if (process.env.PORTAL_DOMAIN_NAME_LENGTH) {
-        portalDomainNameLength = Number(portalDomainNameLengthString);
-    }
     const parsedUrl = getSubdomainAndPath(url, Number(portalDomainNameLength));
     const portalDomain = getDomain(url, Number(portalDomainNameLength));
     const requestDomain = getDomain(url, Number(portalDomainNameLength));

--- a/portal/server/app/route.ts
+++ b/portal/server/app/route.ts
@@ -26,9 +26,14 @@ export async function GET(req: Request) {
     }
 
     // Check if the request is for a site.
-    const parsedUrl = getSubdomainAndPath(url);
-    const portalDomain = getDomain(url);
-    const requestDomain = getDomain(url);
+    let portalDomainNameLengthString = process.env.PORTAL_DOMAIN_NAME_LENGTH;
+    let portalDomainNameLength: Number | undefined;
+    if (process.env.PORTAL_DOMAIN_NAME_LENGTH) {
+        portalDomainNameLength = Number(portalDomainNameLengthString);
+    }
+    const parsedUrl = getSubdomainAndPath(url, Number(portalDomainNameLength));
+    const portalDomain = getDomain(url, Number(portalDomainNameLength));
+    const requestDomain = getDomain(url, Number(portalDomainNameLength));
 
     if (requestDomain == portalDomain && parsedUrl && parsedUrl.subdomain) {
         const forwardToFallback = async () => {

--- a/portal/server/next-env.d.ts
+++ b/portal/server/next-env.d.ts
@@ -5,3 +5,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/portal/worker/src/walrus-sites-sw.ts
+++ b/portal/worker/src/walrus-sites-sw.ts
@@ -31,9 +31,15 @@ self.addEventListener("fetch", async (event) => {
     const scopeString = self.registration.scope;
     const scope = new URL(scopeString);
 
+    // Check if the request is for a site.
+    let portalDomainNameLengthString = process.env.PORTAL_DOMAIN_NAME_LENGTH;
+    let portalDomainNameLength: number | undefined;
+    if (process.env.PORTAL_DOMAIN_NAME_LENGTH) {
+        portalDomainNameLength = Number(portalDomainNameLengthString);
+    }
     const objectIdPath = getObjectIdLink(urlString);
     if (objectIdPath) {
-        event.respondWith(redirectToPortalURLResponse(scope, objectIdPath));
+        event.respondWith(redirectToPortalURLResponse(scope, objectIdPath, portalDomainNameLength));
         return;
     }
 
@@ -43,12 +49,6 @@ self.addEventListener("fetch", async (event) => {
         return;
     }
 
-    // Check if the request is for a site.
-    let portalDomainNameLengthString = process.env.PORTAL_DOMAIN_NAME_LENGTH;
-    let portalDomainNameLength: Number | undefined;
-    if (process.env.PORTAL_DOMAIN_NAME_LENGTH) {
-        portalDomainNameLength = Number(portalDomainNameLengthString);
-    }
     const parsedUrl = getSubdomainAndPath(url, Number(portalDomainNameLength));
     const portalDomain = getDomain(url, Number(portalDomainNameLength));
     const requestDomain = getDomain(url, Number(portalDomainNameLength));

--- a/portal/worker/src/walrus-sites-sw.ts
+++ b/portal/worker/src/walrus-sites-sw.ts
@@ -44,9 +44,14 @@ self.addEventListener("fetch", async (event) => {
     }
 
     // Check if the request is for a site.
-    const parsedUrl = getSubdomainAndPath(url);
-    const portalDomain = getDomain(scope);
-    const requestDomain = getDomain(url);
+    let portalDomainNameLengthString = process.env.PORTAL_DOMAIN_NAME_LENGTH;
+    let portalDomainNameLength: Number | undefined;
+    if (process.env.PORTAL_DOMAIN_NAME_LENGTH) {
+        portalDomainNameLength = Number(portalDomainNameLengthString);
+    }
+    const parsedUrl = getSubdomainAndPath(url, Number(portalDomainNameLength));
+    const portalDomain = getDomain(url, Number(portalDomainNameLength));
+    const requestDomain = getDomain(url, Number(portalDomainNameLength));
 
     console.log("Portal domain and request domain: ", portalDomain, requestDomain);
     console.log("Parsed URL: ", parsedUrl);

--- a/portal/worker/webpack.config.common.js
+++ b/portal/worker/webpack.config.common.js
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 const path = require("path");
+const webpack = require("webpack");
 const CopyPlugin = require("copy-webpack-plugin");
 
 module.exports = {
@@ -36,6 +37,11 @@ module.exports = {
         extensions: [".ts", ".js", ".html"],
     },
     plugins: [
+        new webpack.DefinePlugin({
+            'process.env.PORTAL_DOMAIN_NAME_LENGTH': JSON.stringify(
+                process.env.PORTAL_DOMAIN_NAME_LENGTH || undefined
+            )
+        }),
         new CopyPlugin({
             patterns: [
                 {


### PR DESCRIPTION
The service worker is not working on the testnet service worker portal because it can't access the process object. 

I had to specify the PORTAL_DOMAIN_NAME_LENGTH in the webpack config, so that it is defined upon the build phase.