### PR TITLE
fix: isHtmlPage should not throw exception when path is not parseable

### DIFF
--- a/portal/server/src/utils.ts
+++ b/portal/server/src/utils.ts
@@ -20,14 +20,11 @@ export function isHtmlPage(request: NextRequest): Boolean {
         request.nextUrl,
         Number(config.portalDomainNameLength)
     );
-    if (!parsedUrl?.path) {
-    	throw new Error("No path found in parsed URL");
-    }
     const contentTypeIsHtml = request.headers.get('content-type')?.startsWith('text/html')
     // Used as fallback when content type is undefined.
     const pathEndsWithHTML = parsedUrl?.path?.endsWith('.html')
 
-    return contentTypeIsHtml ?? pathEndsWithHTML;
+    return contentTypeIsHtml ?? !!pathEndsWithHTML;
 }
 
 


### PR DESCRIPTION
We calculate if a page is an html page by the content-type header, so it's irrelevant to throw an exception when the url path is not parseable.