### PR TITLE
fix: prevent 404.html override when routes exist

### DIFF
--- a/portal/common/.env.test
+++ b/portal/common/.env.test
@@ -1,1 +1,3 @@
 RPC_URL_LIST="https://fullnode.testnet.sui.io,https://sui-testnet.public.blastapi.io,https://testnet.suiet.app"
+AGGREGATOR_URL="https://aggregator.walrus-testnet.walrus.space"
+SITE_PACKAGE="0xc5bebae319fc9d2a9dc858b7484cdbd6ef219decf4662dc81a11dc69bb7a5fa7"

--- a/portal/common/lib/http/http_error_responses.ts
+++ b/portal/common/lib/http/http_error_responses.ts
@@ -25,6 +25,13 @@ export function fullNodeFail(): Response {
     return Response404("Failed to contact the full node.");
 }
 
+export function resourceNotFound(): Response {
+    return Response404(
+        mainNotFoundErrorMessage,
+        "Resource not found: The requested resource does not exist."
+    );
+}
+
 function Response404(message: String, secondaryMessage?: String): Response {
     const interpolated = template_404
         .replace("${message}", message)

--- a/portal/common/lib/routing.test.ts
+++ b/portal/common/lib/routing.test.ts
@@ -2,13 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { WalrusSitesRouter } from "./routing";
-import { test, expect } from "vitest";
+import { test, expect, describe } from "vitest";
 import { RPCSelector } from "./rpc_selector";
+import { UrlFetcher } from "./url_fetcher";
+import { ResourceFetcher } from "./resource";
+import { SuiNSResolver } from "./suins";
 
 const snakeSiteObjectId = "0x7a95e4be3948415b852fb287d455166a276d7a52f1a567b4a26b6b5e9c753158";
-const wsRouter = new WalrusSitesRouter(
-    new RPCSelector(process.env.RPC_URL_LIST!.split(","), "testnet"),
-);
+const rpcSelector = new RPCSelector(process.env.RPC_URL_LIST!.split(","), "testnet");
+const wsRouter = new WalrusSitesRouter(rpcSelector);
 
 test.skip("getRoutes", async () => {
     // TODO: when you make sure get_routes fetches
@@ -50,4 +52,47 @@ testCases.forEach(([requestPath, _]) => {
         const match = wsRouter.matchPathToRoute(requestPath, emptyRoutes);
         expect(match).toEqual(undefined);
     });
+});
+
+describe('routing tests', () => {
+    test("should check routes before 404.html", async () => {
+
+        const urlFetcher = new UrlFetcher(
+            new ResourceFetcher(rpcSelector),
+            new SuiNSResolver(rpcSelector),
+            wsRouter
+        );
+
+        const siteObjectId = "0x0977d45a9adb8af8405c0698b0e049de05f8c89da75ca16ac6a6cba76031519f";
+
+        // First get the actual content directly through resolveDomainAndFetchUrl
+        const directResponse = await urlFetcher.resolveDomainAndFetchUrl({
+            subdomain: siteObjectId,
+            path: "/test.html"
+        }, siteObjectId);
+        expect(directResponse.status).toBe(200);
+        const expectedContent = await directResponse.text();
+
+        // Now test the routing flow
+        const routedResponse = await urlFetcher.resolveDomainAndFetchUrl({
+            subdomain: siteObjectId,
+            path: "/test"
+        }, siteObjectId);
+        expect(routedResponse.status).toBe(200);
+        const actualContent = await routedResponse.text();
+
+        // Verify we got the same content as direct fetch
+        expect(actualContent).toBe(expectedContent);
+
+        // Also fetch 404.html to prove we got different content
+        const notFoundResponse = await urlFetcher.resolveDomainAndFetchUrl({
+            subdomain: siteObjectId,
+            path: "/404.html"
+        }, siteObjectId);
+        expect(notFoundResponse.status).toBe(200);
+        const notFoundContent = await notFoundResponse.text();
+
+        // Verify we didn't get 404.html content
+        expect(actualContent).not.toBe(notFoundContent);
+    }, { timeout: 30000 });
 });

--- a/portal/common/lib/routing.test.ts
+++ b/portal/common/lib/routing.test.ts
@@ -11,6 +11,8 @@ import { SuiNSResolver } from "./suins";
 const snakeSiteObjectId = "0x7a95e4be3948415b852fb287d455166a276d7a52f1a567b4a26b6b5e9c753158";
 const rpcSelector = new RPCSelector(process.env.RPC_URL_LIST!.split(","), "testnet");
 const wsRouter = new WalrusSitesRouter(rpcSelector);
+const aggregatorUrl = process.env.AGGREGATOR_URL;
+const sitePackage = process.env.SITE_PACKAGE;
 
 test.skip("getRoutes", async () => {
     // TODO: when you make sure get_routes fetches
@@ -61,9 +63,10 @@ describe('routing tests', () => {
 
     test("should check routes before 404.html", async () => {
         const urlFetcher = new UrlFetcher(
-            new ResourceFetcher(rpcSelector),
+            new ResourceFetcher(rpcSelector, sitePackage),
             new SuiNSResolver(rpcSelector),
-            wsRouter
+            wsRouter,
+            aggregatorUrl
         );
 
         const fetchUrlSpy = vi.spyOn(urlFetcher, 'fetchUrl');

--- a/portal/common/lib/url_fetcher.ts
+++ b/portal/common/lib/url_fetcher.ts
@@ -159,7 +159,7 @@ export class UrlFetcher {
      * @param objectId - The object ID of the site object.
      * @param path - The path of the site resource to fetch. e.g. /index.html
      */
-    private async fetchUrl(
+    public async fetchUrl(
         objectId: string,
         path: string,
     ): Promise<Response> {


### PR DESCRIPTION
When a website has a custom 404.html (e.g., from Next.js build), we incorrectly fetch it without checking routes first. This breaks routing functionality for websites that include 404.html in their build output. Modified route resolution order and added test case to verify proper behavior.

Fixes #400