### PR TITLE
:bug: handle broken backslash path bug on windows

### DIFF
--- a/move/walrus_site/sources/site.move
+++ b/move/walrus_site/sources/site.move
@@ -114,7 +114,7 @@ module walrus_site::site {
 
     /// Creates a new resource path.
     fun new_path(path: String): ResourcePath {
-        ResourcePath { path }
+        ResourcePath { path.replace('\\', '/') }
     }
 
     /// Updates the name of a site.


### PR DESCRIPTION
change

  * change backslash `\` to `/` on `new_path` function

## Background
walrus-site can't render `\` url as browser (e.g chrome) auto convert url path `\` to `/`, on windows `site-builder` will upload object as `\` when interacting with `walrus-sites` move contract, therefore the object path will be inserted as `\`

## Solution
replace `\` with `/` in object path, before writing object to Walrus

## References
related to https://discord.com/channels/946098997637042178/1268610159064780973/1352827924260196393

![image](https://github.com/user-attachments/assets/045cc9f0-84a8-4c26-99aa-faf1e2a94ad2)

when this happens, object with more than one path `\` won't render on walrus.site 

e.g https://discord.com/channels/946098997637042178/1268610159064780973/1353012825592959129

![image](https://github.com/user-attachments/assets/bd96ebd0-71bc-47aa-84ef-0d39f83e4e6d)

* on linux/unix deployment https://ace-walrus.walrus.site/assets/test.txt works
* on windows deployment https://theemptyboxclub.walrus.site/images/logo/logo-word-white.png fails (404)
