### PR TITLE
feat: add second rpc that support suins

### DIFF
--- a/portal/common/lib/constants.ts
+++ b/portal/common/lib/constants.ts
@@ -18,7 +18,7 @@ export const RESOURCE_PATH_MOVE_TYPE = SITE_PACKAGE + "::site::ResourcePath";
 export const TESTNET_RPC_LIST = [
     'https://fullnode.testnet.sui.io',
     'https://sui-testnet.public.blastapi.io',
-    'https://sui-testnet-endpoint.blockvision.org'
+    'https://testnet.suiet.app'
 ];
 
 export const RPC_REQUEST_TIMEOUT_MS = 7000;


### PR DESCRIPTION
Add `https://testnet.suiet.app` as the second rpc that supports suins on testnet.