### PR TITLE
fix(portal): add content type headers for RedirectResponse

### DIFF
--- a/portal/common/lib/redirects.ts
+++ b/portal/common/lib/redirects.ts
@@ -48,6 +48,8 @@ function makeRedirectResponse(url: string): Response {
         status: 302,
         headers: {
             Location: url,
+            "Content-Type": "image/apng, image/avif/, image/jpeg, " +
+                "image/png, image/gif, image/webp, image/svg+xml",
         },
     });
 }


### PR DESCRIPTION
# Summary 

In the documentation we say that [we only support image files](http://docs.localhost:8080/walrus-sites/linking.html) but this is not specified in the redirect response headers.

As a result, the browser doesn't know how to process the file exactly, resulting in the images not loading in various html tags.

In this PR, I added a content type header to the redirect response accepting the most commonly used MIME types for images [based on the MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/MIME_types#image_types).

# Testing

1.  Download an image from walrus like this one: https://www.svgrepo.com/show/191170/walrus.svg
2. Store the image on walrus with `walrus store walrus.svg`
3. Publish a minimal walrus site that contains an image with a link to the above svg like so:
``` html
<!DOCTYPE html>
<html>
<head>
    <title>Testing Redirect Responses!</title>
</head>
<body>
    <img src="https://blobid.walrus/<the-blob-id-from-step-2>" alt="Sample Image">
</body>
</html>
```
4. `site-builder publish example-site/`
5. Browse the site: `https://<your-site>.walrus.site/`