### PR TITLE
feat(portal): sew 82 testnet portal until mainnet should not support b36 domains

### DIFF
--- a/portal/common/lib/routing.test.ts
+++ b/portal/common/lib/routing.test.ts
@@ -66,7 +66,8 @@ describe('routing tests', () => {
             new ResourceFetcher(rpcSelector, sitePackage),
             new SuiNSResolver(rpcSelector),
             wsRouter,
-            aggregatorUrl
+            aggregatorUrl,
+            true
         );
 
         const fetchUrlSpy = vi.spyOn(urlFetcher, 'fetchUrl');

--- a/portal/common/lib/suins.ts
+++ b/portal/common/lib/suins.ts
@@ -27,7 +27,7 @@ export class SuiNSResolver {
         return null;
     }
 
-    hardcodedSubdmains(subdomain: string): string | null {
+    hardcodedSubdomains(subdomain: string): string | null {
         if (subdomain in SITE_NAMES) {
             return SITE_NAMES[subdomain];
         }

--- a/portal/docker/server/Dockerfile
+++ b/portal/docker/server/Dockerfile
@@ -48,6 +48,9 @@ ENV AGGREGATOR_URL=${AGGREGATOR_URL}
 ARG SITE_PACKAGE="0xc5bebae319fc9d2a9dc858b7484cdbd6ef219decf4662dc81a11dc69bb7a5fa7"
 ENV SITE_PACKAGE=${SITE_PACKAGE}
 
+ARG B36_DOMAIN_RESOLUTION_SUPPORT="true"
+ENV B36_DOMAIN_RESOLUTION_SUPPORT=${B36_DOMAIN_RESOLUTION_SUPPORT}
+
 RUN mkdir -p /temp/prod
 COPY portal/package.json portal/bun.lock /temp/prod/
 COPY portal/common /temp/prod/common

--- a/portal/server/.env.example
+++ b/portal/server/.env.example
@@ -9,3 +9,4 @@ RPC_URL_LIST="https://fullnode.testnet.sui.io,https://testnet.suiet.app"
 SUINS_CLIENT_NETWORK="testnet"
 AGGREGATOR_URL="https://aggregator.walrus-testnet.walrus.space"
 SITE_PACKAGE="0xc5bebae319fc9d2a9dc858b7484cdbd6ef219decf4662dc81a11dc69bb7a5fa7"
+B36_DOMAIN_RESOLUTION_SUPPORT=true

--- a/portal/server/app/route.ts
+++ b/portal/server/app/route.ts
@@ -14,6 +14,7 @@ import { standardUrlFetcher, premiumUrlFetcher } from "src/url_fetcher_factory";
 import { NextRequest } from "next/server";
 import { sendToWebAnalytics } from "src/web_analytics";
 import { sendToAmplitude } from "src/amplitude";
+import { Base36toHex } from "@lib/objectId_operations";
 
 if (config.enableSentry) {
     // Only integrate Sentry on production.
@@ -70,13 +71,15 @@ export async function GET(req: NextRequest) {
     if (atBaseUrl) {
         console.log("Serving the landing page from walrus...");
         // Always use the premium page fetcher for the landing page (when available).
+        // The landing page is an exception to the B36_DOMAIN_RESOLUTION_SUPPORT rule.
+        // It will always resolve to an objectId.
         const urlFetcher = config.enableAllowlist ? premiumUrlFetcher : standardUrlFetcher;
         const response = await urlFetcher.resolveDomainAndFetchUrl(
             {
                 subdomain: config.landingPageOidB36,
                 path: parsedUrl?.path ?? "/index.html",
             },
-            null,
+            Base36toHex(config.landingPageOidB36),
             blocklistChecker
         );
         return response;

--- a/portal/server/src/configuration_loader.ts
+++ b/portal/server/src/configuration_loader.ts
@@ -29,6 +29,7 @@ const configurationSchema =
 		amplitudeApiKey: env.AMPLITUDE_API_KEY,
 		aggregatorUrl: env.AGGREGATOR_URL,
 		sitePackage: env.SITE_PACKAGE,
+		b36DomainResolutionSupport: env.B36_DOMAIN_RESOLUTION_SUPPORT
 	}),
 	z.object({
 		edgeConfig: z.string().optional(),
@@ -79,6 +80,7 @@ const configurationSchema =
 		amplitudeApiKey: z.string().optional(),
 		aggregatorUrl: z.string().url({message: "AGGREGATOR_URL is not a valid URL!"}),
 		sitePackage: z.string().refine((val) => val.length === 66 && /^0x[0-9a-fA-F]+$/.test(val)),
+		b36DomainResolutionSupport: stringBoolean
 	})
   	.refine(
    	(data) => {

--- a/portal/server/src/url_fetcher_factory.ts
+++ b/portal/server/src/url_fetcher_factory.ts
@@ -27,7 +27,8 @@ class UrlFetcherFactory {
             new ResourceFetcher(this.premiumRpcSelector, config.sitePackage),
             new SuiNSResolver(this.premiumRpcSelector),
             new WalrusSitesRouter(this.premiumRpcSelector),
-            config.aggregatorUrl
+            config.aggregatorUrl,
+            config.b36DomainResolutionSupport
         );
     }
 
@@ -36,7 +37,8 @@ class UrlFetcherFactory {
             new ResourceFetcher(this.standardRpcSelector, config.sitePackage),
             new SuiNSResolver(this.standardRpcSelector),
             new WalrusSitesRouter(this.standardRpcSelector),
-            config.aggregatorUrl
+            config.aggregatorUrl,
+            config.b36DomainResolutionSupport
         );
     }
 }

--- a/portal/worker/src/walrus-sites-sw.ts
+++ b/portal/worker/src/walrus-sites-sw.ts
@@ -35,6 +35,7 @@ export const urlFetcher = new UrlFetcher(
     new SuiNSResolver(rpcSelector),
     new WalrusSitesRouter(rpcSelector),
     aggregatorUrl,
+    true // b36 domain support should always be enabled for service workers.
 );
 
 self.addEventListener("install", (_event) => {

--- a/site-builder/src/publish.rs
+++ b/site-builder/src/publish.rs
@@ -338,9 +338,15 @@ fn print_summary(
     };
 
     println!(
-        "Browse the resulting site at: https://{}.{}",
-        id_to_base36(&object_id)?,
-        config.portal
+        r#"To browse the site, you have the following options:
+        1. Run a local portal, and browse the site through it: e.g. http://{base36_id}.localhost:3000
+           (more info: https://docs.walrus.site/walrus-sites/portal.html#running-the-portal-locally)
+        2. Use a third-party portal (e.g. walrus.site), which will require a SuiNS name.
+           First, buy a SuiNS name at suins.io (e.g. example-domain), then point it to the site object ID.
+           Finally, browse it with: https://example-domain.{portal}
+           "#,
+        base36_id = id_to_base36(&object_id)?,
+        portal = config.portal
     );
     Ok(())
 }


### PR DESCRIPTION
- Create a B36_DOMAIN_RESOLUTION_SUPPORT environment variable.
- Integrate it to the UrlFetcher class.
- The landing page b36 will always resolve to an object Id regardless of B36_DOMAIN_RESOLUTION_SUPPORT.
- Add B36_DOMAIN_RESOLUTION_SUPPORT to the server/Dockerfile.
- ⚠️ The service worker will always support b36 domains. 
- Update the site-builder publish output string. (`Browse the site with ...`).

Related PR on sui-operations: https://github.com/MystenLabs/sui-operations/pull/5078