### PR TITLE
chore: use a special __wal__ path

### DIFF
--- a/portal/bun.lock
+++ b/portal/bun.lock
@@ -16,7 +16,7 @@
         "vite": "^5.4.12",
       },
       "devDependencies": {
-        "@types/bun": "^1.2.1",
+        "@types/bun": "^1.2.5",
         "@types/pako": "^2.0.3",
         "vite-plugin-html": "^3.2.2",
         "vitest": "^2.1.3",

--- a/portal/server/index.ts
+++ b/portal/server/index.ts
@@ -13,7 +13,13 @@ serve({
 	port: PORT,
 	// Special Walrus Sites routes.
 	routes: {
-		"/api/healthz": await blocklist_healthcheck(),
+		"/__wal__/*": async (req: Request) => {
+			console.log("debug", req.url)
+			if (req.url.endsWith("/healthz")) {
+				return await blocklist_healthcheck()
+			}
+			new Response("Not found!", {status: 404, statusText: "This special wal path does not exist."})
+ 		},
 		"/walrus-sites-sw.js": new Response(await Bun.file("./public/walrus-sites-sw.js").bytes(), {
 			headers: {
 				"Content-Type": "application/javascript",


### PR DESCRIPTION
Any request path that starts with `__wal__` will be a special path used by the portal for health checks etc. 