### PR TITLE
feat: sew 38 explicitly parse request information for amplitude

### DIFF
--- a/portal/bun.lock
+++ b/portal/bun.lock
@@ -34,10 +34,11 @@
         "common": "workspace:common",
         "next": "14.2.21",
         "redis": "^4.7.0",
+        "ua-parser-js": "^2.0.1",
         "zod": "^3.24.1",
       },
       "devDependencies": {
-        "@types/bun": "^1.2.2",
+        "@types/bun": "^1.2.1",
         "@types/node": "^20.16.11",
         "@types/react": "18.3.3",
         "html-loader": "^5.1.0",
@@ -762,6 +763,8 @@
 
     "destroy": ["destroy@1.2.0", "", {}, "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="],
 
+    "detect-europe-js": ["detect-europe-js@0.1.2", "", {}, "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow=="],
+
     "detect-node": ["detect-node@2.1.0", "", {}, "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="],
 
     "didyoumean": ["didyoumean@1.2.2", "", {}, "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="],
@@ -995,6 +998,8 @@
     "is-regexp": ["is-regexp@3.1.0", "", {}, "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA=="],
 
     "is-retry-allowed": ["is-retry-allowed@2.2.0", "", {}, "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg=="],
+
+    "is-standalone-pwa": ["is-standalone-pwa@0.1.1", "", {}, "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g=="],
 
     "is-wsl": ["is-wsl@3.1.0", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw=="],
 
@@ -1475,6 +1480,10 @@
     "type-is": ["type-is@1.6.18", "", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
 
     "typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
+
+    "ua-is-frozen": ["ua-is-frozen@0.1.2", "", {}, "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw=="],
+
+    "ua-parser-js": ["ua-parser-js@2.0.1", "", { "dependencies": { "detect-europe-js": "^0.1.2", "is-standalone-pwa": "^0.1.1", "ua-is-frozen": "^0.1.2" }, "bin": { "ua-parser-js": "script/cli.js" } }, "sha512-PgWLeyhIgff0Jomd3U2cYCdfp5iHbaCMlylG9NoV19tAlvXWUzM3bG2DIasLTI1PrbLtVutGr1CaezttVV2PeA=="],
 
     "undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
 

--- a/portal/server/package.json
+++ b/portal/server/package.json
@@ -16,6 +16,7 @@
         "common": "workspace:common",
         "next": "14.2.21",
         "redis": "^4.7.0",
+        "ua-parser-js": "^2.0.1",
         "zod": "^3.24.1"
     },
     "devDependencies": {

--- a/portal/server/src/amplitude.ts
+++ b/portal/server/src/amplitude.ts
@@ -16,7 +16,7 @@ if (config.amplitudeApiKey) {
 		flushQueueSize: 50,
 		// Events queue will flush every certain milliseconds based on setting.
 		// Default value is 10000 milliseconds.
-		flushIntervalMillis: 3000, // Increase this to at least 10000 for production use.
+		flushIntervalMillis: 20000, // Increase this to at least 10000 for production use.
 	});
 }
 


### PR DESCRIPTION
The server side Amplitude SDK is dumb: it doesn't automatically parse the http request headers to display information about each user like vercel web analytics does. 

From the docs:

If you send data server-side instead of using an SDK, Amplitude cannot track these user properties automatically. You must instead set these properties explicitly. [Source](https://amplitude.com/docs/get-started/user-property-definitions#:~:text=If%20you%20send%20data%20server%2Dside%20instead%20of%20using%20an%20SDK%2C%20Amplitude%20cannot%20track%20these%20user%20properties%20automatically.%20You%20must%20instead%20set%20these%20properties%20explicitly.%C2%A0).