### PR TITLE
fix(portal): improve vercel web analytics event sampling

### DIFF
--- a/portal/server/web_analytics.ts
+++ b/portal/server/web_analytics.ts
@@ -3,27 +3,39 @@
 
 import { NextRequest } from "next/server";
 import { track } from "@vercel/analytics/server";
+import { getSubdomainAndPath } from "@lib/domain_parsing";
+import { config } from "configuration_loader";
 
 export async function send_to_web_analytics(request: NextRequest) {
-    // Extract various details from the request
-    const trackingData = extract_tracking_data(request)
-
     // Track only when the request is for an HTML page.
     // This is to avoid tracking requests for static assets like images, css, etc.
     // Cuts down costs since we are tracking less events.
-    const originalUrl = request.headers.get("x-original-url");
-    if (originalUrl?.endsWith('.html')) {
-        await track('route-access', trackingData)
+    const parsedUrl = getSubdomainAndPath(
+        request.nextUrl,
+        Number(config.portalDomainNameLength)
+    );
+
+    // Extract various details from the request
+    const custom_event_properties = extract_custom_event_properties(request, parsedUrl?.subdomain)
+
+    if (parsedUrl?.path?.endsWith('.html')) {
+        try {
+            await track('pageview', custom_event_properties)
+        } catch (e) {
+            console.warn("Could not track event: ", e);
+        }
     }
 }
 
-function extract_tracking_data(request: NextRequest): CustomEventProperties {
+function extract_custom_event_properties(request: NextRequest, subdomain?: string): CustomEventProperties {
     return {
         originalUrl: request.headers.get("x-original-url") || "Unknown",
+        subdomain
     };
 }
 
 // As of this writing, vercel pro plan supports at most 2 custom event props.
 type CustomEventProperties = {
     originalUrl: string;
+    subdomain?: string;
 };


### PR DESCRIPTION
We would like to only track pageview events for html pages. 

Static files should be excluded. The previous PR included a very weak condition (url should end with `.html`).
This PR build on top of it, improving that condition by using the `getSubdomainAndPath` from the common library.

Also, I renamed the custom event to `pageview` - hopefully this will fix the vercel UI to automatically display this first without any filter. 