### PR TITLE
fix: update info-output format and make request for n_shards more robust

### DIFF
--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -309,7 +309,7 @@ impl ResourceManager {
         ws_resources_path: Option<PathBuf>,
         max_concurrent: Option<NonZeroUsize>,
     ) -> Result<Self> {
-        let n_shards = walrus.info(false).await?.n_shards;
+        let n_shards = walrus.n_shards().await?;
 
         // Cast the keys to lowercase because http headers
         //  are case-insensitive: RFC7230 sec. 2.7.3

--- a/site-builder/src/walrus.rs
+++ b/site-builder/src/walrus.rs
@@ -7,7 +7,7 @@ use std::{num::NonZeroU16, path::PathBuf};
 
 use anyhow::{Context, Result};
 use command::RpcArg;
-use output::{try_from_output, BlobIdOutput, InfoOutput, ReadOutput, StoreOutput};
+use output::{try_from_output, BlobIdOutput, InfoOutput, NShards, ReadOutput, StoreOutput};
 use tokio::process::Command as CliCommand;
 
 use self::types::BlobId;
@@ -93,9 +93,16 @@ impl Walrus {
         create_command!(self, blob_id, file, n_shards, self.rpc_arg())
     }
 
-    /// Issues a `info` JSON command to the Walrus CLI, returning the parsed output.
+    /// Issues an `info` JSON command to the Walrus CLI, returning the parsed output.
+    #[allow(dead_code)]
     pub async fn info(&self, dev: bool) -> Result<InfoOutput> {
         create_command!(self, info, self.rpc_arg(), dev)
+    }
+
+    /// Issues an `info` JSON command to the Walrus CLI, returning the number of shards.
+    pub async fn n_shards(&self) -> Result<NonZeroU16> {
+        let n_shards: NShards = create_command!(self, info, self.rpc_arg(), false)?;
+        Ok(n_shards.n_shards)
     }
 
     fn base_command(&self) -> CliCommand {

--- a/site-builder/src/walrus/output.rs
+++ b/site-builder/src/walrus/output.rs
@@ -3,7 +3,7 @@
 
 //! The output of running commands on the Walrus CLI.
 
-use std::{num::NonZeroU16, path::PathBuf, process::Output};
+use std::{num::NonZeroU16, path::PathBuf, process::Output, time::Duration};
 
 use anyhow::{anyhow, Context, Result};
 use serde::{de::DeserializeOwned, Deserialize};
@@ -176,15 +176,26 @@ pub(crate) struct InfoOutput {
     pub(crate) n_shards: NonZeroU16,
     pub(crate) n_nodes: usize,
     pub(crate) storage_unit_size: u64,
-    pub(crate) price_per_unit_size: u64,
+    pub(crate) storage_price_per_unit_size: u64,
+    pub(crate) write_price_per_unit_size: u64,
     pub(crate) max_blob_size: u64,
     pub(crate) marginal_size: u64,
     pub(crate) metadata_price: u64,
     pub(crate) marginal_price: u64,
+    pub(crate) epoch_duration: Duration,
+    pub(crate) max_epochs_ahead: u32,
     #[serde(skip_deserializing)]
     pub(crate) example_blobs: String,
     #[serde(skip_deserializing)]
     pub(crate) dev_info: String,
+}
+
+/// The number of shards, which can be deserialized from the output of the `info` command.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+pub(crate) struct NShards {
+    pub(crate) n_shards: NonZeroU16,
 }
 
 pub fn try_from_output<T: DeserializeOwned>(output: Output) -> Result<T> {


### PR DESCRIPTION
Updates the info-output format to align it with changes in https://github.com/MystenLabs/walrus/pull/1204.