### PR TITLE
feat: retry fetch aggregator on exception

### DIFF
--- a/portal/common/lib/url_fetcher.ts
+++ b/portal/common/lib/url_fetcher.ts
@@ -212,12 +212,12 @@ export class UrlFetcher {
     private async fetchWithRetry(
         input: string | URL | globalThis.Request,
         init?: RequestInit,
-        retries: number = 3,
+        retries: number = 1,
         delayMs: number = 1000
     ): Promise<Response> {
         let lastError: unknown;
 
-        for (let attempt = 1; attempt <= retries; attempt++) {
+        for (let attempt = 0; attempt <= retries; attempt++) {
             try {
                 const response = await fetch(input, init);
                 return response;
@@ -231,12 +231,7 @@ export class UrlFetcher {
                 await new Promise(resolve => setTimeout(resolve, delayMs));
             }
         }
-
-        // If an exception occurred, throw it
-        if (lastError) {
-            console.error(`All ${retries} fetch attempts failed. Throwing last error.`);
-            throw lastError instanceof Error ? lastError : new Error('Unknown error occurred');
-        }
-        return await fetch(input, init);
+        // All retry attempts failed; throw the last encountered error.
+        throw lastError instanceof Error ? lastError : new Error('Unknown error occurred in fetchWithRetry');
     }
 }

--- a/portal/common/lib/url_fetcher.ts
+++ b/portal/common/lib/url_fetcher.ts
@@ -237,5 +237,6 @@ export class UrlFetcher {
             console.error(`All ${retries} fetch attempts failed. Throwing last error.`);
             throw lastError instanceof Error ? lastError : new Error('Unknown error occurred');
         }
+        return await fetch(input, init);
     }
 }

--- a/portal/common/lib/url_fetcher.ts
+++ b/portal/common/lib/url_fetcher.ts
@@ -203,7 +203,7 @@ export class UrlFetcher {
      * Retries the fetch operation up to a specified number of attempts in case of failure,
      * with a delay between each retry. Logs the status and error messages during retries.
      *
-     * @param input - The URL, URL object, or Request object representing the resource to fetch.
+     * @param input - The URL string, URL object, or Request object representing the resource to fetch.
      * @param init - Optional fetch options such as headers, method, and body.
      * @param retries - The maximum number of retry attempts (default is 3).
      * @param delayMs - The delay in milliseconds between retry attempts (default is 1000ms).


### PR DESCRIPTION
Added a retry mechanism for fetching resources from the aggregator.

Changes:

- Introduced fetchWithRetry method to retry failed fetch requests up to 3 times with a delay.
- Updated UrlFetcher to use fetchWithRetry instead of direct fetch calls.