### PR TITLE
feat(server-portal): do not allow subdomain access when BRING_YOUR_OWN_DOMAIN is true

### DIFF
--- a/portal/common/lib/http/http_error_responses.ts
+++ b/portal/common/lib/http/http_error_responses.ts
@@ -17,7 +17,7 @@ export function siteNotFound(): Response {
 export function noObjectIdFound(): Response {
     return Response404(
         mainNotFoundErrorMessage,
-        "Invalid URL: No object ID could be found."
+        "Invalid URL: Walrus Site not found!"
     );
 }
 
@@ -48,6 +48,13 @@ function Response404(message: String, secondaryMessage?: String): Response {
             "Content-Type": "text/html",
         },
     });
+}
+
+export function bringYourOwnDomainDoesNotSupportSubdomainsYet(attemptedSite: String): Response {
+	return Response404(
+		`This portal does not serve any other Walrus Sites!`,
+		`Please try browsing https://${attemptedSite}.wal.app`
+	)
 }
 
 /**

--- a/portal/server/src/configuration_loader.ts
+++ b/portal/server/src/configuration_loader.ts
@@ -29,7 +29,8 @@ const configurationSchema =
 		amplitudeApiKey: env.AMPLITUDE_API_KEY,
 		aggregatorUrl: env.AGGREGATOR_URL,
 		sitePackage: env.SITE_PACKAGE,
-		b36DomainResolutionSupport: env.B36_DOMAIN_RESOLUTION_SUPPORT
+		b36DomainResolutionSupport: env.B36_DOMAIN_RESOLUTION_SUPPORT,
+		bringYourOwnDomain: env.BRING_YOUR_OWN_DOMAIN,
 	}),
 	z.object({
 		edgeConfig: z.string().optional(),
@@ -80,7 +81,8 @@ const configurationSchema =
 		amplitudeApiKey: z.string().optional(),
 		aggregatorUrl: z.string().url({message: "AGGREGATOR_URL is not a valid URL!"}),
 		sitePackage: z.string().refine((val) => val.length === 66 && /^0x[0-9a-fA-F]+$/.test(val)),
-		b36DomainResolutionSupport: stringBoolean
+		b36DomainResolutionSupport: stringBoolean,
+		bringYourOwnDomain: stringBoolean.optional(),
 	})
   	.refine(
    	(data) => {

--- a/portal/server/src/configuration_loader.ts
+++ b/portal/server/src/configuration_loader.ts
@@ -82,7 +82,7 @@ const configurationSchema =
 		aggregatorUrl: z.string().url({message: "AGGREGATOR_URL is not a valid URL!"}),
 		sitePackage: z.string().refine((val) => val.length === 66 && /^0x[0-9a-fA-F]+$/.test(val)),
 		b36DomainResolutionSupport: stringBoolean,
-		bringYourOwnDomain: stringBoolean.optional(),
+		bringYourOwnDomain: stringBoolean.optional().transform((val) => val ? val : false),
 	})
   	.refine(
    	(data) => {

--- a/portal/server/src/main.ts
+++ b/portal/server/src/main.ts
@@ -14,6 +14,7 @@ import { standardUrlFetcher, premiumUrlFetcher } from "src/url_fetcher_factory";
 import { sendToWebAnalytics } from "src/web_analytics";
 import { sendToAmplitude } from "src/amplitude";
 import { Base36toHex } from "@lib/objectId_operations";
+import { bringYourOwnDomainDoesNotSupportSubdomainsYet } from "@lib/http/http_error_responses";
 
 if (config.enableSentry) {
     // Only integrate Sentry on production.
@@ -65,6 +66,10 @@ export default async function main(req: Request) {
 			blocklistChecker
 		);
 		return response;
+	}
+
+	if (config.bringYourOwnDomain) {
+		return bringYourOwnDomainDoesNotSupportSubdomainsYet(parsedUrl?.subdomain!)
 	}
 
 	return new Response(`Resource at ${url} not found!`, { status: 404 });

--- a/portal/server/src/main.ts
+++ b/portal/server/src/main.ts
@@ -35,7 +35,7 @@ export default async function main(req: Request) {
 	const portalDomain = getDomain(url, Number(portalDomainNameLength));
 	const requestDomain = getDomain(url, Number(portalDomainNameLength));
 
-	if (parsedUrl) {
+	if (parsedUrl && !config.bringYourOwnDomain) {
 		if (blocklistChecker && await blocklistChecker.isBlocked(parsedUrl.subdomain)) {
 			return siteNotFound();
 		}


### PR DESCRIPTION
Tested with creating a .env file with `BRING_YOUR_OWN_DOMAIN=true/false` and without the variable all-together, and printing the output of Configuration, as well as visiting a subdomain.