### PR TITLE
fix(portal): decrease number of events tracked per page-view

### DIFF
--- a/portal/server/web_analytics.ts
+++ b/portal/server/web_analytics.ts
@@ -1,50 +1,29 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { NextRequest, NextResponse } from 'next/server'
-import { track } from '@vercel/analytics/server'
+import { NextRequest } from "next/server";
+import { track } from "@vercel/analytics/server";
 
 export async function send_to_web_analytics(request: NextRequest) {
     // Extract various details from the request
     const trackingData = extract_tracking_data(request)
 
-    // Track the event with comprehensive data
-    await track('route-access', trackingData)
-}
-
-function extract_tracking_data(request: NextRequest): TrackingData {
-    const geo = request.geo || {}
-
-    return {
-        originalUrl: request.headers.get('x-original-url') || 'Unknown User Agent',
-
-        // Network Information
-        ip: request.ip || 'Unknown IP',
-        country: geo.country || 'Unknown',
-        region: geo.region || 'Unknown',
-        city: geo.city || 'Unknown',
-
-        // Client Information
-        userAgent: request.headers.get('user-agent') || 'Unknown User Agent',
-        referer: request.headers.get('referer') || 'Direct',
-
-        // Additional Context
-        timestamp: new Date().toISOString(),
-        protocol: request.nextUrl.protocol,
+    // Track only when the request is for an HTML page.
+    // This is to avoid tracking requests for static assets like images, css, etc.
+    // Cuts down costs since we are tracking less events.
+    const originalUrl = request.headers.get("x-original-url");
+    if (originalUrl?.endsWith('.html')) {
+        await track('route-access', trackingData)
     }
 }
 
-type TrackingData = {
-    originalUrl: string
-    city: string
-
-    ip: string
-    country: string
-    region: string
-
-    userAgent: string
-    referer: string
-
-    timestamp: string
-    protocol: string
+function extract_tracking_data(request: NextRequest): CustomEventProperties {
+    return {
+        originalUrl: request.headers.get("x-original-url") || "Unknown",
+    };
 }
+
+// As of this writing, vercel pro plan supports at most 2 custom event props.
+type CustomEventProperties = {
+    originalUrl: string;
+};


### PR DESCRIPTION
Bonus: Custom event properties in the Pro plan
cannot exceed 2 in total. So I deleted the unused ones.