### PR TITLE
chore: check that each redis url db number is defined correctly

### DIFF
--- a/portal/server/next-env.d.ts
+++ b/portal/server/next-env.d.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 

--- a/portal/server/src/configuration_loader.ts
+++ b/portal/server/src/configuration_loader.ts
@@ -63,8 +63,15 @@ const configurationSchema =
 					message: "SENTRY_TRACES_SAMPLE_RATE must be between 0 and 1",
 				}),
 	    suinsClientNetwork: z.enum(["testnet", "mainnet"]),
-	    blocklistRedisUrl: z.string().optional(),
-	    allowlistRedisUrl: z.string().optional(),
+	    blocklistRedisUrl: z.string().url({message: "BLOCKLIST_REDIS_URL is not a valid URL!"}).optional().refine(
+				// Ensure that the database number is specified and is 0 - this is the blocklist database.
+				(val) => val === undefined || val.endsWith('0')
+			),
+	    allowlistRedisUrl: z.string().url({message: "ALLOWLIST_REDIS_URL is not a valid URL!"}).optional()
+			.refine(
+				// Ensure that the database number is specified and is 1 - this is the allowlist database.
+				(val) => val === undefined || val.endsWith('1')
+			),
 		amplitudeApiKey: z.string().optional(),
 	})
   	.refine(

--- a/portal/server/src/configuration_loader.ts
+++ b/portal/server/src/configuration_loader.ts
@@ -65,12 +65,14 @@ const configurationSchema =
 	    suinsClientNetwork: z.enum(["testnet", "mainnet"]),
 	    blocklistRedisUrl: z.string().url({message: "BLOCKLIST_REDIS_URL is not a valid URL!"}).optional().refine(
 				// Ensure that the database number is specified and is 0 - this is the blocklist database.
-				(val) => val === undefined || val.endsWith('0')
+				(val) => val === undefined || val.endsWith('0'),
+				{message: "BLOCKLIST_REDIS_URL must end with '0' to use the blocklist database."}
 			),
 	    allowlistRedisUrl: z.string().url({message: "ALLOWLIST_REDIS_URL is not a valid URL!"}).optional()
 			.refine(
 				// Ensure that the database number is specified and is 1 - this is the allowlist database.
-				(val) => val === undefined || val.endsWith('1')
+				(val) => val === undefined || val.endsWith('1'),
+				{message: "ALLOWLIST_REDIS_URL must end with '1' to use the allowlist database."}
 			),
 		amplitudeApiKey: z.string().optional(),
 	})


### PR DESCRIPTION
Update the configuration loader zod parsing checks so that when redis urls are provided for the blocklist and allowlist, each database number should be defined correctly. This acts as a Ulysses pact, to prevent us from switching accidentally the db numbers.

i.e. we use the same redis instance for both databases. However, for each database a number should be defined.
The blocklist database should be database `0` and the allowlist the database `1`. 

e.g. 
- `BLOCKLIST_REDIS_URL = redis[s]://[[same-username][:same-password]@][same-host][:same-port][/0]`
- `ALLOWLIST_REDIS_URL = redis[s]://[[same-username][:same-password]@][same-host][:same-port][/1]`