### PR TITLE
fix(server-portal): return when Routes df is not found

### DIFF
--- a/portal/common/lib/routing.ts
+++ b/portal/common/lib/routing.ts
@@ -35,6 +35,7 @@ export class WalrusSitesRouter {
             logger.warn({
                 message: "Routes dynamic field does not contain a `data` field.",
             });
+            return
         } else if (!objectData.bcs) {
             logger.warn({
                 message: "Routes dynamic field does not contain a `bcs` field.",


### PR DESCRIPTION
There was an issue in the cases when a `Routes` dynamic field was not found, an exception would be thrown instead of showing a warning and returning `undefined` a.k.a. an implication that the df was _not found_.