### PR TITLE
feat(common): support for new SuiNS walrus site id resolution

### DIFF
--- a/portal/common/lib/rpc_selector.ts
+++ b/portal/common/lib/rpc_selector.ts
@@ -157,7 +157,7 @@ export class RPCSelector implements RPCSelectorInterface {
     }
 
     private isValidSuiNSResponse(suinsResponse?: string): boolean {
-        return suinsResponse ? true : false // FIXME: Implement this
+        return true // FIXME: Implement this
     }
 
     public async getObject(input: GetObjectParams): Promise<SuiObjectResponse> {

--- a/portal/common/lib/rpc_selector.ts
+++ b/portal/common/lib/rpc_selector.ts
@@ -184,6 +184,7 @@ export class RPCSelector implements RPCSelectorInterface {
 
     public async getNameRecord(name: string): Promise<NameRecord | null> {
         const nameRecord = await this.invokeWithFailover<NameRecord>('getNameRecord', [name])
+        console.log('DEBUG', nameRecord)
         return nameRecord
     }
 }

--- a/portal/common/lib/rpc_selector.ts
+++ b/portal/common/lib/rpc_selector.ts
@@ -39,7 +39,7 @@ class WrappedSuiClient extends SuiClient {
             client: this as SuiClient,
             network: 'testnet' // TODO: get network from config
         });
-        const nameRecord = await suinsClient.getNameRecord(name) // TODO: invokeWithFailover
+        const nameRecord = await suinsClient.getNameRecord(name)
         return nameRecord
     }
 }

--- a/portal/common/lib/rpc_selector.ts
+++ b/portal/common/lib/rpc_selector.ts
@@ -133,7 +133,7 @@ export class RPCSelector implements RPCSelectorInterface {
 
             return result;
         } catch (error) {
-            throw new Error(`Failed to contact fallback RPC clients.`, error);
+            throw new Error(`Failed to contact fallback RPC clients.`);
         }
     }
 

--- a/portal/common/lib/rpc_selector.ts
+++ b/portal/common/lib/rpc_selector.ts
@@ -129,7 +129,9 @@ export class RPCSelector implements RPCSelectorInterface {
 
             return result;
         } catch (error) {
-            throw new Error(`Failed to contact fallback RPC clients.`);
+            const message = `Failed to contact fallback RPC clients.`
+            logger.error({ message, error: error });
+            throw new Error(message);
         }
     }
 

