### PR TITLE
refactor(portal): make sp locally deployable and vercel independent

### DIFF
--- a/portal/server/app/route.ts
+++ b/portal/server/app/route.ts
@@ -9,7 +9,7 @@ import { siteNotFound } from "@lib/http/http_error_responses";
 import integrateLoggerWithSentry from "sentry_logger";
 import blocklistChecker from "custom_blocklist_checker";
 
-if (process.env.NODE_ENV === "production") {
+if (process.env.ENABLE_SENTRY === "true") {
     // Only integrate Sentry on production.
     integrateLoggerWithSentry();
 }

--- a/portal/server/custom_blocklist_checker.ts
+++ b/portal/server/custom_blocklist_checker.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { has } from '@vercel/edge-config';
+import BlocklistChecker from "@lib/blocklist_checker";
+
+/**
+* Defines a blocklistChecker that is integrated with Vercel's Edge Config.
+* This means that the blocklistChecker will check if a domain is in the blocklist
+* by calling the Vercel Edge Config API.
+*
+* @returns {BlocklistChecker} The blocklistChecker that is integrated with Vercel's Edge Config.
+*/
+function create_blocklist_checker(): BlocklistChecker {
+    const blocklistChecker = new BlocklistChecker(
+        (id: string) => {
+            console.log(`Checking if the "${id}" suins domain is in the blocklist...`);
+            return has(id)
+        }
+    );
+    return blocklistChecker;
+}
+
+let blocklistChecker: BlocklistChecker | undefined;
+if (process.env.NODE_ENV === "production") {
+    blocklistChecker = create_blocklist_checker();
+}
+export default blocklistChecker;

--- a/portal/server/custom_blocklist_checker.ts
+++ b/portal/server/custom_blocklist_checker.ts
@@ -22,7 +22,7 @@ function create_blocklist_checker(): BlocklistChecker {
 }
 
 let blocklistChecker: BlocklistChecker | undefined;
-if (process.env.NODE_ENV === "production") {
+if (process.env.ENABLE_BLOCKLIST === "true") {
     blocklistChecker = create_blocklist_checker();
 }
 export default blocklistChecker;

--- a/portal/server/next.config.mjs
+++ b/portal/server/next.config.mjs
@@ -1,9 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-
 import {withSentryConfig} from '@sentry/nextjs';
-// Copyright (c) Mysten Labs, Inc.
-// SPDX-License-Identifier: Apache-2.0
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {

--- a/portal/server/sentry.client.config.ts
+++ b/portal/server/sentry.client.config.ts
@@ -7,7 +7,7 @@
 
 import * as Sentry from "@sentry/nextjs";
 
-if (process.env.NODE_ENV === "production") {
+if (process.env.ENABLE_SENTRY === "production") {
     Sentry.init({
         dsn: process.env.SENTRY_DSN,
 

--- a/portal/server/sentry.client.config.ts
+++ b/portal/server/sentry.client.config.ts
@@ -7,12 +7,14 @@
 
 import * as Sentry from "@sentry/nextjs";
 
-Sentry.init({
-  dsn: process.env.SENTRY_DSN,
+if (process.env.NODE_ENV === "production") {
+    Sentry.init({
+        dsn: process.env.SENTRY_DSN,
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
+        // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
+        tracesSampleRate: 1,
 
-  // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: true,
-});
+        // Setting this option to true will print useful information to the console while you're setting up Sentry.
+        debug: true,
+    });
+}

--- a/portal/server/sentry.edge.config.ts
+++ b/portal/server/sentry.edge.config.ts
@@ -8,12 +8,14 @@
 
 import * as Sentry from "@sentry/nextjs";
 
-Sentry.init({
-  dsn: process.env.SENTRY_DSN,
+if (process.env.NODE_ENV === "production") {
+    Sentry.init({
+        dsn: process.env.SENTRY_DSN,
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
+        // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
+        tracesSampleRate: 1,
 
-  // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: false,
-});
+        // Setting this option to true will print useful information to the console while you're setting up Sentry.
+        debug: false,
+    });
+}

--- a/portal/server/sentry.edge.config.ts
+++ b/portal/server/sentry.edge.config.ts
@@ -8,7 +8,7 @@
 
 import * as Sentry from "@sentry/nextjs";
 
-if (process.env.NODE_ENV === "production") {
+if (process.env.ENABLE_SENTRY === "production") {
     Sentry.init({
         dsn: process.env.SENTRY_DSN,
 

--- a/portal/server/sentry.server.config.ts
+++ b/portal/server/sentry.server.config.ts
@@ -7,12 +7,14 @@
 
 import * as Sentry from "@sentry/nextjs";
 
-Sentry.init({
-  dsn: process.env.SENTRY_DSN,
+if (process.env.NODE_ENV === "production") {
+    Sentry.init({
+        dsn: process.env.SENTRY_DSN,
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
+        // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
+        tracesSampleRate: 1,
 
-  // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: false,
-});
+        // Setting this option to true will print useful information to the console while you're setting up Sentry.
+        debug: false,
+    });
+}

--- a/portal/server/sentry.server.config.ts
+++ b/portal/server/sentry.server.config.ts
@@ -7,7 +7,7 @@
 
 import * as Sentry from "@sentry/nextjs";
 
-if (process.env.NODE_ENV === "production") {
+if (process.env.ENABLE_SENTRY === "production") {
     Sentry.init({
         dsn: process.env.SENTRY_DSN,
 

--- a/portal/server/sentry_logger.ts
+++ b/portal/server/sentry_logger.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import logger from "@lib/logger";
+import * as Sentry from "@sentry/node";
+
+function addLoggingArgsToSentry(args: { [key: string]: any }) {
+    Object.entries(args).forEach(([key, value]) => {
+        if (key !== "message") { // Skipping the 'message' key
+            console.log(`${key}: ${value}`)
+            Sentry.setTag(key, value);
+        }
+    });
+}
+
+function integrateLoggerWithSentry() {
+    logger.setErrorPredicate(args => {
+        addLoggingArgsToSentry(args);
+        Sentry.captureException(new Error(args.message ))
+    });
+    logger.setWarnPredicate(args => {
+        addLoggingArgsToSentry(args);
+        Sentry.addBreadcrumb({ message: args.message, data: args, level: 'warning' })
+    } );
+    logger.setInfoPredicate(args => {
+        addLoggingArgsToSentry(args);
+        Sentry.addBreadcrumb({ message: args.message, data: args, level: 'info'})
+    } );
+    logger.setDebugPredicate(args => {
+        addLoggingArgsToSentry(args);
+        Sentry.addBreadcrumb({ message: args.message, data: args, level: 'debug' })
+    });
+}
+
+export default integrateLoggerWithSentry;

--- a/portal/worker/webpack.config.common.js
+++ b/portal/worker/webpack.config.common.js
@@ -40,6 +40,9 @@ module.exports = {
         new webpack.DefinePlugin({
             'process.env.PORTAL_DOMAIN_NAME_LENGTH': JSON.stringify(
                 process.env.PORTAL_DOMAIN_NAME_LENGTH || undefined
+            ),
+            'process.env.RPC_URL_LIST': JSON.stringify(
+                process.env.RPC_URL_LIST || undefined
             )
         }),
         new CopyPlugin({


### PR DESCRIPTION
- Create `sentry_logger.ts`
- Create `custom_blocklist_checker.ts`
- Only integrate sentry and edge config upon production deployments, i.e. when running `pnpm run serve:prod:server`