### PR TITLE
fix: redis-client issue connect only once

### DIFF
--- a/portal/blocklist_api/src/redis.ts
+++ b/portal/blocklist_api/src/redis.ts
@@ -94,4 +94,8 @@ if (!redisUrl.endsWith('0')) {
 const redisClient = new RedisClientFacade(
 	redisUrl
 );
+(async () => {
+    await redisClient.connect();
+})();
+
 export default redisClient;


### PR DESCRIPTION
forgot to issue `connect()`