--- a/portal/common/lib/rpc_selector.ts
+++ b/portal/common/lib/rpc_selector.ts
@@ -22,10 +22,15 @@ interface RPCSelectorInterface {
 
 class WrappedSuiClient extends SuiClient {
     private url: string;
+    private suinsClient: SuinsClient;
 
     constructor(url: string) {
         super({ url });
         this.url = url;
+        this.suinsClient = new SuinsClient({
+            client: this as SuiClient,
+            network: 'testnet' // TODO: get network from config
+        });
     }
 
     public getURL(): string {
@@ -35,12 +40,7 @@ class WrappedSuiClient extends SuiClient {
     // Extends the SuiClient class to add a method to get a SuiNS record.
     // Useful for treating the SuiClient as a SuiNS client during the invokeWithFailover method.
     public async getNameRecord(name: string): Promise<NameRecord | null> {
-        const suinsClient = new SuinsClient({
-            client: this as SuiClient,
-            network: 'testnet' // TODO: get network from config
-        });
-        const nameRecord = await suinsClient.getNameRecord(name)
-        return nameRecord
+        return await this.suinsClient.getNameRecord(name)
     }
 }
 

--- a/portal/common/lib/rpc_selector.ts
+++ b/portal/common/lib/rpc_selector.ts
@@ -9,8 +9,8 @@ import {
     SuiObjectResponse,
 } from "@mysten/sui/client";
 import { SuinsClient } from "@mysten/suins";
-import { NameRecord } from "@mysten/suins/src/types";
 import logger from "./logger";
+import { NameRecord } from "./types";
 
 interface RPCSelectorInterface {
     getObject(input: GetObjectParams): Promise<SuiObjectResponse>;

--- a/portal/common/lib/rpc_selector.ts
+++ b/portal/common/lib/rpc_selector.ts
@@ -184,7 +184,6 @@ export class RPCSelector implements RPCSelectorInterface {
 
     public async getNameRecord(name: string): Promise<NameRecord | null> {
         const nameRecord = await this.invokeWithFailover<NameRecord>('getNameRecord', [name])
-        console.log('DEBUG', nameRecord)
         return nameRecord
     }
 }

--- a/portal/common/lib/suins.test.ts
+++ b/portal/common/lib/suins.test.ts
@@ -4,6 +4,7 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { SuiNSResolver } from './suins';
 import { RPCSelector } from './rpc_selector';
+import { NameRecord } from './types';
 
 describe('resolveSuiNsAddress', () => {
     const rpcSelector = new RPCSelector(process.env.RPC_URL_LIST!.split(','))
@@ -17,34 +18,45 @@ describe('resolveSuiNsAddress', () => {
 
     test('should resolve known SuiNS addresses', async () => {
         const cases = [
-            ["subname", "0x123"],
-            ["example", "0xabc"]
+            // The most common case.
+            ["subname", {
+                name: "dummyName",
+                nftId: "dummyNftId",
+                targetAddress: "dummyTargetAddress",
+                expirationTimestampMs: 1234567890,
+                data: { key: "dummyValue" },
+                avatar: "dummyAvatar",
+                contentHash: "dummyContentHash",
+                walrusSiteId: "0x57414C525553"
+            }],
+            // Deprecated case where the walrusSiteId is not set, but the targetAddress is used
+            //  instead:
+            ["docs", {
+              name: 'docs.sui',
+              nftId: '0xcc8ee266bc1f07b3218696912c7e5244aeb0e32c8c9befec059e3527558e4063',
+              targetAddress: '0x57414C525553',
+              expirationTimestampMs: '1749826519160',
+              data: {},
+              avatar: undefined,
+              contentHash: undefined,
+              walrusSiteId: undefined
+            }]
         ];
 
         for (const [input, expected] of cases) {
-            // Mock the rpcSelectorSingleton.call method
-            vi.spyOn(rpcSelector, 'call').mockResolvedValueOnce(expected);
-
-            const result = await suiNSResolver.resolveSuiNsAddress(input);
-
-            expect(result).toBe(expected);
-            expect(rpcSelector.call).toHaveBeenCalledWith(
-                "call",
-                ["suix_resolveNameServiceAddress", [`${input}.sui`]]
-            );
+            vi.spyOn(rpcSelector, 'getNameRecord').mockResolvedValueOnce(expected as NameRecord);
+            const result: string = await suiNSResolver.resolveSuiNsAddress(input as string);
+            expect(result).toBe("0x57414C525553");
+            expect(rpcSelector.getNameRecord).toHaveBeenCalledWith(`${input}.sui`);
         }
     });
 
     test('should return null for an unknown SuiNS address', async () => {
-        // Mock the rpcSelectorSingleton.call method to return null
-        vi.spyOn(rpcSelector, 'call').mockResolvedValueOnce(null);
-
+        vi.spyOn(rpcSelector, 'getNameRecord').mockResolvedValueOnce(null);
         const result = await suiNSResolver.resolveSuiNsAddress("unknown");
-
-        expect(result).toBeNull();
-        expect(rpcSelector.call).toHaveBeenCalledWith(
-            "call",
-            ["suix_resolveNameServiceAddress", ["unknown.sui"]]
+        expect(rpcSelector.getNameRecord).toHaveBeenCalledWith(
+            "unknown.sui"
         );
+        expect(result).toBeNull();
     });
 });

--- a/portal/common/lib/suins.ts
+++ b/portal/common/lib/suins.ts
@@ -3,6 +3,7 @@
 import { SITE_NAMES } from "./constants";
 import { RPCSelector } from "./rpc_selector";
 import logger from "./logger";
+import { NameRecord } from "@mysten/suins/src/types";
 
 export class SuiNSResolver {
     constructor(private rpcSelector: RPCSelector) {}
@@ -13,12 +14,15 @@ export class SuiNSResolver {
     */
     async resolveSuiNsAddress(subdomain: string
     ): Promise<string | null> {
-        const suiObjectId: string = await this.rpcSelector.call<string>("call", ["suix_resolveNameServiceAddress", [
-            subdomain + ".sui",
-        ]]);
-        if (suiObjectId) {
-            logger.info({ message: "resolved suins name", resolvedSuiNSName: subdomain, suiObjectId: suiObjectId });
-            return suiObjectId;
+        const nameRecord: NameRecord | null = await this.rpcSelector.getNameRecord(`${subdomain}.sui`);
+        if (nameRecord) {
+            const resolvedSuiNSName = nameRecord.walrusSiteId ?? nameRecord.targetAddress;
+            logger.info({
+                message: "Resolved SuiNS name",
+                subdomain,
+                resolvedSuiNSName
+            });
+            return resolvedSuiNSName;
         }
         return null;
     }

--- a/portal/common/lib/suins.ts
+++ b/portal/common/lib/suins.ts
@@ -16,8 +16,11 @@ export class SuiNSResolver {
         const suiObjectId: string = await this.rpcSelector.call<string>("call", ["suix_resolveNameServiceAddress", [
             subdomain + ".sui",
         ]]);
-        logger.info({ message: "resolved suins name", resolvedSuiNSName: subdomain, suiObjectId: suiObjectId });
-        return suiObjectId ? suiObjectId : null;
+        if (suiObjectId) {
+            logger.info({ message: "resolved suins name", resolvedSuiNSName: subdomain, suiObjectId: suiObjectId });
+            return suiObjectId;
+        }
+        return null;
     }
 
     hardcodedSubdmains(subdomain: string): string | null {

--- a/portal/common/lib/suins.ts
+++ b/portal/common/lib/suins.ts
@@ -3,7 +3,7 @@
 import { SITE_NAMES } from "./constants";
 import { RPCSelector } from "./rpc_selector";
 import logger from "./logger";
-import { NameRecord } from "@mysten/suins/src/types";
+import { NameRecord } from "./types";
 
 export class SuiNSResolver {
     constructor(private rpcSelector: RPCSelector) {}

--- a/portal/common/lib/types/index.ts
+++ b/portal/common/lib/types/index.ts
@@ -117,3 +117,17 @@ export type Routes = {
 export function isRoutes(obj: any): obj is Routes {
     return obj && typeof obj.routes_list === "object" && obj.routes_list instanceof Map;
 }
+
+/**
+ * A NameRecord entry of SuiNS Names.
+ */
+export type NameRecord = {
+	name: string;
+	nftId: string;
+	targetAddress: string;
+	expirationTimestampMs: number;
+	data: Record<string, string>;
+	avatar?: string;
+	contentHash?: string;
+	walrusSiteId?: string;
+};

--- a/portal/common/package.json
+++ b/portal/common/package.json
@@ -1,7 +1,8 @@
 {
 		"dependencies": {
 				"@mysten/bcs": "^1.1.0",
-				"@mysten/sui": "^1.12.0",
+				"@mysten/sui": "1.18.1",
+				"@mysten/suins": "^0.6.3",
 				"base-x": "^4.0.0",
 				"pako": "^2.1.0",
 				"parse-domain": "8.0.2",

--- a/portal/pnpm-lock.yaml
+++ b/portal/pnpm-lock.yaml
@@ -14,8 +14,11 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0
       '@mysten/sui':
-        specifier: ^1.12.0
-        version: 1.12.0(typescript@5.6.3)
+        specifier: 1.18.1
+        version: 1.18.1(typescript@5.6.3)
+      '@mysten/suins':
+        specifier: ^0.6.3
+        version: 0.6.3(typescript@5.6.3)
       base-x:
         specifier: ^4.0.0
         version: 4.0.0
@@ -202,6 +205,10 @@ packages:
     resolution: {integrity: sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/runtime@7.26.0':
+    resolution: {integrity: sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.25.9':
     resolution: {integrity: sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==}
@@ -448,9 +455,20 @@ packages:
   '@mysten/bcs@1.1.0':
     resolution: {integrity: sha512-yy9/1Y4d0FlRywS1+9ze/T7refCbrvwFwJIOKs9M3QBK1njbcHZp+LkVeLqBvIJA5eZ3ZCzmhQ1Xq4Sed5mEBA==}
 
+  '@mysten/bcs@1.2.1':
+    resolution: {integrity: sha512-RMSaUsNb8oR0rTRVIOOcyoEVJqQi6DLvMXN+7mvDcki12FJFQ0lF89zQa7AV7cIurWlDQfJ8VIbCuRDyK+955A==}
+
   '@mysten/sui@1.12.0':
     resolution: {integrity: sha512-DrSyja04xyGrTGlIQKMwZ6MywxNPkjyIcDLm915Zisoy1/uIgPoHc4cx53JyiG92z/HgowTVGGCCIzH53DIYXA==}
     engines: {node: '>=18'}
+
+  '@mysten/sui@1.18.1':
+    resolution: {integrity: sha512-ccMVOHM4KQhUvbBirE1rkn9THDJUX7y7W1cDMoCKnlPsIwTtQifZc7ysyBNjCMAS42y8Kq4VpiRagPjf13Am5A==}
+    engines: {node: '>=18'}
+
+  '@mysten/suins@0.6.3':
+    resolution: {integrity: sha512-qCd0RTnLCBLLwZV5OVUCKDYIiaVQGn6JsXcJLt2BI0GL9t2K+5VyaXL6BNfxVisEXQ3OxRBS7J+pVwrY/laAZg==}
+    engines: {node: '>=16'}
 
   '@next/env@14.2.21':
     resolution: {integrity: sha512-lXcwcJd5oR01tggjWJ6SrNNYFGuOOMB9c251wUNkjCpkoXOPkDeF/15c3mnVlBqrW4JJXb2kVxDFhC4GduJt2A==}
@@ -758,6 +776,16 @@ packages:
   '@prisma/instrumentation@5.19.1':
     resolution: {integrity: sha512-VLnzMQq7CWroL5AeaW0Py2huiNKeoMfCH3SUxstdzPrlWQi6UQ9UrfcbUkNHlVFqOMacqy8X/8YtE0kuKDpD9w==}
 
+  '@pythnetwork/price-service-client@1.9.0':
+    resolution: {integrity: sha512-SLm3IFcfmy9iMqHeT4Ih6qMNZhJEefY14T9yTlpsH2D/FE5+BaGGnfcexUifVlfH6M7mwRC4hEFdNvZ6ebZjJg==}
+    deprecated: This package is deprecated and is no longer maintained. Please use @pythnetwork/hermes-client instead.
+
+  '@pythnetwork/price-service-sdk@1.8.0':
+    resolution: {integrity: sha512-tFZ1thj3Zja06DzPIX2dEWSi7kIfIyqreoywvw5NQ3Z1pl5OJHQGMEhxt6Li3UCGSp2ooYZS9wl8/8XfrfrNSA==}
+
+  '@pythnetwork/pyth-sui-js@2.1.0':
+    resolution: {integrity: sha512-oSfpqtLATTEVaac/YbaRQBvOI7DM+Qds5O0GJjEcky7UQRtz/tlU9tjQ6VRn3vm8IXw8P1mKzJcaTIO134X9Sw==}
+
   '@rollup/plugin-commonjs@26.0.1':
     resolution: {integrity: sha512-UnsKoZK6/aGIH6AdkptXhNvhaqftcjq3zZdT+LY5Ftms6JR06nADcDsYp5hTU9E2lbJUEOhdlY5J4DNTneM+jQ==}
     engines: {node: '>=16.0.0 || 14 >= 14.17'}
@@ -990,6 +1018,10 @@ packages:
     engines: {node: '>= 14'}
     peerDependencies:
       webpack: '>=4.40.0'
+
+  '@simplewebauthn/typescript-types@7.4.0':
+    resolution: {integrity: sha512-8/ZjHeUPe210Bt5oyaOIGx4h8lHdsQs19BiOT44gi/jBEgK7uBGA0Fy7NRsyh777al3m6WM0mBf0UR7xd4R7WQ==}
+    deprecated: This package has been renamed to @simplewebauthn/types. Please install @simplewebauthn/types instead to ensure you receive future updates.
 
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
@@ -1355,6 +1387,9 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  axios-retry@3.9.1:
+    resolution: {integrity: sha512-8PJDLJv7qTTMMwdnbMvrLYuvB47M81wRtxQmEdV5w4rgbTXTt+vtPkXwajOfOdSyv/wZICJOC+/UhXH4aQ/R+w==}
+
   axios@1.7.7:
     resolution: {integrity: sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==}
 
@@ -1367,6 +1402,9 @@ packages:
   base-x@5.0.0:
     resolution: {integrity: sha512-sMW3VGSX1QWVFA6l8U62MLKz29rRfpTlYdCqLdpLo1/Yd4zZwSbnUaDfciIAowAqvq7YFnWq9hrhdg1KYgc1lQ==}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   batch@0.6.1:
     resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
 
@@ -1376,6 +1414,9 @@ packages:
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
+
+  bn.js@5.2.1:
+    resolution: {integrity: sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==}
 
   body-parser@1.20.3:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
@@ -1407,6 +1448,9 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -2128,6 +2172,9 @@ packages:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -2219,6 +2266,10 @@ packages:
     resolution: {integrity: sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==}
     engines: {node: '>=12'}
 
+  is-retry-allowed@2.2.0:
+    resolution: {integrity: sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==}
+    engines: {node: '>=10'}
+
   is-wsl@3.1.0:
     resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
     engines: {node: '>=16'}
@@ -2232,6 +2283,11 @@ packages:
   isobject@3.0.1:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
+
+  isomorphic-ws@4.0.1:
+    resolution: {integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==}
+    peerDependencies:
+      ws: '*'
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
@@ -2256,6 +2312,9 @@ packages:
   jiti@1.21.6:
     resolution: {integrity: sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==}
     hasBin: true
+
+  jose@5.9.6:
+    resolution: {integrity: sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2659,6 +2718,9 @@ packages:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
 
+  poseidon-lite@0.2.1:
+    resolution: {integrity: sha512-xIr+G6HeYfOhCuswdqcFpSX47SPhm0EpisWJ6h7fHlWwaVIvH3dLnejpatrtw6Xc6HaLrpq05y7VRfvDmDGIog==}
+
   postcss-calc@10.0.2:
     resolution: {integrity: sha512-DT/Wwm6fCKgpYVI7ZEWuPJ4az8hiEHtCUeYjZXqU7Ou4QqYh1Df2yCQ7Ca6N7xqKPFkxN3fhf+u9KSoOCJNAjg==}
     engines: {node: ^18.12 || ^20.9 || >=22.0}
@@ -2952,6 +3014,9 @@ packages:
   rechoir@0.8.0:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
     engines: {node: '>= 10.13.0'}
+
+  regenerator-runtime@0.14.1:
+    resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
 
   relateurl@0.2.7:
     resolution: {integrity: sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==}
@@ -3307,6 +3372,9 @@ packages:
     peerDependencies:
       typescript: '*'
       webpack: ^5.0.0
+
+  ts-log@2.2.7:
+    resolution: {integrity: sha512-320x5Ggei84AxzlXp91QkIGSw5wgaLT6GeAH0KsqDmRZdVWW2OiSeVvElVoatk3f7nicwXlElXsoFkARiGE2yg==}
 
   tsc@2.0.4:
     resolution: {integrity: sha512-fzoSieZI5KKJVBYGvwbVZs/J5za84f2lSTLPYf6AGiIf43tZ3GNrI1QzTLcjtyDDP4aLxd46RTZq1nQxe7+k5Q==}
@@ -3682,6 +3750,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.26.0
 
+  '@babel/runtime@7.26.0':
+    dependencies:
+      regenerator-runtime: 0.14.1
+
   '@babel/template@7.25.9':
     dependencies:
       '@babel/code-frame': 7.26.2
@@ -3876,6 +3948,10 @@ snapshots:
     dependencies:
       bs58: 6.0.0
 
+  '@mysten/bcs@1.2.1':
+    dependencies:
+      bs58: 6.0.0
+
   '@mysten/sui@1.12.0(typescript@5.6.3)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
@@ -3894,6 +3970,39 @@ snapshots:
       - '@gql.tada/svelte-support'
       - '@gql.tada/vue-support'
       - typescript
+
+  '@mysten/sui@1.18.1(typescript@5.6.3)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
+      '@mysten/bcs': 1.2.1
+      '@noble/curves': 1.6.0
+      '@noble/hashes': 1.5.0
+      '@scure/bip32': 1.5.0
+      '@scure/bip39': 1.4.0
+      '@simplewebauthn/typescript-types': 7.4.0
+      '@suchipi/femver': 1.0.0
+      bech32: 2.0.0
+      gql.tada: 1.8.10(graphql@16.9.0)(typescript@5.6.3)
+      graphql: 16.9.0
+      jose: 5.9.6
+      poseidon-lite: 0.2.1
+      valibot: 0.36.0
+    transitivePeerDependencies:
+      - '@gql.tada/svelte-support'
+      - '@gql.tada/vue-support'
+      - typescript
+
+  '@mysten/suins@0.6.3(typescript@5.6.3)':
+    dependencies:
+      '@mysten/sui': 1.18.1(typescript@5.6.3)
+      '@pythnetwork/pyth-sui-js': 2.1.0(typescript@5.6.3)
+    transitivePeerDependencies:
+      - '@gql.tada/svelte-support'
+      - '@gql.tada/vue-support'
+      - bufferutil
+      - debug
+      - typescript
+      - utf-8-validate
 
   '@next/env@14.2.21': {}
 
@@ -4245,6 +4354,37 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@pythnetwork/price-service-client@1.9.0':
+    dependencies:
+      '@pythnetwork/price-service-sdk': 1.8.0
+      '@types/ws': 8.5.12
+      axios: 1.7.7
+      axios-retry: 3.9.1
+      isomorphic-ws: 4.0.1(ws@8.18.0)
+      ts-log: 2.2.7
+      ws: 8.18.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+
+  '@pythnetwork/price-service-sdk@1.8.0':
+    dependencies:
+      bn.js: 5.2.1
+
+  '@pythnetwork/pyth-sui-js@2.1.0(typescript@5.6.3)':
+    dependencies:
+      '@mysten/sui': 1.18.1(typescript@5.6.3)
+      '@pythnetwork/price-service-client': 1.9.0
+      buffer: 6.0.3
+    transitivePeerDependencies:
+      - '@gql.tada/svelte-support'
+      - '@gql.tada/vue-support'
+      - bufferutil
+      - debug
+      - typescript
+      - utf-8-validate
+
   '@rollup/plugin-commonjs@26.0.1(rollup@3.29.5)':
     dependencies:
       '@rollup/pluginutils': 5.1.3(rollup@3.29.5)
@@ -4540,6 +4680,8 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  '@simplewebauthn/typescript-types@7.4.0': {}
 
   '@sinclair/typebox@0.27.8': {}
 
@@ -4922,6 +5064,11 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  axios-retry@3.9.1:
+    dependencies:
+      '@babel/runtime': 7.26.0
+      is-retry-allowed: 2.2.0
+
   axios@1.7.7:
     dependencies:
       follow-redirects: 1.15.9
@@ -4936,11 +5083,15 @@ snapshots:
 
   base-x@5.0.0: {}
 
+  base64-js@1.5.1: {}
+
   batch@0.6.1: {}
 
   bech32@2.0.0: {}
 
   binary-extensions@2.3.0: {}
+
+  bn.js@5.2.1: {}
 
   body-parser@1.20.3:
     dependencies:
@@ -4991,6 +5142,11 @@ snapshots:
       base-x: 5.0.0
 
   buffer-from@1.1.2: {}
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   bundle-name@4.1.0:
     dependencies:
@@ -5763,6 +5919,8 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   import-in-the-middle@1.11.2:
@@ -5832,6 +5990,8 @@ snapshots:
 
   is-regexp@3.1.0: {}
 
+  is-retry-allowed@2.2.0: {}
+
   is-wsl@3.1.0:
     dependencies:
       is-inside-container: 1.0.0
@@ -5841,6 +6001,10 @@ snapshots:
   isexe@2.0.0: {}
 
   isobject@3.0.1: {}
+
+  isomorphic-ws@4.0.1(ws@8.18.0):
+    dependencies:
+      ws: 8.18.0
 
   jackspeak@3.4.3:
     dependencies:
@@ -5878,6 +6042,8 @@ snapshots:
       supports-color: 8.1.1
 
   jiti@1.21.6: {}
+
+  jose@5.9.6: {}
 
   js-tokens@4.0.0: {}
 
@@ -6220,6 +6386,8 @@ snapshots:
     dependencies:
       find-up: 4.1.0
 
+  poseidon-lite@0.2.1: {}
+
   postcss-calc@10.0.2(postcss@8.4.47):
     dependencies:
       postcss: 8.4.47
@@ -6495,6 +6663,8 @@ snapshots:
   rechoir@0.8.0:
     dependencies:
       resolve: 1.22.8
+
+  regenerator-runtime@0.14.1: {}
 
   relateurl@0.2.7: {}
 
@@ -6900,6 +7070,8 @@ snapshots:
       source-map: 0.7.4
       typescript: 5.6.3
       webpack: 5.95.0(webpack-cli@5.1.4)
+
+  ts-log@2.2.7: {}
 
   tsc@2.0.4: {}
 


### PR DESCRIPTION
### Summary

This PR integrates the new functionality of SuiNS name records supporting a `walrusSiteId` to enable sites to connect with both a wallet and a walrus site. For backwards compatibility, we fall back to `nameRecord.targetAddress`.

Note: We don't need to use a `rpcSelector.validateSuinsResponse` because if the full node fails to return something valid, it throws an error that we catch on an outer try/catch block. 

### Changelog
- install `@mysten/suins`
- upgrade `@mysten/sui` to `1.18.1` to be compatible with suins.
- add `getNameRecord` call to `WrappedSuiClient`.
- create a new `NameRecord` type in `common/types` since the suins lib does not export it.
- update `SuiNSResolver` to use `rpcSelector.getNameRecord`.
- update unit tests accordingly.