### PR TITLE
feat: create SENTRY_TRACES_SAMPLE_RATE env variable

### DIFF
--- a/portal/server/configuration_loader.ts
+++ b/portal/server/configuration_loader.ts
@@ -1,18 +1,17 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-type StringBoolean = 'true' | 'false';
+type StringBoolean = "true" | "false";
 function isStringBoolean(value: string): value is StringBoolean {
-    return value === 'true' || value === 'false';
+    return value === "true" || value === "false";
 }
 function toBoolean(value: string): Boolean {
-    return value === 'true';
+    return value === "true";
 }
 
-
 /**
-* Configuration based on the environment variables.
-*/
+ * Configuration based on the environment variables.
+ */
 export type Configuration = {
     edgeConfig?: string;
     edgeConfigAllowlist?: string;
@@ -25,15 +24,16 @@ export type Configuration = {
     enableSentry: Boolean;
     sentryAuthToken?: string;
     sentryDsn?: string;
-}
+    sentryTracesSampleRate?: number;
+};
 
 /**
-* A utility class that makes it safe to load the environment
-* variables of the project.
-* By using this class, we can ensure that the environment
-* variables are loaded correctly and their data types are
-* correct.
-*/
+ * A utility class that makes it safe to load the environment
+ * variables of the project.
+ * By using this class, we can ensure that the environment
+ * variables are loaded correctly and their data types are
+ * correct.
+ */
 class ConfigurationLoader {
     get config(): Configuration {
         return {
@@ -47,115 +47,130 @@ class ConfigurationLoader {
             rpcUrlList: this.loadRpcUrlList(),
             enableSentry: this.loadEnableSentry(),
             sentryAuthToken: this.loadSentryAuthToken(),
-            sentryDsn: this.loadSentryDsn()
-        }
+            sentryDsn: this.loadSentryDsn(),
+            sentryTracesSampleRate: this.loadSentryTracesSampleRate(),
+        };
     }
 
     private loadEdgeConfig(): string | undefined {
-        return this.loadEnableBlocklist() ? process.env.EDGE_CONFIG : undefined
+        return this.loadEnableBlocklist() ? process.env.EDGE_CONFIG : undefined;
     }
 
     private loadEdgeConfigAllowlist(): string | undefined {
-        return this.loadEnableAllowlist() ? process.env.EDGE_CONFIG_ALLOWLIST : undefined
+        return this.loadEnableAllowlist() ? process.env.EDGE_CONFIG_ALLOWLIST : undefined;
     }
 
     private loadEnableBlocklist(): Boolean {
         if (!process.env.ENABLE_BLOCKLIST) {
-            throw new Error('Missing ENABLE_BLOCKLIST environment variable.')
+            throw new Error("Missing ENABLE_BLOCKLIST environment variable.");
         }
-        const enable = process.env.ENABLE_BLOCKLIST.toLowerCase()
+        const enable = process.env.ENABLE_BLOCKLIST.toLowerCase();
         if (!isStringBoolean(enable)) {
-            throw new Error('ENABLE_BLOCKLIST must be "true" or "false".')
+            throw new Error('ENABLE_BLOCKLIST must be "true" or "false".');
         }
-        return toBoolean(enable)
+        return toBoolean(enable);
     }
 
     private loadEnableAllowlist(): Boolean {
         if (!process.env.ENABLE_ALLOWLIST) {
-            throw new Error('Missing ENABLE_ALLOWLIST environment variable.')
+            throw new Error("Missing ENABLE_ALLOWLIST environment variable.");
         }
-        const enable = process.env.ENABLE_ALLOWLIST.toLowerCase()
+        const enable = process.env.ENABLE_ALLOWLIST.toLowerCase();
         if (!isStringBoolean(enable)) {
-            throw new Error('ENABLE_ALLOWLIST must be "true" or "false".')
+            throw new Error('ENABLE_ALLOWLIST must be "true" or "false".');
         }
-        return toBoolean(enable)
+        return toBoolean(enable);
     }
 
     private loadLandingPageOidB36(): string {
-        const pageOidB36 = process.env.LANDING_PAGE_OID_B36
+        const pageOidB36 = process.env.LANDING_PAGE_OID_B36;
         if (!pageOidB36) {
-            throw new Error('Missing LANDING_PAGE_OID_B36 environment variable.')
+            throw new Error("Missing LANDING_PAGE_OID_B36 environment variable.");
         }
-        const base36Pattern = /^[0-9a-z]+$/i
+        const base36Pattern = /^[0-9a-z]+$/i;
         if (!base36Pattern.test(pageOidB36)) {
-            throw new Error('LANDING_PAGE_OID_B36 must be a valid base36 string.')
+            throw new Error("LANDING_PAGE_OID_B36 must be a valid base36 string.");
         }
-        return pageOidB36
+        return pageOidB36;
     }
 
     private loadPortalDomainNameLength(): number | undefined {
-        const portalDomainNameLength = process.env.PORTAL_DOMAIN_NAME_LENGTH
+        const portalDomainNameLength = process.env.PORTAL_DOMAIN_NAME_LENGTH;
         if (!portalDomainNameLength) {
-            return undefined
+            return undefined;
         }
         if (portalDomainNameLength && Number(portalDomainNameLength) <= 0) {
-            throw new Error('PORTAL_DOMAIN_NAME_LENGTH must be positive number.')
+            throw new Error("PORTAL_DOMAIN_NAME_LENGTH must be positive number.");
         }
-        return Number(portalDomainNameLength)
+        return Number(portalDomainNameLength);
     }
 
     private loadPremiumRpcUrlList(): string[] {
-        const premiumRpcUrlListString = process.env.PREMIUM_RPC_URL_LIST
+        const premiumRpcUrlListString = process.env.PREMIUM_RPC_URL_LIST;
         if (!premiumRpcUrlListString) {
-           throw new Error('Missing PREMIUM_RPC_URL_LIST environment variable.')
+            throw new Error("Missing PREMIUM_RPC_URL_LIST environment variable.");
         }
-        const premiumRpcUrlList = premiumRpcUrlListString.split(',')
+        const premiumRpcUrlList = premiumRpcUrlListString.split(",");
         if (premiumRpcUrlList.length <= 0) {
-            throw new Error('PREMIUM_RPC_URL_LIST must not be empty.')
+            throw new Error("PREMIUM_RPC_URL_LIST must not be empty.");
         }
-        return premiumRpcUrlList
+        return premiumRpcUrlList;
     }
 
     private loadRpcUrlList(): string[] {
-        const rpcUrlListString = process.env.RPC_URL_LIST
+        const rpcUrlListString = process.env.RPC_URL_LIST;
         if (!rpcUrlListString) {
-            throw new Error('Missing RPC_URL_LIST environment variable.')
+            throw new Error("Missing RPC_URL_LIST environment variable.");
         }
-        const rpcUrlList = rpcUrlListString.trim().split(',')
+        const rpcUrlList = rpcUrlListString.trim().split(",");
         if (rpcUrlList.length <= 0) {
-            throw new Error('RPC_URL_LIST must not be empty.')
+            throw new Error("RPC_URL_LIST must not be empty.");
         }
-        return rpcUrlList
+        return rpcUrlList;
     }
 
     private loadEnableSentry(): Boolean {
         if (!process.env.ENABLE_SENTRY) {
-            throw new Error('Missing ENABLE_SENTRY environment variable.')
+            throw new Error("Missing ENABLE_SENTRY environment variable.");
         }
-        const enable = process.env.ENABLE_SENTRY.toLowerCase()
+        const enable = process.env.ENABLE_SENTRY.toLowerCase();
         if (!isStringBoolean(enable)) {
-            throw new Error('ENABLE_SENTRY must be "true" or "false".')
+            throw new Error('ENABLE_SENTRY must be "true" or "false".');
         }
-        return toBoolean(enable)
+        return toBoolean(enable);
     }
 
     private loadSentryAuthToken(): string | undefined {
         if (this.loadEnableSentry()) {
-            const authToken = process.env.SENTRY_AUTH_TOKEN
+            const authToken = process.env.SENTRY_AUTH_TOKEN;
             if (!authToken) {
-                throw new Error('Missing SENTRY_AUTH_TOKEN environment variable.')
+                throw new Error("Missing SENTRY_AUTH_TOKEN environment variable.");
             }
-            return authToken
+            return authToken;
         }
     }
 
     private loadSentryDsn(): string | undefined {
         if (this.loadEnableSentry()) {
-            const dsn = process.env.SENTRY_DSN
+            const dsn = process.env.SENTRY_DSN;
             if (!dsn) {
-                throw new Error('Missing SENTRY_DSN environment variable.')
+                throw new Error("Missing SENTRY_DSN environment variable.");
             }
-            return dsn
+            return dsn;
+        }
+    }
+
+    private loadSentryTracesSampleRate(): number | undefined {
+        if (this.loadEnableSentry()) {
+            const tracesSampleRate = process.env.SENTRY_TRACES_SAMPLE_RATE;
+            if (!tracesSampleRate) {
+                throw new Error("Missing SENTRY_TRACES_SAMPLE_RATE environment variable.");
+            }
+            const rate = Number(tracesSampleRate);
+            if (rate < 0 || rate > 1) {
+                throw new Error("SENTRY_TRACES_SAMPLE_RATE must be a number between 0 and 1.");
+            }
+            return rate;
         }
     }
 }

