### PR TITLE
fix(service-worker & cache): remove checkCachedVersionMatchesOnChain

### DIFF
--- a/portal/worker/src/caching.ts
+++ b/portal/worker/src/caching.ts
@@ -6,7 +6,7 @@ import { DomainDetails } from "@lib/types";
 import rpcSelectorSingleton from "@lib/rpc_selector";
 
 const CACHE_NAME = "walrus-sites-cache";
-const CACHE_EXPIRATION_TIME = 60 * 60 * 1000; // 1 hour in milliseconds
+const CACHE_EXPIRATION_TIME = 60 * 1000; // 1 minute in milliseconds
 
 /**
  * Respond to the request using the cache API.

--- a/portal/worker/src/caching.ts
+++ b/portal/worker/src/caching.ts
@@ -3,7 +3,6 @@
 
 import { resolveAndFetchPage } from "@lib/page_fetching";
 import { DomainDetails } from "@lib/types";
-import rpcSelectorSingleton from "@lib/rpc_selector";
 
 const CACHE_NAME = "walrus-sites-cache";
 const CACHE_EXPIRATION_TIME = 60 * 1000; // 1 minute in milliseconds

--- a/portal/worker/src/walrus-sites-sw.ts
+++ b/portal/worker/src/walrus-sites-sw.ts
@@ -5,7 +5,7 @@ import { getDomain, getSubdomainAndPath } from "@lib/domain_parsing";
 import { redirectToAggregatorUrlResponse, redirectToPortalURLResponse } from "@lib/redirects";
 import { getBlobIdLink, getObjectIdLink } from "@lib/links";
 import resolveWithCache from "./caching";
-import { resolveAndFetchPage, resolveObjectId } from "@lib/page_fetching";
+import { resolveAndFetchPage } from "@lib/page_fetching";
 
 // This is to get TypeScript to recognize `clients` and `self` Default type of `self` is
 // `WorkerGlobalScope & typeof globalThis` https://github.com/microsoft/TypeScript/issues/14877
@@ -68,11 +68,7 @@ self.addEventListener("fetch", async (event) => {
         // Attempt to fetch from cache
         const fetchFromCache = async (): Promise<Response> => {
             console.log("Pre-fetching the sui object ID");
-            const resolvedObjectId = await resolveObjectId(parsedUrl);
-            if (typeof resolvedObjectId !== "string") {
-                return resolvedObjectId;
-            }
-            return await resolveWithCache(resolvedObjectId, parsedUrl, urlString);
+            return await resolveWithCache(parsedUrl, urlString);
         };
 
         event.respondWith(handleFetchRequest());


### PR DESCRIPTION
1. Fixed the issue of the caching mechanism always "missing" in the service worker.
2. Updated the CACHE_EXPIRATION_TIME to 1 hour.

The resolveObjectId function would only be called on the site::Site object and not for each Resource (which makes sense as it is doing the suins-to-objectId resolution).

However, this meant that a lot of requests would be tagged as "cache miss" incorrectly, because the
site::Site version would be compared with the
site::Resource version inside the checkCachedVersionMatchesOnChain.

Thinking more about it, the end goal of using a cache is to avoid making requests to the RPC nodes.
Always checking for the sui object version contradicts this. Therefore I decided to remove the checkCachedVersionMatchesOnChain altogether.

Remember that caches expire, so at some point the resource contents will be updated anyway.