### PR TITLE
feat(site-builder): add single resource to existing site

### DIFF
--- a/site-builder/src/publish.rs
+++ b/site-builder/src/publish.rs
@@ -35,14 +35,7 @@ use crate::{
         SITE_MODULE,
     },
     summary::{SiteDataDiffSummary, Summarizable},
-    util::{
-        get_site_id_from_response,
-        id_to_base36,
-        load_wallet_context,
-        path_or_defaults_if_exist,
-        sign_and_send_ptb,
-    },
-    walrus::Walrus,
+    util::{get_site_id_from_response, id_to_base36, path_or_defaults_if_exist, sign_and_send_ptb},
     Config,
 };
 
@@ -158,7 +151,7 @@ impl SiteEditor {
     }
 
     pub async fn destroy(&self, site_id: ObjectID) -> Result<()> {
-        let mut wallet = load_wallet_context(&self.config.general.wallet)?;
+        let mut wallet = self.config.wallet()?;
         let ptb = SitePtb::new(self.config.package, Identifier::new(SITE_MODULE)?)?;
         let mut ptb = ptb.with_call_arg(&wallet.get_object_ref(site_id).await?.into())?;
         let site = RemoteSiteFactory::new(
@@ -215,16 +208,6 @@ impl SiteEditor<EditOptions> {
             display::done();
         }
 
-        let wallet = load_wallet_context(&self.config.general.wallet)?;
-
-        let walrus = Walrus::new(
-            self.config.walrus_binary(),
-            self.config.gas_budget(),
-            self.config.general.rpc_url.clone(),
-            self.config.general.walrus_config.clone(),
-            self.config.general.wallet.clone(),
-        );
-
         let (ws_resources, ws_resources_path) = load_ws_resources(
             &self.edit_options.publish_options.ws_resources,
             self.directory(),
@@ -237,7 +220,7 @@ impl SiteEditor<EditOptions> {
         }
 
         let mut resource_manager = ResourceManager::new(
-            walrus.clone(),
+            self.config.walrus_client(),
             ws_resources,
             ws_resources_path,
             self.edit_options.publish_options.max_concurrent,
@@ -253,8 +236,6 @@ impl SiteEditor<EditOptions> {
 
         let mut site_manager = SiteManager::new(
             self.config.clone(),
-            walrus,
-            wallet,
             self.edit_options.site_id.clone(),
             self.edit_options.publish_options.epochs,
             self.edit_options.when_upload.clone(),
@@ -343,7 +324,7 @@ fn print_summary(
 }
 
 /// Gets the configuration from the provided file, or looks in the default directory.
-fn load_ws_resources(
+pub(crate) fn load_ws_resources(
     path: &Option<PathBuf>,
     site_dir: &Path,
 ) -> Result<(Option<WSResources>, Option<PathBuf>)> {


### PR DESCRIPTION
Introduces a new command, `update-resource`, with which a single resource can be added without verifying the state of the site object.