### PR TITLE
fix(logs): when sentry is enabled logs should still be human readable

### DIFF
--- a/portal/server/src/sentry_logger.ts
+++ b/portal/server/src/sentry_logger.ts
@@ -7,26 +7,29 @@ import * as Sentry from "@sentry/bun";
 function addLoggingArgsToSentry(args: { [key: string]: any }) {
     Object.entries(args).forEach(([key, value]) => {
         if (key !== "message") { // Skipping the 'message' key
-            console.log(`${key}: ${value}`)
-            Sentry.setTag(key, value);
+        Sentry.setTag(key, value);
         }
     });
 }
 
 function integrateLoggerWithSentry() {
     logger.setErrorPredicate(args => {
-        addLoggingArgsToSentry(args);
+   		console.error(JSON.stringify(args).replace('\n', ''))
+    	addLoggingArgsToSentry(args);
         Sentry.captureException(new Error(args.message ))
     });
     logger.setWarnPredicate(args => {
+  		console.warn(JSON.stringify(args).replace('\n', ''))
         addLoggingArgsToSentry(args);
         Sentry.addBreadcrumb({ message: args.message, data: args, level: 'warning' })
     } );
     logger.setInfoPredicate(args => {
+  		console.info(JSON.stringify(args).replace('\n', ''))
         addLoggingArgsToSentry(args);
         Sentry.addBreadcrumb({ message: args.message, data: args, level: 'info'})
     } );
     logger.setDebugPredicate(args => {
+  		console.debug(JSON.stringify(args).replace('\n', ''))
         addLoggingArgsToSentry(args);
         Sentry.addBreadcrumb({ message: args.message, data: args, level: 'debug' })
     });


### PR DESCRIPTION
When Sentry was enabled the console logs would lose their structure.
This PR fixes this by showing logs as they would be in the case where sentry is not enabled.

i.e.
**Before**
```
| "range":"null"
│ "rpcClientSelected":"https://fullnode.testnet.sui.io"
│ "fetchedResourceResult":"{\"path\":\"/projects2.png\",\"headers\":{},\"blob_id\":\"Dbt-53bmZNbD0LhqZw_2i-19heJATVXICE9YGI

```

**After**
```
│ {"message":"Add the range headers of the resource","range":"null"}
│ {"message":"RPC selected","rpcClientSelected":"https://fullnode.testnet.sui.io"}
│ {"message":"Successfully fetched resource!","fetchedResourceResult":"{\"path\":\"/projects2.png\",\"headers\":{},\"blob_id\":\"Dbt-53bmZNbD0LhqZw_2i-19heJATVXICE9YGI
```