### PR TITLE
feat: sew 100 include events upon site creation and update

### DIFF
--- a/move/walrus_site/Move.lock
+++ b/move/walrus_site/Move.lock
@@ -22,7 +22,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.41.0"
+compiler-version = "1.44.3"
 edition = "2024.beta"
 flavor = "sui"
 
@@ -36,6 +36,6 @@ published-version = "1"
 
 [env.testnet]
 chain-id = "4c78adac"
-original-published-id = "0xe004477d29e97cc42fa00203227fad8d87eabf583b79618dddfde638e8efc11c"
-latest-published-id = "0xe004477d29e97cc42fa00203227fad8d87eabf583b79618dddfde638e8efc11c"
+original-published-id = "0x9d055e60cc8012d43c396194395e8f80c54afd083d908bdfbc3c37906f59146e"
+latest-published-id = "0x9d055e60cc8012d43c396194395e8f80c54afd083d908bdfbc3c37906f59146e"
 published-version = "1"

--- a/move/walrus_site/sources/events.move
+++ b/move/walrus_site/sources/events.move
@@ -3,7 +3,7 @@ module walrus_site::events {
     use sui::event;
     use walrus_site::metadata::Metadata;
 
-    public struct SiteCreated has copy, drop {
+    public struct SiteCreatedEvent has copy, drop {
         site_id: ID,
         site_name: String,
         site_metadata_link: Option<String>,
@@ -13,18 +13,18 @@ module walrus_site::events {
         site_metadata_creator: Option<String>,
     }
 
-    public struct SiteBurned has copy, drop {
+    public struct SiteBurnedEvent has copy, drop {
         site_id: ID,
     }
 
-    public struct SiteNameUpdate has copy, drop {
+    public struct SiteNameUpdateEvent has copy, drop {
         site_id: ID,
         old_name: String,
         new_name: String,
     }
 
     public fun emit_site_created(site_id: ID, name: String, metadata: &Metadata) {
-        event::emit(SiteCreated {
+        event::emit(SiteCreatedEvent {
             site_id,
             site_name: name,
             site_metadata_link: metadata.link(),
@@ -36,13 +36,13 @@ module walrus_site::events {
     }
 
     public fun emit_site_burned(site_id: ID) {
-        event::emit(SiteBurned {
+        event::emit(SiteBurnedEvent {
             site_id,
         });
     }
 
     public fun emit_site_update_name(site_id: ID, old_name: String, new_name: String) {
-        event::emit(SiteNameUpdate {
+        event::emit(SiteNameUpdateEvent {
             site_id,
             old_name,
             new_name,

--- a/move/walrus_site/sources/events.move
+++ b/move/walrus_site/sources/events.move
@@ -23,7 +23,7 @@ module walrus_site::events {
         new_name: String,
     }
 
-    public fun emit_site_created(site_id: ID, name: String, metadata: &Metadata) {
+    public(package) fun emit_site_created(site_id: ID, name: String, metadata: &Metadata) {
         event::emit(SiteCreatedEvent {
             site_id,
             site_name: name,
@@ -35,13 +35,13 @@ module walrus_site::events {
         });
     }
 
-    public fun emit_site_burned(site_id: ID) {
+    public(package) fun emit_site_burned(site_id: ID) {
         event::emit(SiteBurnedEvent {
             site_id,
         });
     }
 
-    public fun emit_site_update_name(site_id: ID, old_name: String, new_name: String) {
+    public(package) fun emit_site_update_name(site_id: ID, old_name: String, new_name: String) {
         event::emit(SiteNameUpdateEvent {
             site_id,
             old_name,

--- a/move/walrus_site/sources/events.move
+++ b/move/walrus_site/sources/events.move
@@ -1,0 +1,52 @@
+module walrus_site::events {
+	use sui::event;
+	use std::string::String;
+	use walrus_site::metadata::Metadata;
+
+    public struct SiteCreated has copy, drop {
+        site_id: ID,
+        site_name: String,
+        site_metadata_link: Option<String>,
+        site_metadata_image_url: Option<String>,
+        site_metadata_description: Option<String>,
+        site_metadata_project_url: Option<String>,
+        site_metadata_creator: Option<String>,
+    }
+
+    public struct SiteBurned has copy, drop {
+    	site_id: ID,
+    }
+
+    public struct SiteNameUpdate has copy, drop {
+    	site_id: ID,
+     	old_name: String,
+      	new_name: String
+    }
+
+    public fun emit_site_created(site_id: ID, name: String, metadata: &Metadata) {
+   		event::emit(SiteCreated {
+		    site_id,
+		    site_name: name,
+		    site_metadata_link: metadata.link(),
+		    site_metadata_image_url: metadata.image_url(),
+		    site_metadata_description: metadata.description(),
+		    site_metadata_project_url: metadata.project_url(),
+		    site_metadata_creator: metadata.creator(),
+	    });
+    }
+
+    public fun emit_site_burned(site_id: ID) {
+     event::emit(SiteBurned {
+     		site_id,
+     	});
+    }
+
+    public fun emit_site_update_name(site_id: ID, old_name: String, new_name: String) {
+     event::emit(SiteNameUpdate {
+     		site_id,
+       		old_name,
+         	new_name
+     	});
+    }
+
+}

--- a/move/walrus_site/sources/events.move
+++ b/move/walrus_site/sources/events.move
@@ -1,7 +1,7 @@
 module walrus_site::events {
-	use sui::event;
-	use std::string::String;
-	use walrus_site::metadata::Metadata;
+    use std::string::String;
+    use sui::event;
+    use walrus_site::metadata::Metadata;
 
     public struct SiteCreated has copy, drop {
         site_id: ID,
@@ -14,39 +14,38 @@ module walrus_site::events {
     }
 
     public struct SiteBurned has copy, drop {
-    	site_id: ID,
+        site_id: ID,
     }
 
     public struct SiteNameUpdate has copy, drop {
-    	site_id: ID,
-     	old_name: String,
-      	new_name: String
+        site_id: ID,
+        old_name: String,
+        new_name: String,
     }
 
     public fun emit_site_created(site_id: ID, name: String, metadata: &Metadata) {
-   		event::emit(SiteCreated {
-		    site_id,
-		    site_name: name,
-		    site_metadata_link: metadata.link(),
-		    site_metadata_image_url: metadata.image_url(),
-		    site_metadata_description: metadata.description(),
-		    site_metadata_project_url: metadata.project_url(),
-		    site_metadata_creator: metadata.creator(),
-	    });
+        event::emit(SiteCreated {
+            site_id,
+            site_name: name,
+            site_metadata_link: metadata.link(),
+            site_metadata_image_url: metadata.image_url(),
+            site_metadata_description: metadata.description(),
+            site_metadata_project_url: metadata.project_url(),
+            site_metadata_creator: metadata.creator(),
+        });
     }
 
     public fun emit_site_burned(site_id: ID) {
-     event::emit(SiteBurned {
-     		site_id,
-     	});
+        event::emit(SiteBurned {
+            site_id,
+        });
     }
 
     public fun emit_site_update_name(site_id: ID, old_name: String, new_name: String) {
-     event::emit(SiteNameUpdate {
-     		site_id,
-       		old_name,
-         	new_name
-     	});
+        event::emit(SiteNameUpdate {
+            site_id,
+            old_name,
+            new_name,
+        });
     }
-
 }

--- a/move/walrus_site/sources/metadata.move
+++ b/move/walrus_site/sources/metadata.move
@@ -1,0 +1,49 @@
+module walrus_site::metadata {
+	use std::string::String;
+
+	/// A struct that contains the Site's metadata.
+    public struct Metadata has copy, drop, store {
+        link: Option<String>,
+        image_url: Option<String>,
+        description: Option<String>,
+        project_url: Option<String>,
+        creator: Option<String>,
+    }
+
+	/// Creates a new Metadata object.
+    public fun new_metadata(
+        link: Option<String>,
+        image_url: Option<String>,
+        description: Option<String>,
+        project_url: Option<String>,
+        creator: Option<String>,
+    ): Metadata {
+        Metadata {
+            link,
+            image_url,
+            description,
+            project_url,
+            creator,
+        }
+    }
+
+    public fun link(metadata: &Metadata): Option<String> {
+    	metadata.link
+    }
+
+    public fun image_url(metadata: &Metadata): Option<String> {
+    	metadata.image_url
+    }
+
+    public fun description(metadata: &Metadata): Option<String> {
+    	metadata.description
+    }
+
+    public fun project_url(metadata: &Metadata): Option<String> {
+    	metadata.project_url
+    }
+
+    public fun creator(metadata: &Metadata): Option<String> {
+    	metadata.creator
+    }
+}

--- a/move/walrus_site/sources/metadata.move
+++ b/move/walrus_site/sources/metadata.move
@@ -1,7 +1,7 @@
 module walrus_site::metadata {
-	use std::string::String;
+    use std::string::String;
 
-	/// A struct that contains the Site's metadata.
+    /// A struct that contains the Site's metadata.
     public struct Metadata has copy, drop, store {
         link: Option<String>,
         image_url: Option<String>,
@@ -10,7 +10,7 @@ module walrus_site::metadata {
         creator: Option<String>,
     }
 
-	/// Creates a new Metadata object.
+    /// Creates a new Metadata object.
     public fun new_metadata(
         link: Option<String>,
         image_url: Option<String>,
@@ -28,22 +28,22 @@ module walrus_site::metadata {
     }
 
     public fun link(metadata: &Metadata): Option<String> {
-    	metadata.link
+        metadata.link
     }
 
     public fun image_url(metadata: &Metadata): Option<String> {
-    	metadata.image_url
+        metadata.image_url
     }
 
     public fun description(metadata: &Metadata): Option<String> {
-    	metadata.description
+        metadata.description
     }
 
     public fun project_url(metadata: &Metadata): Option<String> {
-    	metadata.project_url
+        metadata.project_url
     }
 
     public fun creator(metadata: &Metadata): Option<String> {
-    	metadata.creator
+        metadata.creator
     }
 }

--- a/move/walrus_site/sources/site.move
+++ b/move/walrus_site/sources/site.move
@@ -1,7 +1,11 @@
 /// The module exposes the functionality to create and update Walrus sites.
 module walrus_site::site {
     use std::string::String;
-    use sui::{display::{Self, Display}, dynamic_field as df, package::{Self, Publisher}, vec_map};
+    use sui::{
+    	display::{Self, Display}, dynamic_field as df, package::{Self, Publisher}, vec_map
+    };
+    use walrus_site::events::{emit_site_created, emit_site_burned, emit_site_update_name};
+    use walrus_site::metadata::{Metadata};
 
     /// The name of the dynamic field containing the routes.
     const ROUTES_FIELD: vector<u8> = b"routes";
@@ -15,15 +19,6 @@ module walrus_site::site {
     public struct Site has key, store {
         id: UID,
         name: String,
-        link: Option<String>,
-        image_url: Option<String>,
-        description: Option<String>,
-        project_url: Option<String>,
-        creator: Option<String>,
-    }
-
-    /// A struct that contains the Site's metadata.
-    public struct Metadata has copy, drop, store {
         link: Option<String>,
         image_url: Option<String>,
         description: Option<String>,
@@ -78,39 +73,19 @@ module walrus_site::site {
 
     /// Creates a new site.
     public fun new_site(name: String, metadata: Metadata, ctx: &mut TxContext): Site {
-        let Metadata {
-            link,
-            image_url,
-            description,
-            project_url,
-            creator,
-        } = metadata;
-        Site {
+        let site = Site {
             id: object::new(ctx),
             name,
-            link,
-            image_url,
-            description,
-            project_url,
-            creator,
-        }
-    }
-
-    /// Creates a new Metadata object.
-    public fun new_metadata(
-        link: Option<String>,
-        image_url: Option<String>,
-        description: Option<String>,
-        project_url: Option<String>,
-        creator: Option<String>,
-    ): Metadata {
-        Metadata {
-            link,
-            image_url,
-            description,
-            project_url,
-            creator,
-        }
+            link: metadata.link(),
+            image_url: metadata.image_url(),
+            description: metadata.description(),
+            project_url: metadata.project_url(),
+            creator: metadata.creator(),
+        };
+       	emit_site_created(
+      		object::id(&site), name, &metadata
+       	);
+        site
     }
 
     /// Optionally creates a new Range object.
@@ -172,23 +147,19 @@ module walrus_site::site {
 
     /// Updates the name of a site.
     public fun update_name(site: &mut Site, new_name: String) {
-        site.name = new_name
+    	emit_site_update_name(
+     		object::id(site), site.name, new_name
+     	);
+   		site.name = new_name
     }
 
     /// Update the site metadata.
     public fun update_metadata(site: &mut Site, metadata: Metadata) {
-        let Metadata {
-            link,
-            image_url,
-            description,
-            project_url,
-            creator,
-        } = metadata;
-        site.link = link;
-        site.image_url = image_url;
-        site.description = description;
-        site.project_url = project_url;
-        site.creator = creator;
+        site.link = metadata.link();
+        site.image_url = metadata.image_url();
+        site.description = metadata.description();
+        site.project_url = metadata.project_url();
+        site.creator = metadata.creator();
     }
 
     /// Adds a resource to an existing site.
@@ -275,7 +246,8 @@ module walrus_site::site {
     /// delete the dynamic fields, they will become unaccessible and you will not be able to delete
     /// them in the future.
     public fun burn(site: Site) {
-        let Site {
+    	emit_site_burned(object::id(&site));
+    	let Site {
             id,
             ..,
         } = site;

--- a/move/walrus_site/sources/site.move
+++ b/move/walrus_site/sources/site.move
@@ -1,11 +1,11 @@
 /// The module exposes the functionality to create and update Walrus sites.
 module walrus_site::site {
     use std::string::String;
-    use sui::{
-    	display::{Self, Display}, dynamic_field as df, package::{Self, Publisher}, vec_map
+    use sui::{display::{Self, Display}, dynamic_field as df, package::{Self, Publisher}, vec_map};
+    use walrus_site::{
+        events::{emit_site_created, emit_site_burned, emit_site_update_name},
+        metadata::Metadata
     };
-    use walrus_site::events::{emit_site_created, emit_site_burned, emit_site_update_name};
-    use walrus_site::metadata::{Metadata};
 
     /// The name of the dynamic field containing the routes.
     const ROUTES_FIELD: vector<u8> = b"routes";
@@ -82,9 +82,11 @@ module walrus_site::site {
             project_url: metadata.project_url(),
             creator: metadata.creator(),
         };
-       	emit_site_created(
-      		object::id(&site), name, &metadata
-       	);
+        emit_site_created(
+            object::id(&site),
+            name,
+            &metadata,
+        );
         site
     }
 
@@ -147,10 +149,12 @@ module walrus_site::site {
 
     /// Updates the name of a site.
     public fun update_name(site: &mut Site, new_name: String) {
-    	emit_site_update_name(
-     		object::id(site), site.name, new_name
-     	);
-   		site.name = new_name
+        emit_site_update_name(
+            object::id(site),
+            site.name,
+            new_name,
+        );
+        site.name = new_name
     }
 
     /// Update the site metadata.
@@ -246,8 +250,8 @@ module walrus_site::site {
     /// delete the dynamic fields, they will become unaccessible and you will not be able to delete
     /// them in the future.
     public fun burn(site: Site) {
-    	emit_site_burned(object::id(&site));
-    	let Site {
+        emit_site_burned(object::id(&site));
+        let Site {
             id,
             ..,
         } = site;

--- a/move/walrus_site/tests/site_tests.move
+++ b/move/walrus_site/tests/site_tests.move
@@ -64,7 +64,7 @@ module walrus_site::site_tests {
         let mut scenario = test_scenario::begin(owner);
         // Create a site.
         {
-            let metadata = walrus_site::site::new_metadata(
+            let metadata = walrus_site::metadata::new_metadata(
                 option::some(b"https://<b36>.walrus.site".to_string()),
                 option::some(b"https://<b36>.walrus.site/image.png".to_string()),
                 option::some(b"This is a test site.".to_string()),
@@ -173,7 +173,7 @@ module walrus_site::site_tests {
         let mut scenario = test_scenario::begin(owner);
         // Create a site.
         {
-            let metadata = walrus_site::site::new_metadata(
+            let metadata = walrus_site::metadata::new_metadata(
                 option::some(b"https://<b36>.walrus.site".to_string()),
                 option::some(b"https://<b36>.walrus.site/image.png".to_string()),
                 option::some(b"This is a test site.".to_string()),
@@ -197,7 +197,7 @@ module walrus_site::site_tests {
         {
             let mut site = scenario.take_from_sender<Site>();
             // Update the site metadata.
-            let metadata = walrus_site::site::new_metadata(
+            let metadata = walrus_site::metadata::new_metadata(
                 option::some(b"https://<b36>.walrus.site".to_string()),
                 option::some(b"https://<b36>.walrus.site/image.png".to_string()),
                 option::some(b"I am just updating the site metadata.".to_string()),

--- a/site-builder/src/site/builder.rs
+++ b/site-builder/src/site/builder.rs
@@ -106,7 +106,7 @@ impl<T> SitePtb<T> {
 
         self.pt_builder.programmable_move_call(
             self.package,
-            self.module.clone(),
+            Identifier::new("metadata").unwrap(),
             Identifier::new("new_metadata").unwrap(),
             vec![],
             args,

--- a/sites-config.yaml
+++ b/sites-config.yaml
@@ -1,6 +1,6 @@
 # module: site
 # portal: walrus.site
-package: 0xe004477d29e97cc42fa00203227fad8d87eabf583b79618dddfde638e8efc11c
+package: 0x9d055e60cc8012d43c396194395e8f80c54afd083d908bdfbc3c37906f59146e
 # general:
 #   rpc_url: https://fullnode.testnet.sui.io:443
 #   wallet: /path/to/.sui/sui_config/client.yaml


### PR DESCRIPTION
## Summary
1. Include events for Site creation, deletion, etc. 
2. Refactor: create a separate Metadata module.

## Testing

1. Rebuild the site-builder (note: this PR updates the packageId in the sites-config.yaml)
2. Publish the examples/snake.
3. Make a curl request to listen to one of the events introduced in the contract:
```
curl -X POST https://fullnode.testnet.sui.io:443 \
-H "Content-Type: application/json" \
-d '{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "suix_queryEvents",
  "params": [
    {
      "MoveModule": {
        "package": "0x9d055e60cc8012d43c396194395e8f80c54afd083d908bdfbc3c37906f59146e",
        "module": "site",
        "type": "0x9d055e60cc8012d43c396194395e8f80c54afd083d908bdfbc3c37906f59146e::events::SiteCreated"
      }
    },
    null,
    3,
    false
  ]
}'
```

**Note**: The package id used above might have changed if there are more commits added to this PR. Please update it accordingly if you want to test it out. 