### PR TITLE
fix(site-builder): fix parsing of blob extensions

### DIFF
--- a/site-builder/src/walrus/output.rs
+++ b/site-builder/src/walrus/output.rs
@@ -40,6 +40,19 @@ pub enum RegisterBlobOp {
     ReuseStorage { encoded_length: u64 },
     /// A registration was already present.
     ReuseRegistration { encoded_length: u64 },
+    /// The blob was already certified, but its lifetime is too short.
+    ReuseAndExtend {
+        encoded_length: u64,
+        // The number of epochs extended wrt the original epoch end.
+        epochs_extended: EpochCount,
+    },
+    /// The blob was registered, but not certified, and its lifetime is shorter than
+    /// the desired one.
+    ReuseAndExtendNonCertified {
+        encoded_length: u64,
+        // The number of epochs extended wrt the original epoch end.
+        epochs_extended: EpochCount,
+    },
 }
 
 /// Result when attempting to store a blob.


### PR DESCRIPTION
Recently, support for blob extensions was added to the `walrus` CLI, this PR makes the site-builder compatible with these new outputs. See [here](https://github.com/MystenLabs/walrus-docs/actions/runs/13430256831/job/37537274187) for an example of the incompatibility.

This should be cherry-picked to the `testnet` branch.