--- a/portal/server/sentry.client.config.ts
+++ b/portal/server/sentry.client.config.ts
@@ -13,7 +13,7 @@ if (config.enableSentry) {
         dsn: config.sentryDsn,
 
         // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-        tracesSampleRate: 0.01,
+        tracesSampleRate: config.sentryTracesSampleRate,
 
         // Setting this option to true will print useful information to the console while you're setting up Sentry.
         debug: true,

--- a/portal/server/sentry.edge.config.ts
+++ b/portal/server/sentry.edge.config.ts
@@ -14,7 +14,7 @@ if (config.enableSentry) {
         dsn: config.sentryDsn,
 
         // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-        tracesSampleRate: 0.01,
+        tracesSampleRate: config.sentryTracesSampleRate,
 
         // Setting this option to true will print useful information to the console while you're setting up Sentry.
         debug: false,

--- a/portal/server/sentry.server.config.ts
+++ b/portal/server/sentry.server.config.ts
@@ -13,7 +13,7 @@ if (config.enableSentry) {
         dsn: config.sentryDsn,
 
         // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-        tracesSampleRate: 0.01,
+        tracesSampleRate: config.sentryTracesSampleRate,
 
         // Setting this option to true will print useful information to the console while you're setting up Sentry.
         debug: false,


### PR DESCRIPTION
Defining the `SENTRY_TRACES_SAMPLE_RATE`
can give us more flexibility to increase and
decrease this number based on the traffic we get
without the need of creating PRs and changing
the code directly.