### PR TITLE
feat: improve Cookie Monster so it eats multiple cookies on all domains

### DIFF
--- a/portal/bun.lock
+++ b/portal/bun.lock
@@ -33,6 +33,7 @@
         "@vercel/edge-config": "^1.4.0",
         "common": "workspace:common",
         "cookie": "^1.0.2",
+        "psl": "^1.15.0",
         "redis": "^4.7.0",
         "ua-parser-js": "^2.0.1",
         "zod": "^3.24.1",
@@ -40,6 +41,7 @@
       "devDependencies": {
         "@types/bun": "^1.2.5",
         "@types/node": "^20.16.11",
+        "@types/psl": "^1.1.3",
         "@types/react": "18.3.3",
         "html-loader": "^5.1.0",
         "prettier": "^3.3.3",
@@ -518,6 +520,8 @@
     "@types/pg-pool": ["@types/pg-pool@2.0.6", "", { "dependencies": { "@types/pg": "*" } }, "sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ=="],
 
     "@types/prop-types": ["@types/prop-types@15.7.14", "", {}, "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ=="],
+
+    "@types/psl": ["@types/psl@1.1.3", "", {}, "sha512-Iu174JHfLd7i/XkXY6VDrqSlPvTDQOtQI7wNAXKKOAADJ9TduRLkNdMgjGiMxSttUIZnomv81JAbAbC0DhggxA=="],
 
     "@types/qs": ["@types/qs@6.9.18", "", {}, "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA=="],
 
@@ -1328,6 +1332,10 @@
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+
+    "psl": ["psl@1.15.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "qs": ["qs@6.13.0", "", { "dependencies": { "side-channel": "^1.0.6" } }, "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg=="],
 

--- a/portal/server/package.json
+++ b/portal/server/package.json
@@ -13,6 +13,7 @@
         "@vercel/edge-config": "^1.4.0",
         "common": "workspace:common",
         "cookie": "^1.0.2",
+        "psl": "^1.15.0",
         "redis": "^4.7.0",
         "ua-parser-js": "^2.0.1",
         "zod": "^3.24.1"
@@ -20,6 +21,7 @@
     "devDependencies": {
         "@types/bun": "^1.2.5",
         "@types/node": "^20.16.11",
+        "@types/psl": "^1.1.3",
         "@types/react": "18.3.3",
         "html-loader": "^5.1.0",
         "prettier": "^3.3.3",


### PR DESCRIPTION
Before, the cookie monster was eating only a single cookie, without setting the domain attribute
Now, it eats all the cookies.

Example:
```
reginaldosilva@MacBook-Pro portal % curl --verbose 'http://localhost:3000/'  -H'Cookie: barab=in; baraba=un' -H'Host: walrusadventures.walrus.site' >/dev/null 
* Host localhost:3000 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying [::1]:3000...
* Connected to localhost (::1) port 3000
> GET / HTTP/1.1
> Host: walrusadventures.walrus.site
> User-Agent: curl/8.7.1
> Accept: */*
> Cookie: barab=in; baraba=un
> 
* Request completely sent off
< HTTP/1.1 404 Not Found
< set-cookie: barab=deleted; Domain=walrusadventures.walrus.site; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly
< set-cookie: barab=deleted; Domain=walrus.site; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly
< set-cookie: baraba=deleted; Domain=walrusadventures.walrus.site; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly
< set-cookie: baraba=deleted; Domain=walrus.site; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly
< Content-Type: text/html
< Date: Tue, 18 Mar 2025 16:13:22 GMT
< Content-Length: 277689
< 
{ [81560 bytes data]
100  271k  100  271k    0     0   455k      0 --:--:-- --:--:-- --:--:--  455k
* Connection #0 to host localhost left intact
```