### PR TITLE
chore(site-builder): general reliability improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5978,6 +5978,7 @@ dependencies = [
  "home",
  "move-core-types",
  "notify",
+ "rand",
  "regex",
  "serde",
  "serde_json",

--- a/site-builder/Cargo.toml
+++ b/site-builder/Cargo.toml
@@ -18,6 +18,7 @@ futures = "0.3.30"
 home = "0.5.9"
 move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.39.0" }
 notify = "6.1.1"
+rand = "0.8.5"
 regex = "1.11.0"
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"

--- a/site-builder/src/backoff.rs
+++ b/site-builder/src/backoff.rs
@@ -1,0 +1,238 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{num::Saturating, time::Duration};
+
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use serde::{Deserialize, Serialize};
+
+/// Wrapper for the configuration for the exponential backoff strategy.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExponentialBackoffConfig {
+    /// The minimum backoff duration.
+    pub min_backoff: Duration,
+    /// The maximum backoff duration.
+    pub max_backoff: Duration,
+    /// The maximum number of retries.
+    ///
+    /// If `None`, the backoff strategy will keep retrying indefinitely.
+    pub max_retries: Option<u32>,
+}
+
+impl ExponentialBackoffConfig {
+    /// Creates a new configuration with the given parameters.
+    #[allow(dead_code)]
+    pub fn new(min_backoff: Duration, max_backoff: Duration, max_retries: Option<u32>) -> Self {
+        ExponentialBackoffConfig {
+            min_backoff,
+            max_backoff,
+            max_retries,
+        }
+    }
+
+    /// Gets a new [`ExponentialBackoff`] strategy with the given seed from the configuration.
+    pub fn get_strategy(&self, seed: u64) -> ExponentialBackoff<StdRng> {
+        ExponentialBackoff::new_with_seed(
+            self.min_backoff,
+            self.max_backoff,
+            self.max_retries,
+            seed,
+        )
+    }
+}
+
+impl Default for ExponentialBackoffConfig {
+    fn default() -> Self {
+        ExponentialBackoffConfig {
+            min_backoff: Duration::from_secs(1),
+            max_backoff: Duration::from_secs(30),
+            max_retries: Some(10),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ExponentialBackoffState {
+    min_backoff: Duration,
+    max_backoff: Duration,
+    sequence_index: u32,
+    max_retries: Option<u32>,
+}
+
+/// The representation of a backoff strategy.
+pub trait BackoffStrategy {
+    /// Steps the backoff iterator, returning the next delay and advances the backoff.
+    ///
+    /// Returns `None` if the strategy mandates that the consumer should stop backing off.
+    fn next_delay(&mut self) -> Option<Duration>;
+}
+
+impl ExponentialBackoffState {
+    /// Creates new state with the provided minimum and maximum bounds.
+    ///
+    /// If `max_retries` is `None`, this backoff strategy will keep retrying indefinitely.
+    pub fn new(min_backoff: Duration, max_backoff: Duration, max_retries: Option<u32>) -> Self {
+        Self {
+            min_backoff,
+            max_backoff,
+            sequence_index: 0,
+            max_retries,
+        }
+    }
+
+    /// Creates a new `ExponentialBackoffTracker` that yields an infinite sequence of backoffs
+    /// between the min and max specified.
+    #[allow(dead_code)]
+    pub fn new_infinite(min_backoff: Duration, max_backoff: Duration) -> Self {
+        Self::new(min_backoff, max_backoff, None)
+    }
+
+    pub fn next_delay<R: Rng + ?Sized>(&mut self, rng: &mut R) -> Option<Duration> {
+        if let Some(max_retries) = self.max_retries {
+            if self.sequence_index >= max_retries {
+                return None;
+            }
+        }
+
+        let next_delay_value = self
+            .min_backoff
+            .saturating_mul(Saturating(2u32).pow(self.sequence_index).0)
+            .saturating_add(Self::random_offset(rng))
+            .min(self.max_backoff);
+
+        self.sequence_index = self.sequence_index.saturating_add(1);
+
+        Some(next_delay_value)
+    }
+
+    fn random_offset<R: Rng + ?Sized>(rng: &mut R) -> Duration {
+        let millis = rng.gen_range(0..=ExponentialBackoff::MAX_RAND_OFFSET_MS);
+        Duration::from_millis(millis)
+    }
+}
+
+/// An iterator over exponential wait durations.
+///
+/// Returns the wait duration for an exponential backoff with a multiplicative factor of 2, and
+/// where each duration includes a random positive offset.
+///
+/// For the `i`-th iterator element and bounds `min_backoff` and `max_backoff`, this returns the
+/// sequence `min(max_backoff, 2^i * min_backoff + rand_i)`.
+#[derive(Debug)]
+pub struct ExponentialBackoff<R> {
+    state: ExponentialBackoffState,
+    rng: R,
+}
+
+impl ExponentialBackoff<StdRng> {
+    /// Maximum number of milliseconds to randomly add to the delay time.
+    const MAX_RAND_OFFSET_MS: u64 = 1000;
+
+    /// Creates a new iterator with the provided minimum and maximum bounds,
+    /// and seeded with the provided value.
+    ///
+    /// If `max_retries` is `None`, this backoff strategy will keep retrying indefinitely.
+    pub fn new_with_seed(
+        min_backoff: Duration,
+        max_backoff: Duration,
+        max_retries: Option<u32>,
+        seed: u64,
+    ) -> ExponentialBackoff<StdRng> {
+        ExponentialBackoff::<StdRng>::new_with_rng(
+            min_backoff,
+            max_backoff,
+            max_retries,
+            StdRng::seed_from_u64(seed),
+        )
+    }
+}
+
+impl<R: Rng> ExponentialBackoff<R> {
+    /// Creates a new iterator with the provided minimum and maximum bounds, with the provided
+    /// iterator.
+    ///
+    /// If `max_retries` is `None`, this backoff strategy will keep retrying indefinitely.
+    pub fn new_with_rng(
+        min_backoff: Duration,
+        max_backoff: Duration,
+        max_retries: Option<u32>,
+        rng: R,
+    ) -> Self {
+        Self {
+            state: ExponentialBackoffState::new(min_backoff, max_backoff, max_retries),
+            rng,
+        }
+    }
+
+    fn next_delay(&mut self) -> Option<Duration> {
+        self.state.next_delay(&mut self.rng)
+    }
+}
+
+impl<R: Rng> Iterator for ExponentialBackoff<R> {
+    type Item = Duration;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next_delay()
+    }
+}
+
+impl<I> BackoffStrategy for I
+where
+    I: Iterator<Item = Duration>,
+{
+    fn next_delay(&mut self) -> Option<Duration> {
+        self.next()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use crate::backoff::ExponentialBackoff;
+
+    #[test]
+    fn backoff_is_exponential() {
+        let min = Duration::from_millis(500);
+        let max = Duration::from_secs(3600);
+
+        let expected: Vec<_> = (0u32..)
+            .map(|i| min * 2u32.pow(i))
+            .take_while(|d| *d < max)
+            .chain([max; 2])
+            .collect();
+
+        let actual: Vec<_> = ExponentialBackoff::new_with_seed(min, max, None, 42)
+            .take(expected.len())
+            .collect();
+
+        assert_eq!(expected.len(), actual.len());
+        assert_ne!(expected, actual, "retries must have a random component");
+
+        for (expected, actual) in expected.iter().zip(actual) {
+            let expected_min = *expected;
+            let expected_max =
+                *expected + Duration::from_millis(ExponentialBackoff::MAX_RAND_OFFSET_MS);
+
+            assert!(actual >= expected_min, "{actual:?} >= {expected_min:?}");
+            assert!(actual <= expected_max);
+        }
+    }
+
+    #[test]
+    fn backoff_stops_after_max_retries() {
+        let retries = 5;
+        let mut strategy = ExponentialBackoff::new_with_seed(
+            Duration::from_millis(1),
+            Duration::from_millis(5),
+            Some(retries),
+            42,
+        );
+        let mut actual = 0;
+        while let Some(_d) = strategy.next_delay() {
+            actual += 1;
+        }
+        assert_eq!(retries, actual);
+    }
+}

--- a/site-builder/src/retry_client.rs
+++ b/site-builder/src/retry_client.rs
@@ -1,0 +1,362 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Infrastructure for retrying RPC calls with backoff, in case there are network errors.
+//!
+//! Wraps the [`SuiClient`] to introduce retries.
+
+use std::{fmt::Debug, future::Future, str::FromStr};
+
+use anyhow::{bail, Result};
+use rand::{
+    rngs::{StdRng, ThreadRng},
+    Rng as _,
+};
+use serde::{de::DeserializeOwned, Serialize};
+use sui_sdk::{
+    apis::EventApi,
+    error::SuiRpcResult,
+    rpc_types::{
+        Balance,
+        Coin,
+        ObjectsPage,
+        Page,
+        SuiObjectDataOptions,
+        SuiObjectResponse,
+        SuiObjectResponseQuery,
+        SuiRawData,
+    },
+    wallet_context::WalletContext,
+    SuiClient,
+    SuiClientBuilder,
+};
+use sui_types::{
+    base_types::{ObjectID, SuiAddress},
+    dynamic_field::{derive_dynamic_field_id, DynamicFieldInfo},
+    TypeTag,
+};
+use tracing::Level;
+
+use crate::{
+    backoff::{BackoffStrategy, ExponentialBackoff, ExponentialBackoffConfig},
+    site::contracts::{
+        get_sui_object_from_object_response,
+        AssociatedContractStruct,
+        TypeOriginMap,
+    },
+    types::SuiDynamicField,
+};
+
+/// The list of HTTP status codes that are retriable.
+const RETRIABLE_RPC_ERRORS: &[&str] = &["429", "500", "502"];
+
+/// Trait to test if an error is produced by a temporary RPC failure and can be retried.
+pub trait RetriableRpcError: Debug {
+    /// Returns `true` if the error is a retriable network error.
+    fn is_retriable_rpc_error(&self) -> bool;
+}
+
+impl RetriableRpcError for anyhow::Error {
+    fn is_retriable_rpc_error(&self) -> bool {
+        self.downcast_ref::<sui_sdk::error::Error>()
+            .map(|error| error.is_retriable_rpc_error())
+            .unwrap_or(false)
+    }
+}
+
+impl RetriableRpcError for sui_sdk::error::Error {
+    fn is_retriable_rpc_error(&self) -> bool {
+        if let sui_sdk::error::Error::RpcError(rpc_error) = self {
+            let error_string = rpc_error.to_string();
+            if RETRIABLE_RPC_ERRORS
+                .iter()
+                .any(|&s| error_string.contains(s))
+            {
+                return true;
+            }
+        }
+        false
+    }
+}
+
+/// Retries the given function while it returns retriable errors.[
+async fn retry_rpc_errors<S, F, T, E, Fut>(mut strategy: S, mut func: F) -> Result<T, E>
+where
+    S: BackoffStrategy,
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, E>>,
+    E: RetriableRpcError,
+{
+    loop {
+        let value = func().await;
+
+        match value {
+            Ok(value) => return Ok(value),
+            Err(error) if error.is_retriable_rpc_error() => {
+                if let Some(delay) = strategy.next_delay() {
+                    tracing::debug!(
+                        ?delay,
+                        ?error,
+                        "attempt failed with retriable RPC error, waiting before retrying"
+                    );
+                    tokio::time::sleep(delay).await;
+                } else {
+                    tracing::debug!(
+                        "last attempt failed with retriable RPC error, returning last failure value"
+                    );
+                    return Err(error);
+                }
+            }
+            Err(error) => {
+                tracing::debug!("non-retriable error, returning last failure value");
+                return Err(error);
+            }
+        }
+    }
+}
+
+/// A [`SuiClient`] that retries RPC calls with backoff in case of network errors.
+///
+/// This retriable client wraps functions from the [`CoinReadApi`][sui_sdk::apis::CoinReadApi] and
+/// the [`ReadApi`][sui_sdk::apis::ReadApi] of the [`SuiClient`], and
+/// additionally provides some convenience methods.
+#[allow(missing_debug_implementations)]
+#[derive(Clone)]
+pub struct RetriableSuiClient {
+    sui_client: SuiClient,
+    backoff_config: ExponentialBackoffConfig,
+}
+
+impl RetriableSuiClient {
+    /// Creates a new retriable client.
+    ///
+    /// NB: If you are creating the sui client from a wallet context, you should use
+    /// [`RetriableSuiClient::new_from_wallet`] instead. This is because the wallet context will
+    /// make a call to the RPC server in [`WalletContext::get_client`], which may fail without any
+    /// retries. `new_from_wallet` will handle this case correctly.
+    pub fn new(sui_client: SuiClient, backoff_config: ExponentialBackoffConfig) -> Self {
+        RetriableSuiClient {
+            sui_client,
+            backoff_config,
+        }
+    }
+
+    /// Returns a reference to the inner backoff configuration.
+    pub fn backoff_config(&self) -> &ExponentialBackoffConfig {
+        &self.backoff_config
+    }
+
+    /// Creates a new retriable client from an RCP address.
+    pub async fn new_for_rpc<S: AsRef<str>>(
+        rpc_address: S,
+        backoff_config: ExponentialBackoffConfig,
+    ) -> Result<Self> {
+        let client = SuiClientBuilder::default().build(rpc_address).await?;
+        Ok(Self::new(client, backoff_config))
+    }
+
+    /// Creates a new retriable client from a wallet context.
+    #[tracing::instrument(level = Level::DEBUG, skip_all)]
+    pub async fn new_from_wallet(
+        wallet: &WalletContext,
+        backoff_config: ExponentialBackoffConfig,
+    ) -> Result<Self> {
+        let strategy = backoff_config.get_strategy(ThreadRng::default().gen());
+        let client = retry_rpc_errors(strategy, || async { wallet.get_client().await }).await?;
+        Ok(Self::new(client, backoff_config))
+    }
+
+    // Reimplementation of the `SuiClient` methods.
+
+    /// Return a list of coins for the given address, or an error upon failure.
+    ///
+    /// Calls [`sui_sdk::apis::CoinReadApi::select_coins`] internally.
+    #[tracing::instrument(level = Level::DEBUG, skip_all)]
+    pub async fn select_coins(
+        &self,
+        address: SuiAddress,
+        coin_type: Option<String>,
+        amount: u128,
+        exclude: Vec<ObjectID>,
+    ) -> SuiRpcResult<Vec<Coin>> {
+        retry_rpc_errors(self.get_strategy(), || async {
+            self.sui_client
+                .coin_read_api()
+                .select_coins(address, coin_type.clone(), amount, exclude.clone())
+                .await
+        })
+        .await
+    }
+
+    /// Returns the balance for the given coin type owned by address.
+    ///
+    /// Calls [`sui_sdk::apis::CoinReadApi::get_balance`] internally.
+    #[tracing::instrument(level = Level::DEBUG, skip_all)]
+    pub async fn get_balance(
+        &self,
+        owner: SuiAddress,
+        coin_type: Option<String>,
+    ) -> SuiRpcResult<Balance> {
+        retry_rpc_errors(self.get_strategy(), || async {
+            self.sui_client
+                .coin_read_api()
+                .get_balance(owner, coin_type.clone())
+                .await
+        })
+        .await
+    }
+
+    /// Returns the dynamic fields for the object.
+    ///
+    /// Calls [`sui_sdk::apis::ReadApi::get_dynamic_fields`] internally.
+    #[tracing::instrument(level = Level::DEBUG, skip_all)]
+    pub async fn get_dynamic_fields(
+        &self,
+        object_id: ObjectID,
+        cursor: Option<ObjectID>,
+        limit: Option<usize>,
+    ) -> SuiRpcResult<Page<DynamicFieldInfo, ObjectID>> {
+        retry_rpc_errors(self.get_strategy(), || async {
+            self.sui_client
+                .read_api()
+                .get_dynamic_fields(object_id, cursor, limit)
+                .await
+        })
+        .await
+    }
+
+    /// Return a paginated response with the objects owned by the given address.
+    ///
+    /// Calls [`sui_sdk::apis::ReadApi::get_owned_objects`] internally.
+    #[tracing::instrument(level = Level::DEBUG, skip_all)]
+    pub async fn get_owned_objects(
+        &self,
+        address: SuiAddress,
+        query: Option<SuiObjectResponseQuery>,
+        cursor: Option<ObjectID>,
+        limit: Option<usize>,
+    ) -> SuiRpcResult<ObjectsPage> {
+        retry_rpc_errors(self.get_strategy(), || async {
+            self.sui_client
+                .read_api()
+                .get_owned_objects(address, query.clone(), cursor, limit)
+                .await
+        })
+        .await
+    }
+
+    /// Returns a [`SuiObjectResponse`] based on the provided [`ObjectID`].
+    ///
+    /// Calls [`sui_sdk::apis::ReadApi::get_object_with_options`] internally.
+    #[tracing::instrument(level = Level::DEBUG, skip_all)]
+    pub async fn get_object_with_options(
+        &self,
+        object_id: ObjectID,
+        options: SuiObjectDataOptions,
+    ) -> SuiRpcResult<SuiObjectResponse> {
+        retry_rpc_errors(self.get_strategy(), || async {
+            self.sui_client
+                .read_api()
+                .get_object_with_options(object_id, options.clone())
+                .await
+        })
+        .await
+    }
+
+    /// Return a list of [SuiObjectResponse] from the given vector of [ObjectID]s.
+    ///
+    /// Calls [`sui_sdk::apis::ReadApi::multi_get_object_with_options`] internally.
+    #[tracing::instrument(level = Level::DEBUG, skip_all)]
+    pub async fn multi_get_object_with_options(
+        &self,
+        object_ids: Vec<ObjectID>,
+        options: SuiObjectDataOptions,
+    ) -> SuiRpcResult<Vec<SuiObjectResponse>> {
+        retry_rpc_errors(self.get_strategy(), || async {
+            self.sui_client
+                .read_api()
+                .multi_get_object_with_options(object_ids.clone(), options.clone())
+                .await
+        })
+        .await
+    }
+
+    /// Returns a reference to the [`EventApi`].
+    ///
+    /// Internally calls the [`SuiClient::event_api`] function. Note that no retries are
+    /// implemented for this function.
+    pub fn event_api(&self) -> &EventApi {
+        self.sui_client.event_api()
+    }
+
+    // Other wrapper methods.
+
+    #[tracing::instrument(level = Level::DEBUG, skip_all)]
+    pub(crate) async fn get_sui_object<U>(&self, object_id: ObjectID) -> Result<U>
+    where
+        U: AssociatedContractStruct,
+    {
+        retry_rpc_errors(self.get_strategy(), || async {
+            get_sui_object_from_object_response(
+                &self
+                    .get_object_with_options(
+                        object_id,
+                        SuiObjectDataOptions::new().with_bcs().with_type(),
+                    )
+                    .await?,
+            )
+        })
+        .await
+    }
+
+    pub(crate) async fn get_dynamic_field_object<K, V>(
+        &self,
+        parent: ObjectID,
+        key_type: TypeTag,
+        key: K,
+    ) -> Result<V>
+    where
+        V: AssociatedContractStruct,
+        K: DeserializeOwned + Serialize,
+    {
+        let key_tag = key_type.to_canonical_string(true);
+        let object_id = derive_dynamic_field_id(
+            parent,
+            &TypeTag::from_str(&format!("0x2::dynamic_object_field::Wrapper<{}>", key_tag))
+                .expect("valid type tag"),
+            &bcs::to_bytes(&key).expect("key should be serializable"),
+        )?;
+
+        let field: SuiDynamicField<K, ObjectID> = self.get_sui_object(object_id).await?;
+        let inner = self.get_sui_object(field.value).await?;
+        Ok(inner)
+    }
+
+    /// Gets the type origin map for a given package.
+    pub(crate) async fn type_origin_map_for_package(
+        &self,
+        package_id: ObjectID,
+    ) -> Result<TypeOriginMap> {
+        let Ok(Some(SuiRawData::Package(raw_package))) = self
+            .get_object_with_options(
+                package_id,
+                SuiObjectDataOptions::default().with_type().with_bcs(),
+            )
+            .await?
+            .into_object()
+            .map(|object| object.bcs)
+        else {
+            bail!("package not found with ID {package_id}");
+        };
+        Ok(raw_package
+            .type_origin_table
+            .into_iter()
+            .map(|origin| ((origin.module_name, origin.datatype_name), origin.package))
+            .collect())
+    }
+
+    /// Gets a backoff strategy, seeded from the internal RNG.
+    fn get_strategy(&self) -> ExponentialBackoff<StdRng> {
+        self.backoff_config.get_strategy(ThreadRng::default().gen())
+    }
+}

--- a/site-builder/src/site/contracts.rs
+++ b/site-builder/src/site/contracts.rs
@@ -139,10 +139,12 @@ impl fmt::Display for StructTag<'_> {
     }
 }
 
+#[allow(dead_code)]
 pub(crate) async fn get_sui_object<U>(sui_client: &SuiClient, object_id: ObjectID) -> Result<U>
 where
     U: AssociatedContractStruct,
 {
+    let start = std::time::Instant::now();
     get_sui_object_from_object_response(
         &sui_client
             .read_api()
@@ -152,6 +154,13 @@ where
             )
             .await?,
     )
+    .inspect(|_| {
+        tracing::debug!(
+            %object_id,
+            elapsed = ?start.elapsed(),
+            "got sui object",
+        )
+    })
 }
 
 pub(crate) fn get_sui_object_from_object_response<U>(

--- a/site-builder/src/util.rs
+++ b/site-builder/src/util.rs
@@ -14,14 +14,13 @@ use sui_sdk::{
         SuiTransactionBlockResponse,
     },
     wallet_context::WalletContext,
-    SuiClient,
 };
 use sui_types::{
     base_types::{ObjectID, ObjectRef, SuiAddress},
     transaction::{ProgrammableTransaction, TransactionData},
 };
 
-use crate::site::contracts::TypeOriginMap;
+use crate::{retry_client::RetriableSuiClient, site::contracts::TypeOriginMap};
 
 pub async fn sign_and_send_ptb(
     active_address: SuiAddress,
@@ -142,11 +141,10 @@ pub fn path_or_defaults_if_exist(path: &Option<PathBuf>, defaults: &[PathBuf]) -
 
 /// Gets the type origin map for a given package.
 pub(crate) async fn type_origin_map_for_package(
-    sui_client: &SuiClient,
+    sui_client: &RetriableSuiClient,
     package_id: ObjectID,
 ) -> Result<TypeOriginMap> {
     let Ok(Some(SuiRawData::Package(raw_package))) = sui_client
-        .read_api()
         .get_object_with_options(
             package_id,
             SuiObjectDataOptions::default().with_type().with_bcs(),


### PR DESCRIPTION
Add multiple reliability improvements to shield the site builder from network errors and full node rate limiting. 
Specifically:
- All calls to the sui client are now wrapped and are retried with backoff
- OS network failures (os error 54) are retried when fetching the dynamic fields

In a follow up, would be nice to start using `multi_get_object`.