### PR TITLE
fix: modify destroy command to use latest Walrus multi-delete command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3162,6 +3162,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5997,6 +6006,7 @@ dependencies = [
  "flate2",
  "futures",
  "home",
+ "itertools 0.14.0",
  "move-core-types",
  "notify",
  "rand",

--- a/site-builder/Cargo.toml
+++ b/site-builder/Cargo.toml
@@ -17,6 +17,7 @@ fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto" }
 flate2 = "1.0.30"
 futures = "0.3.30"
 home = "0.5.9"
+itertools = "0.14.0"
 move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.39.0" }
 notify = "6.1.1"
 rand = "0.8.5"

--- a/site-builder/src/walrus.rs
+++ b/site-builder/src/walrus.rs
@@ -15,6 +15,7 @@ use output::{
     StorageInfoOutput,
     StoreOutput,
 };
+use sui_types::base_types::ObjectID;
 use tokio::process::Command as CliCommand;
 
 use self::types::BlobId;
@@ -93,8 +94,8 @@ impl Walrus {
     }
 
     /// Issues a `delete` JSON command to the Walrus CLI, returning the parsed output.
-    pub async fn delete(&mut self, object_id: String) -> Result<DestroyOutput> {
-        create_command!(self, delete, object_id)
+    pub async fn delete(&mut self, object_ids: Vec<ObjectID>) -> Result<DestroyOutput> {
+        create_command!(self, delete, object_ids)
     }
 
     /// Issues a `store with dry run arg` JSON command to the Walrus CLI, returning the parsed output.

--- a/site-builder/src/walrus/command.rs
+++ b/site-builder/src/walrus/command.rs
@@ -8,6 +8,7 @@ use std::{num::NonZeroU16, path::PathBuf};
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
+use sui_types::base_types::ObjectID;
 
 use super::types::BlobId;
 use crate::EpochCountOrMax;
@@ -76,7 +77,8 @@ pub enum Command {
     /// Deletes a blob from Walrus.
     Delete {
         /// The objectID of the blob to be deleted.
-        object_id: String,
+        #[serde_as(as = "Vec<DisplayFromStr>")]
+        object_ids: Vec<ObjectID>,
     },
     BlobId {
         file: PathBuf,
@@ -191,8 +193,8 @@ impl WalrusCmdBuilder {
     }
 
     /// Adds a [`Command::Delete`] command to the builder.
-    pub fn delete(self, object_id: String) -> WalrusCmdBuilder<Command> {
-        let command = Command::Delete { object_id };
+    pub fn delete(self, object_ids: Vec<ObjectID>) -> WalrusCmdBuilder<Command> {
+        let command = Command::Delete { object_ids };
         self.with_command(command)
     }
 

--- a/site-builder/src/walrus/output.rs
+++ b/site-builder/src/walrus/output.rs
@@ -220,13 +220,18 @@ pub struct BlobIdOutput {
 
 /// The output of the `destroy` command.
 #[derive(Debug, Clone, Deserialize)]
-#[allow(unused)]
-#[allow(non_snake_case)]
-pub struct DestroyOutput {
+pub struct DestroyOutput(pub Vec<DeleteOutput>);
+
+/// The output of the `destroy` command.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+pub struct DeleteOutput {
     /// The objectId deleted.
-    pub objectId: String,
+    // TODO: Check if we need another hierarchy level here.
+    pub object_id: String,
     /// The blobs deleted.
-    pub deletedBlobs: Vec<String>,
+    pub deleted_blobs: Vec<Blob>,
 }
 
 /// The number of shards, which can be deserialized from the output of the `info` command.


### PR DESCRIPTION
The `delete` command of the Walrus CLI was improved in https://github.com/MystenLabs/walrus/pull/1644, with some breaking changes to the JSON API.

Some open TODOs:
- [ ] Error handling.
- [ ] Check if there are some other changes to the `delete` command.
