### PR TITLE
Fix RPC Selector Logic in UrlFetcherFactory

### DIFF
--- a/portal/common/lib/types/index.ts
+++ b/portal/common/lib/types/index.ts
@@ -37,7 +37,7 @@ export type Range = {
  * Checks if the range is well formed.
  */
 function isRangeValid(range: Range): boolean {
-    if (!range.start !== null && !range.end !== null) {
+    if (range.start == null && range.end == null) {
         return false;
     }
     if (range.start !== null && range.start < 0) {

--- a/portal/server/url_fetcher_factory.ts
+++ b/portal/server/url_fetcher_factory.ts
@@ -20,17 +20,17 @@ class UrlFetcherFactory {
 
     public static premiumUrlFetcher(): UrlFetcher {
         return new UrlFetcher(
-            new ResourceFetcher(this.standardRpcSelector),
-            new SuiNSResolver(this.standardRpcSelector),
-            new WalrusSitesRouter(this.standardRpcSelector)
+            new ResourceFetcher(this.premiumRpcSelector),
+            new SuiNSResolver(this.premiumRpcSelector),
+            new WalrusSitesRouter(this.premiumRpcSelector)
         );
     }
 
     public static standardUrlFetcher(): UrlFetcher {
         return new UrlFetcher(
-            new ResourceFetcher(this.premiumRpcSelector),
-            new SuiNSResolver(this.premiumRpcSelector),
-            new WalrusSitesRouter(this.premiumRpcSelector)
+            new ResourceFetcher(this.standardRpcSelector),
+            new SuiNSResolver(this.standardRpcSelector),
+            new WalrusSitesRouter(this.standardRpcSelector)
         );
     }
 }


### PR DESCRIPTION
Corrected the RPCSelector logic in UrlFetcherFactory to align with the intended functionality for premium and standard URL fetchers.

### Changes Made:
- `premiumUrlFetcher` now uses `premiumRpcSelector` to ensure it leverages premium RPC nodes for faster and more reliable content delivery.
- `standardUrlFetcher` now uses `standardRpcSelector` to appropriately use standard RPC nodes for basic operations.

### Why This Change Was Necessary:
- Previously, the `premiumUrlFetcher` and `standardUrlFetcher` were incorrectly assigned RPC selectors. This caused a mismatch in behavior where premium fetchers were using standard nodes and vice versa.
- This fix ensures the fetchers work as intended, maintaining performance expectations and fulfilling the logic outlined in the class's documentation.

This change resolves the logical inconsistency and improves the reliability of URL fetching mechanisms for different use cases.

This PR might show changes from the previous PR. However, those changes have already been merged into the main branch. This PR only includes the newly made corrections.