### PR TITLE
feat: add SUINS_CLIENT_NETWORK to config

### DIFF
--- a/portal/common/lib/resource.test.ts
+++ b/portal/common/lib/resource.test.ts
@@ -42,7 +42,8 @@ vi.mock("./bcs_data_parsing", async (importOriginal) => {
 describe("fetchResource", () => {
     console.log("RPC URLS:", process.env.RPC_URL_LIST!.split(','));
     const rpcSelector = new RPCSelector(
-        process.env.RPC_URL_LIST!.split(',')
+        process.env.RPC_URL_LIST!.split(','),
+        'testnet'
     )
     const resourceFetcher = new ResourceFetcher(rpcSelector);
     // Mock SuiClient methods

--- a/portal/common/lib/routing.test.ts
+++ b/portal/common/lib/routing.test.ts
@@ -7,7 +7,7 @@ import { RPCSelector } from "./rpc_selector";
 
 const snakeSiteObjectId = "0x7a95e4be3948415b852fb287d455166a276d7a52f1a567b4a26b6b5e9c753158";
 const wsRouter = new WalrusSitesRouter(
-    new RPCSelector(process.env.RPC_URL_LIST!.split(",")),
+    new RPCSelector(process.env.RPC_URL_LIST!.split(","), "testnet"),
 );
 
 test.skip("getRoutes", async () => {

--- a/portal/common/lib/rpc_selector.ts
+++ b/portal/common/lib/rpc_selector.ts
@@ -10,7 +10,7 @@ import {
 } from "@mysten/sui/client";
 import { SuinsClient } from "@mysten/suins";
 import logger from "./logger";
-import { NameRecord } from "./types";
+import { NameRecord, Network } from "./types";
 
 interface RPCSelectorInterface {
     getObject(input: GetObjectParams): Promise<SuiObjectResponse>;
@@ -24,12 +24,12 @@ class WrappedSuiClient extends SuiClient {
     private url: string;
     private suinsClient: SuinsClient;
 
-    constructor(url: string) {
+    constructor(url: string, network: Network) {
         super({ url });
         this.url = url;
         this.suinsClient = new SuinsClient({
             client: this as SuiClient,
-            network: 'testnet' // TODO: get network from config
+            network
         });
     }
 
@@ -49,9 +49,9 @@ export class RPCSelector implements RPCSelectorInterface {
     private clients: WrappedSuiClient[];
     private selectedClient: WrappedSuiClient | undefined;
 
-    constructor(rpcURLs: string[]) {
+    constructor(rpcURLs: string[], network: Network) {
         // Initialize clients.
-        this.clients = rpcURLs.map((rpcUrl) => new WrappedSuiClient(rpcUrl));
+        this.clients = rpcURLs.map((rpcUrl) => new WrappedSuiClient(rpcUrl, network));
         this.selectedClient = undefined;
     }
 

--- a/portal/common/lib/suins.test.ts
+++ b/portal/common/lib/suins.test.ts
@@ -7,7 +7,7 @@ import { RPCSelector } from './rpc_selector';
 import { NameRecord } from './types';
 
 describe('resolveSuiNsAddress', () => {
-    const rpcSelector = new RPCSelector(process.env.RPC_URL_LIST!.split(','))
+    const rpcSelector = new RPCSelector(process.env.RPC_URL_LIST!.split(','), "testnet")
     const suiNSResolver = new SuiNSResolver(
         rpcSelector
     );

--- a/portal/common/lib/types/index.ts
+++ b/portal/common/lib/types/index.ts
@@ -131,3 +131,8 @@ export type NameRecord = {
 	contentHash?: string;
 	walrusSiteId?: string;
 };
+
+/**
+ * The Sui client network type.
+ */
+export type Network = 'testnet' | 'mainnet';

--- a/portal/server/configuration_loader.ts
+++ b/portal/server/configuration_loader.ts
@@ -25,6 +25,7 @@ export type Configuration = {
     sentryAuthToken?: string;
     sentryDsn?: string;
     sentryTracesSampleRate?: number;
+    suinsClientNetwork: 'testnet' | 'mainnet'
 };
 
 /**
@@ -49,6 +50,7 @@ class ConfigurationLoader {
             sentryAuthToken: this.loadSentryAuthToken(),
             sentryDsn: this.loadSentryDsn(),
             sentryTracesSampleRate: this.loadSentryTracesSampleRate(),
+            suinsClientNetwork: this.loadSuinsClientNetwork()
         };
     }
 
@@ -172,6 +174,19 @@ class ConfigurationLoader {
             }
             return rate;
         }
+    }
+
+    private loadSuinsClientNetwork(): 'testnet' | 'mainnet' {
+        const suinsClientNetworkValue = process.env.SUINS_CLIENT_NETWORK;
+        if (suinsClientNetworkValue) {
+            if (suinsClientNetworkValue == 'testnet' || suinsClientNetworkValue == 'mainnet') {
+                return suinsClientNetworkValue
+            }
+            throw new Error(
+                "Incorrect SUINS_CLIENT_NETWORK value! Should be either 'testnet' or 'mainnet'"
+            )
+        }
+        throw new Error("No SUINS_CLIENT_NETWORK variable set!")
     }
 }
 

--- a/portal/server/url_fetcher_factory.ts
+++ b/portal/server/url_fetcher_factory.ts
@@ -15,8 +15,12 @@ import { config } from "configuration_loader";
 * while standard fetchers use standard RPC nodes.
 */
 class UrlFetcherFactory {
-    private static readonly premiumRpcSelector = new RPCSelector(config.premiumRpcUrlList);
-    private static readonly standardRpcSelector = new RPCSelector(config.rpcUrlList);
+    private static readonly premiumRpcSelector = new RPCSelector(
+        config.premiumRpcUrlList, config.suinsClientNetwork
+    );
+    private static readonly standardRpcSelector = new RPCSelector(
+        config.rpcUrlList, config.suinsClientNetwork
+    );
 
     public static premiumUrlFetcher(): UrlFetcher {
         return new UrlFetcher(

--- a/portal/worker/src/walrus-sites-sw.ts
+++ b/portal/worker/src/walrus-sites-sw.ts
@@ -20,6 +20,9 @@ const rpcUrlList = process.env.RPC_URL_LIST;
 if (!rpcUrlList) {
     throw new Error("Missing RPC_URL_LIST environment variable");
 }
+if (!['testnet', 'mainnet'].includes(rpcUrlList)) {
+    throw new Error("Invalid RPC_URL_LIST environment variable");
+}
 const suinsClientNetwork = process.env.SUINS_CLIENT_NETWORK;
 if (!suinsClientNetwork) {
     throw new Error("Missing SUINS_CLIENT_NETWORK environment variable");

--- a/portal/worker/src/walrus-sites-sw.ts
+++ b/portal/worker/src/walrus-sites-sw.ts
@@ -10,6 +10,7 @@ import { ResourceFetcher } from "@lib/resource";
 import { RPCSelector } from "@lib/rpc_selector";
 import { SuiNSResolver } from "@lib/suins";
 import { WalrusSitesRouter } from "@lib/routing";
+import { Network } from "@lib/types";
 
 // This is to get TypeScript to recognize `clients` and `self` Default type of `self` is
 // `WorkerGlobalScope & typeof globalThis` https://github.com/microsoft/TypeScript/issues/14877
@@ -20,14 +21,14 @@ const rpcUrlList = process.env.RPC_URL_LIST;
 if (!rpcUrlList) {
     throw new Error("Missing RPC_URL_LIST environment variable");
 }
-if (!['testnet', 'mainnet'].includes(rpcUrlList)) {
-    throw new Error("Invalid RPC_URL_LIST environment variable");
-}
 const suinsClientNetwork = process.env.SUINS_CLIENT_NETWORK;
 if (!suinsClientNetwork) {
     throw new Error("Missing SUINS_CLIENT_NETWORK environment variable");
 }
-const rpcSelector = new RPCSelector(rpcUrlList.split(','), suinsClientNetwork);
+if (!['testnet', 'mainnet'].includes(suinsClientNetwork)) {
+    throw new Error("Invalid SUINS_CLIENT_NETWORK environment variable");
+}
+const rpcSelector = new RPCSelector(rpcUrlList.split(','), suinsClientNetwork as Network);
 export const urlFetcher = new UrlFetcher(
     new ResourceFetcher(rpcSelector),
     new SuiNSResolver(rpcSelector),

--- a/portal/worker/src/walrus-sites-sw.ts
+++ b/portal/worker/src/walrus-sites-sw.ts
@@ -20,7 +20,11 @@ const rpcUrlList = process.env.RPC_URL_LIST;
 if (!rpcUrlList) {
     throw new Error("Missing RPC_URL_LIST environment variable");
 }
-const rpcSelector = new RPCSelector(rpcUrlList.split(','));
+const suinsClientNetwork = process.env.SUINS_CLIENT_NETWORK;
+if (!suinsClientNetwork) {
+    throw new Error("Missing SUINS_CLIENT_NETWORK environment variable");
+}
+const rpcSelector = new RPCSelector(rpcUrlList.split(','), suinsClientNetwork);
 export const urlFetcher = new UrlFetcher(
     new ResourceFetcher(rpcSelector),
     new SuiNSResolver(rpcSelector),

--- a/portal/worker/webpack.config.common.js
+++ b/portal/worker/webpack.config.common.js
@@ -44,7 +44,10 @@ module.exports = {
             ),
             'process.env.RPC_URL_LIST': JSON.stringify(
                 process.env.RPC_URL_LIST || undefined
-            )
+            ),
+            'process.env.SUINS_CLIENT_NETWORK': JSON.stringify(
+                process.env.SUINS_CLIENT_NETWORK || undefined
+            ),
         }),
         new CopyPlugin({
             patterns: [


### PR DESCRIPTION
- Add `network` param to the RPC selector's constructor.
- Parse the `SUINS_CLIENT_NETWORK` field from the environment variables.