### PR TITLE
chore: fix dockerfile

### DIFF
--- a/portal/docker/server/Dockerfile
+++ b/portal/docker/server/Dockerfile
@@ -1,6 +1,6 @@
 # use the official Bun image
 # see all versions at https://hub.docker.com/r/oven/bun/tags
-FROM oven/bun:1 AS base
+FROM oven/bun:1.1 AS base
 WORKDIR /usr/src/app
 
 # install dependencies into temp directory

--- a/portal/docker/server/Dockerfile
+++ b/portal/docker/server/Dockerfile
@@ -3,6 +3,10 @@
 FROM oven/bun:1 AS base
 WORKDIR /usr/src/app
 
+# install dependencies into temp directory
+# this will cache them and speed up future builds
+FROM base AS install
+
 RUN apt-get update -y
 RUN apt-get install -y ca-certificates
 
@@ -44,14 +48,12 @@ ENV AGGREGATOR_URL=${AGGREGATOR_URL}
 ARG SITE_PACKAGE="0xc5bebae319fc9d2a9dc858b7484cdbd6ef219decf4662dc81a11dc69bb7a5fa7"
 ENV SITE_PACKAGE=${SITE_PACKAGE}
 
-# install dependencies into temp directory
-# this will cache them and speed up future builds
-FROM base AS install
 RUN mkdir -p /temp/prod
 COPY portal/package.json portal/bun.lock /temp/prod/
 COPY portal/common /temp/prod/common
 COPY portal/server /temp/prod/server
 COPY portal/worker /temp/prod/worker
+COPY public/ /temp/prod/public
 RUN cd /temp/prod && bun install --frozen-lockfile
 RUN cd /temp/prod && bun run build:server
 
@@ -62,6 +64,7 @@ COPY --from=install /temp/prod/node_modules node_modules
 COPY --from=install /temp/prod/package.json .
 COPY --from=install /temp/prod/server/package.json server/package.json
 COPY --from=install /temp/prod/server/.next server/.next
+COPY --from=install /temp/prod/public public/
 
 # run the app
 USER bun
@@ -75,6 +78,7 @@ COPY --from=install /temp/prod/node_modules node_modules
 COPY --from=install /temp/prod/package.json .
 COPY --from=install /temp/prod/server/package.json server/package.json
 COPY --from=install /temp/prod/server/.next server/.next
+COPY --from=install /temp/prod/public public/
 
 # run the app
 USER bun

--- a/portal/docker/server/Dockerfile
+++ b/portal/docker/server/Dockerfile
@@ -53,7 +53,7 @@ COPY portal/package.json portal/bun.lock /temp/prod/
 COPY portal/common /temp/prod/common
 COPY portal/server /temp/prod/server
 COPY portal/worker /temp/prod/worker
-COPY public/ /temp/prod/public
+COPY portal/public /temp/prod/public
 RUN cd /temp/prod && bun install --frozen-lockfile
 RUN cd /temp/prod && bun run build:server
 

--- a/portal/docker/server/Dockerfile
+++ b/portal/docker/server/Dockerfile
@@ -1,6 +1,6 @@
 # use the official Bun image
 # see all versions at https://hub.docker.com/r/oven/bun/tags
-FROM oven/bun:1.1 AS base
+FROM oven/bun:1.2.1 AS base
 WORKDIR /usr/src/app
 
 # install dependencies into temp directory

--- a/portal/docker/server/Dockerfile
+++ b/portal/docker/server/Dockerfile
@@ -63,7 +63,7 @@ COPY --from=install /temp/prod/node_modules node_modules
 COPY --from=install /temp/prod/package.json .
 COPY --from=install /temp/prod/server/package.json server/package.json
 COPY --from=install /temp/prod/server/.next server/.next
-COPY --from=install /temp/prod/server/public public/
+COPY --from=install /temp/prod/server/public server/public/
 
 # run the app
 USER bun
@@ -77,7 +77,7 @@ COPY --from=install /temp/prod/node_modules node_modules
 COPY --from=install /temp/prod/package.json .
 COPY --from=install /temp/prod/server/package.json server/package.json
 COPY --from=install /temp/prod/server/.next server/.next
-COPY --from=install /temp/prod/server/public public/
+COPY --from=install /temp/prod/server/public server/public/
 
 # run the app
 USER bun

--- a/portal/docker/server/Dockerfile
+++ b/portal/docker/server/Dockerfile
@@ -63,7 +63,7 @@ COPY --from=install /temp/prod/node_modules node_modules
 COPY --from=install /temp/prod/package.json .
 COPY --from=install /temp/prod/server/package.json server/package.json
 COPY --from=install /temp/prod/server/.next server/.next
-COPY --from=install /temp/prod/public public/
+COPY --from=install /temp/prod/server/public public/
 
 # run the app
 USER bun

--- a/portal/docker/server/Dockerfile
+++ b/portal/docker/server/Dockerfile
@@ -53,7 +53,6 @@ COPY portal/package.json portal/bun.lock /temp/prod/
 COPY portal/common /temp/prod/common
 COPY portal/server /temp/prod/server
 COPY portal/worker /temp/prod/worker
-COPY portal/public /temp/prod/public
 RUN cd /temp/prod && bun install --frozen-lockfile
 RUN cd /temp/prod && bun run build:server
 
@@ -78,7 +77,7 @@ COPY --from=install /temp/prod/node_modules node_modules
 COPY --from=install /temp/prod/package.json .
 COPY --from=install /temp/prod/server/package.json server/package.json
 COPY --from=install /temp/prod/server/.next server/.next
-COPY --from=install /temp/prod/public public/
+COPY --from=install /temp/prod/server/public public/
 
 # run the app
 USER bun


### PR DESCRIPTION
1. `over/bun:1` will automatically use latest 1.x.x release, which is 1.2.4 now, but it has some compatibility issues with the current version of `zod` we're using, so fixing it to 1.2.1 as indicated in bun.lock
2. make base image cleaner, those env vars are needed only during building phase, so no need to be in the base image.
3. copy `public/` folder over so that we can serve `walrus-site-sw.js` for some 404 issues