### PR TITLE
fix(common-lib): remove error from subdomainToObjectId

### DIFF
--- a/portal/common/lib/objectId_operations.ts
+++ b/portal/common/lib/objectId_operations.ts
@@ -31,7 +31,6 @@ export function subdomainToObjectId(subdomain: string): string | null {
         });
         return isValidSuiObjectId(objectId) ? objectId : null;
     } catch (e) {
-        logger.error({ message: "Error converting subdomain to object id", error: e });
         return null;
     }
 }


### PR DESCRIPTION
The error from the logger would show up as
something crucial on Sentry, which is not.
Actually this is not even an error, because
the code will always "fail", e.g. return null
for suins domains