### PR TITLE
fix(server-portal): bump Dockerfile Bun to 1.2.5

### DIFF
--- a/portal/docker/server/Dockerfile
+++ b/portal/docker/server/Dockerfile
@@ -1,6 +1,6 @@
 # use the official Bun image
 # see all versions at https://hub.docker.com/r/oven/bun/tags
-FROM oven/bun:1.2.1 AS base
+FROM oven/bun:1.2.5 AS base
 WORKDIR /usr/src/app
 
 # install dependencies into temp directory


### PR DESCRIPTION
Routes are available only for Bun v1.2.3+