### PR TITLE
feat(docs): include a star-history graph and update the portal description

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,14 @@ Documentation of Walrus and Walrus Sites is available at [docs.walrus.site](http
 ## Repo structure
 
 - [`move`](./move/) contains the smart contract for creating and updating Walrus Sites on chain.
-- [`portal`](./portal/) is the implementation of a portal to access Walrus Sites. It is based on
-  service workers.
+- [`portal`](./portal/) contains the implementations of the portals to access Walrus Sites.
 - The [`site-builder`](./site-builder/) is a Rust cli tool to create Walrus Sites, starting from the
   output of a standard website building tool (i.e., a directory containing html/css/js).
-- In [`examples`](./examples/) there is a collection of websites to test the functions of the Walrus
+- In [`examples`](./examples/) there is a handy collection of websites to test the functions of the Walrus
   Sites.
+
+## Star History
+
+Walrus Sites is open source! Here is a graph showing the star history over time.
+
+[![Star History Chart](https://api.star-history.com/svg?repos=MystenLabs/walrus-sites&type=Date)](https://star-history.com/#MystenLabs/walrus-sites&Date)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repo contains the various components of a working [Walrus
 Site](https://docs.walrus.site/walrus-sites/intro.html). The resources of a Walrus Site are stored
 on Walrus, and the metadata and ownership of the site is managed through Sui.
 
-Documentation of Walrus and Walrus Sites is available at [docs.walrus.site](https://docs.walrus.site).
+Documentation of Walrus and Walrus Sites is available at [docs.walrus.site](https://docs.walrus.site/walrus-sites/intro.html).
 
 ## Repo structure
 
@@ -14,6 +14,7 @@ Documentation of Walrus and Walrus Sites is available at [docs.walrus.site](http
   output of a standard website building tool (i.e., a directory containing html/css/js).
 - In [`examples`](./examples/) there is a handy collection of websites to test the functions of the Walrus
   Sites.
+- In [`c4`](./c4/) there is the C4 model depicting the architecture of the project.
 
 ## Star History
 


### PR DESCRIPTION
- start history: https://star-history.com/#MystenLabs/walrus-sites&Date.
- portal description: the README referred to only a single portal; the service worker. Now we have more, so I updated it.
- add a bullet point explaining what the `c4/` directory is used for.
- link directly to the walrus-sites docs instead of the walrus docs. 