### PR TITLE
feat(docker): add gh action to publish testnet sp to docker hub

### DIFF
--- a/.github/workflows/docker-hub-testnet-sp.yml
+++ b/.github/workflows/docker-hub-testnet-sp.yml
@@ -50,6 +50,14 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             ENABLE_SENTRY=false
+            ENABLE_BLOCKLIST=false
+            ENABLE_ALLOWLIST=false
+            LANDING_PAGE_OID_B36=41qecxqcyzqm8gl0cp2fqd6iq62j0jo5thr39nb0bsg39acnib
+            PREMIUM_RPC_URL_LIST=https://fullnode.testnet.sui.io
+            RPC_URL_LIST=https://fullnode.testnet.sui.io,https://testnet.suiet.app
+            SUINS_CLIENT_NETWORK=testnet
+            AGGREGATOR_URL=https://aggregator.walrus-testnet.walrus.space
+            SITE_PACKAGE=0xc5bebae319fc9d2a9dc858b7484cdbd6ef219decf4662dc81a11dc69bb7a5fa7
           no-cache: true
 
       - name: Generate artifact attestation

--- a/.github/workflows/docker-hub-testnet-sp.yml
+++ b/.github/workflows/docker-hub-testnet-sp.yml
@@ -50,14 +50,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             ENABLE_SENTRY=false
-            ENABLE_BLOCKLIST=false
-            ENABLE_ALLOWLIST=false
-            LANDING_PAGE_OID_B36=41qecxqcyzqm8gl0cp2fqd6iq62j0jo5thr39nb0bsg39acnib
-            PREMIUM_RPC_URL_LIST=https://fullnode.testnet.sui.io
-            RPC_URL_LIST=https://fullnode.testnet.sui.io,https://testnet.suiet.app
-            SUINS_CLIENT_NETWORK=testnet
-            AGGREGATOR_URL=https://aggregator.walrus-testnet.walrus.space
-            SITE_PACKAGE=0xc5bebae319fc9d2a9dc858b7484cdbd6ef219decf4662dc81a11dc69bb7a5fa7
           no-cache: true
 
       - name: Generate artifact attestation

--- a/.github/workflows/docker-hub-testnet-sp.yml
+++ b/.github/workflows/docker-hub-testnet-sp.yml
@@ -1,0 +1,60 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# GitHub recommends pinning actions to a commit SHA.
+# To get a newer version, you will need to update the SHA.
+# You can also reference a tag or branch, but the action may change without warning.
+
+name: Publish Docker image
+
+on:
+  push:
+    branches: [testnet]
+  workflow_dispatch:
+
+jobs:
+  push_to_registry:
+    name: Push testnet server portal Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.DOCKER_HUB_NAMESPACE }}/${{ env.DOCKER_HUB_REPOSITORY }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: .
+          file: ./portal/docker/server/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            ENABLE_SENTRY=false
+          no-cache: true
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: index.docker.io/${{ env.DOCKER_HUB_NAMESPACE }}/${{ env.DOCKER_HUB_REPOSITORY }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/portal/docker/server/Dockerfile
+++ b/portal/docker/server/Dockerfile
@@ -57,7 +57,7 @@ RUN cd /temp/prod && bun install --frozen-lockfile
 RUN cd /temp/prod && bun run build:server
 
 # debug image target
-FROM base as debug
+FROM base AS debug
 RUN apt update && apt install -y curl netcat-traditional
 COPY --from=install /temp/prod/node_modules node_modules
 COPY --from=install /temp/prod/package.json .
@@ -78,6 +78,44 @@ COPY --from=install /temp/prod/package.json .
 COPY --from=install /temp/prod/server/package.json server/package.json
 COPY --from=install /temp/prod/server/.next server/.next
 COPY --from=install /temp/prod/server/public server/public/
+
+# environment variables, can be overridden by docker build --build-arg <arg>=<value>
+ARG ENABLE_ALLOWLIST="false"
+ENV ENABLE_ALLOWLIST=${ENABLE_ALLOWLIST}
+
+ARG ENABLE_BLOCKLIST="false"
+ENV ENABLE_BLOCKLIST=${ENABLE_BLOCKLIST}
+
+ARG ENABLE_SENTRY="false"
+ENV ENABLE_SENTRY=${ENABLE_SENTRY}
+ENV SENTRY_LOG_LEVEL=debug
+ENV SENTRY_SUPPRESS_GLOBAL_ERROR_HANDLER_FILE_WARNING=1
+ARG SENTRY_AUTH_TOKEN
+ENV SENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN}
+
+ARG ENABLE_VERCEL_WEB_ANALYTICS="false"
+ENV ENABLE_VERCEL_WEB_ANALYTICS=${ENABLE_VERCEL_WEB_ANALYTICS}
+
+ARG LANDING_PAGE_OID_B36="41qecxqcyzqm8gl0cp2fqd6iq62j0jo5the39nb0bsg39acnib"
+ENV LANDING_PAGE_OID_B36=${LANDING_PAGE_OID_B36}
+
+ARG PORTAL_DOMAIN_NAME_LENGTH=""
+ENV PORTAL_DOMAIN_NAME_LENGTH=${PORTAL_DOMAIN_NAME_LENGTH}
+
+ARG PREMIUM_RPC_URL_LIST="https://fullnode.testnet.sui.io"
+ENV PREMIUM_RPC_URL_LIST=${PREMIUM_RPC_URL_LIST}
+
+ARG RPC_URL_LIST="https://fullnode.testnet.sui.io,https://testnet.suiet.app"
+ENV RPC_URL_LIST=${RPC_URL_LIST}
+
+ARG SUINS_CLIENT_NETWORK="testnet"
+ENV SUINS_CLIENT_NETWORK=${SUINS_CLIENT_NETWORK}
+
+ARG AGGREGATOR_URL="https://aggregator.walrus-testnet.walrus.space"
+ENV AGGREGATOR_URL=${AGGREGATOR_URL}
+
+ARG SITE_PACKAGE="0xc5bebae319fc9d2a9dc858b7484cdbd6ef219decf4662dc81a11dc69bb7a5fa7"
+ENV SITE_PACKAGE=${SITE_PACKAGE}
 
 # run the app
 USER bun


### PR DESCRIPTION
A new docker image will be published each time we merge to testnet. 
The workflow can also be triggered manually.  In the future, we will have to do the same for mainnet. 

⚠️ **Warning**! I updated the Dockerfile, redeclaring the ARG and ENV variables after the `FROM base AS release` step. 
If we don't do this, the environment variables do not persist when running the container after `docker build -f portal/docker/server/Dockerfile -t server-portal --no-cache . --build-arg ENABLE_SENTRY=false`. Dockerfile ARGs disappear between FROM statements: https://stackoverflow.com/a/56748289.

TODO 
- [ ] Setup a testnet server portal namespace and a walrus sites repository in docker hub. 
- [ ] Update the environment variable and secrets accordingly.