### PR TITLE
chore: using invalid domain names to represent links

### DIFF
--- a/portal/common/lib/links.test.ts
+++ b/portal/common/lib/links.test.ts
@@ -6,13 +6,13 @@ import { getObjectIdLink, getBlobIdLink } from './links';
 import { DomainDetails } from './types';
 
 const getObjectIdLinkTestCases: [string, DomainDetails | null][] = [
-    ["https://example.suiobj/resource/path", { subdomain: "example", path: "/resource/path" }],
-    // ["https://another-example.suiobj/another/resource/path",
-        // { subdomain: "another-example", path: "/another/resource/path" }],
-    // ["https://invalidsite.com/something", null],
-    // ["https://example.suiobj/", { subdomain: "example", path: "/" }],
-    // ["https://example.suiobj", null],
-    // ["https://example.suiobj/resource", { subdomain: "example", path: "/resource" }],
+    ["https://example.suiobj.invalid/resource/path", { subdomain: "example", path: "/resource/path" }],
+    ["https://another-example.suiobj.invalid/another/resource/path",
+        { subdomain: "another-example", path: "/another/resource/path" }],
+    ["https://invalidsite.com/something", null],
+    ["https://example.suiobj.invalid/", { subdomain: "example", path: "/" }],
+    ["https://example.suiobj.invalid", { subdomain: "example", path: "/" }],
+    ["https://example.suiobj.invalid/resource", { subdomain: "example", path: "/resource" }],
 ];
 
 describe('getObjectIdLink', () => {
@@ -27,12 +27,12 @@ describe('getObjectIdLink', () => {
 });
 
 const getBlobIdLinkTestCases: [string, string | null][] = [
-    ["https://blobid.walrus/blob-id-123", "blob-id-123"],
-    ["https://blobid.walrus/another-blob-id", "another-blob-id"],
+    ["https://blobid.walrus.invalid/blob-id-123", "blob-id-123"],
+    ["https://blobid.walrus.invalid/another-blob-id", "another-blob-id"],
     ["https://invalidsite.com/something", null],
-    ["https://blobid.walrus/", null],
-    ["https://blobid.walrus", null],
-    ["https://blobid.walrus/blob-id-456", "blob-id-456"],
+    ["https://blobid.walrus.invalid/", null],
+    ["https://blobid.walrus.invalid", null],
+    ["https://blobid.walrus.invalid/blob-id-456", "blob-id-456"],
 ];
 
 describe('getBlobIdLink', () => {

--- a/portal/common/lib/links.ts
+++ b/portal/common/lib/links.ts
@@ -13,7 +13,7 @@ import logger from "./logger";
  */
 export function getObjectIdLink(url: URL): DomainDetails | null {
     logger.info({ message: "Trying to extract the sui link from:", originalUrl: url.href});
-    const suiResult = /^https:\/\/(.+)\.suiobj\/(.*)$/.exec(url.href);
+    const suiResult = /^https:\/\/(.+)\.suiobj.invalid\/(.*)$/.exec(url.href);
     if (suiResult) {
         const parsedDomainDetails = { subdomain: suiResult[1], path: "/" + suiResult[2] };
         logger.info({ message: "Matched sui link", parsedDomainDetails: parsedDomainDetails });
@@ -30,7 +30,7 @@ export function getObjectIdLink(url: URL): DomainDetails | null {
  */
 export function getBlobIdLink(url: URL): string | null {
     logger.info({ message: "Trying to extract the walrus link from:", originalUrl: url.href });
-    const walrusResult = /^https:\/\/blobid\.walrus\/(.+)$/.exec(url.href);
+    const walrusResult = /^https:\/\/blobid\.walrus.invalid\/(.+)$/.exec(url.href);
     if (walrusResult) {
         logger.info({ message: "Matched walrus link using blobid.walrus", walrusResult: walrusResult[1]});
         return walrusResult[1];

--- a/portal/common/vite.config.mts
+++ b/portal/common/vite.config.mts
@@ -6,7 +6,7 @@ import { defineConfig, loadEnv } from 'vite';
 export default defineConfig(({ mode }) => ({
     assetsInclude: ["**/*.html"],
     test: {
-        onConsoleLog: () => true,
+        onConsoleLog: () => false,
         env: loadEnv(mode, process.cwd(), ''),
     },
 }));


### PR DESCRIPTION
We're using [https://*.suiobj](about:blank) and https://blobid.walrus/.* . Should be following [RFC 6761 (section 6.4)](https://www.rfc-editor.org/rfc/rfc6761.html#:~:text=6.4.%20%20Domain%20Name%20Reservation%20Considerations%20for%20%22invalid.%22) and use the `.invalid` suffix instead.