### PR TITLE
feat(common-lib): derive routes df instead of fetch

### DIFF
--- a/portal/common/lib/constants.ts
+++ b/portal/common/lib/constants.ts
@@ -14,4 +14,3 @@ export const SITE_NAMES: { [key: string]: string } = {
 export const FALLBACK_PORTAL = "blob.store";
 // The string representing the ResourcePath struct in the walrus_site package.
 export const RESOURCE_PATH_MOVE_TYPE = SITE_PACKAGE + "::site::ResourcePath";
-export const ROUTES_MOVE_TYPE = SITE_PACKAGE + "::site::Routes";

--- a/portal/common/lib/constants.ts
+++ b/portal/common/lib/constants.ts
@@ -14,3 +14,4 @@ export const SITE_NAMES: { [key: string]: string } = {
 export const FALLBACK_PORTAL = "blob.store";
 // The string representing the ResourcePath struct in the walrus_site package.
 export const RESOURCE_PATH_MOVE_TYPE = SITE_PACKAGE + "::site::ResourcePath";
+export const ROUTES_MOVE_TYPE = SITE_PACKAGE + "::site::Routes";

--- a/portal/common/lib/routing.ts
+++ b/portal/common/lib/routing.ts
@@ -50,14 +50,13 @@ export class WalrusSitesRouter {
     /**
      * Derives and fetches the Routes dynamic field object.
      *
-     * @param client - The SuiClient instance.
-     * @param objectId - The site object ID.
+     * @param siteObjectId - The site object ID.
      * @returns The routes object.
      */
-    private async fetchRoutesDynamicFieldObject(objectId: string): Promise<SuiObjectResponse> {
+    private async fetchRoutesDynamicFieldObject(siteObjectId: string): Promise<SuiObjectResponse> {
         const routesMoveType = "vector<u8>";
         const dynamicFieldId = deriveDynamicFieldID(
-            objectId,
+            siteObjectId,
             routesMoveType,
             bcs.vector(bcs.u8()).serialize(Buffer.from("routes")).toBytes(),
         );


### PR DESCRIPTION
This change will save us from doing one additional request each time we need to fetch the `Routes` dynamic field. 

It derives the dynamic field object ID of `Routes` instead of fetching it. 