### PR TITLE
fix: amplitude user agent header

### DIFF
--- a/portal/docker/server/Dockerfile
+++ b/portal/docker/server/Dockerfile
@@ -59,4 +59,4 @@ COPY --from=install /temp/prod/server/.next server/.next
 USER bun
 EXPOSE 3000/tcp
 ENV NODE_ENV=production
-CMD [ "bun", "run", "server:prod" ]
+CMD [ "bun", "run", "server" ]

--- a/portal/package.json
+++ b/portal/package.json
@@ -14,6 +14,5 @@
     "worker": "bun -F worker serve:prod",
     "build:server": "bun -F server build",
     "server": "bun -F server start",
-    "server:prod": "bun -F server start:prod"
   }
 }

--- a/portal/package.json
+++ b/portal/package.json
@@ -13,6 +13,6 @@
     "build:worker": "bun -F worker build:prod",
     "worker": "bun -F worker serve:prod",
     "build:server": "bun -F server build",
-    "server": "bun -F server start",
+    "server": "bun -F server start"
   }
 }

--- a/portal/server/app/route.ts
+++ b/portal/server/app/route.ts
@@ -29,7 +29,7 @@ export async function GET(req: NextRequest) {
 
     // Send the page view event to either Amplitude or Vercel Web Analytics.
     if (config.amplitudeApiKey) {
-		await sendToAmplitude(req);
+		await sendToAmplitude(req, url);
 	}
     if (config.enableVercelWebAnalytics) {
 		await sendToWebAnalytics(req);

--- a/portal/server/package.json
+++ b/portal/server/package.json
@@ -5,8 +5,7 @@
     "scripts": {
         "dev": "next dev",
         "build": "next build",
-        "start": "next start",
-        "start:prod": "next start -H 0.0.0.0 -p 3000"
+        "start": "next start"
     },
     "dependencies": {
         "@amplitude/analytics-node": "^1.3.6",


### PR DESCRIPTION
amplitude is kind of broken after being moved behind a LB
1. `request.nextUrl` is not being reliable behind a LB, it's showing something like `http://localhost:3000/something` in the log, we cannot infer subdomain from `localhost`
2. `ua = new uaparser.UAParser(request.headers.get("user-agent") ?? undefined);` will always fail as the `UAParser` due to constructor overload. By always passing a string to the constructor, we can avoid the confusion.
3. `request.headers.get("x-forwarded-for")` are something like `ip1, ip2` behind GCP LB, we should always take the first ip in the chain, otherwise Amplitude will be confused and show completely incorrect geo country.