### PR TITLE
refactor: replace deprecated clap attributes to align with clap 4.x syntax

### DIFF
--- a/portal/common/lib/suins.test.ts
+++ b/portal/common/lib/suins.test.ts
@@ -29,18 +29,6 @@ describe('resolveSuiNsAddress', () => {
                 contentHash: "dummyContentHash",
                 walrusSiteId: "0x57414C525553"
             }],
-            // Deprecated case where the walrusSiteId is not set, but the targetAddress is used
-            //  instead:
-            ["docs", {
-              name: 'docs.sui',
-              nftId: '0xcc8ee266bc1f07b3218696912c7e5244aeb0e32c8c9befec059e3527558e4063',
-              targetAddress: '0x57414C525553',
-              expirationTimestampMs: '1749826519160',
-              data: {},
-              avatar: undefined,
-              contentHash: undefined,
-              walrusSiteId: undefined
-            }]
         ];
 
         for (const [input, expected] of cases) {

--- a/portal/common/lib/suins.ts
+++ b/portal/common/lib/suins.ts
@@ -18,7 +18,7 @@ export class SuiNSResolver {
     	const reqStartTime = Date.now();
         const nameRecord: NameRecord | null = await this.rpcSelector.getNameRecord(`${subdomain}.sui`);
         if (nameRecord) {
-            const resolvedSuiNSName = nameRecord.walrusSiteId ?? nameRecord.targetAddress;
+            const resolvedSuiNSName = nameRecord.walrusSiteId;
             logger.info({
                 message: "Resolved SuiNS name",
                 subdomain,

--- a/site-builder/src/args.rs
+++ b/site-builder/src/args.rs
@@ -1,0 +1,300 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Arguments for the site builder CLI.
+
+use std::{
+    num::{NonZeroU32, NonZeroUsize},
+    path::PathBuf,
+};
+
+use anyhow::{anyhow, ensure, Result};
+use clap::{Parser, Subcommand};
+use serde::{Deserialize, Serialize};
+use sui_sdk::wallet_context::WalletContext;
+use sui_types::base_types::ObjectID;
+
+use crate::{util::load_wallet_context, walrus::output::EpochCount};
+
+#[derive(Parser, Clone, Debug, Deserialize)]
+#[command(rename_all = "kebab-case")]
+pub(crate) struct GeneralArgs {
+    /// The URL or the RPC endpoint to connect the client to.
+    ///
+    /// Can be specified as a CLI argument or in the config.
+    #[arg(long)]
+    pub(crate) rpc_url: Option<String>,
+    /// The path to the Sui Wallet config.
+    ///
+    /// Can be specified as a CLI argument or in the config.
+    #[arg(long)]
+    pub(crate) wallet: Option<PathBuf>,
+    /// The env to be used for the Sui wallet.
+    ///
+    /// If not specified, the env specified in the sites-config (under `wallet_env`) will be used.
+    /// If the wallet env is also not specified in the config, the env configured in the Sui client
+    /// will be used.
+    #[arg(long)]
+    pub(crate) wallet_env: Option<String>,
+    /// The path or name of the walrus binary.
+    ///
+    /// The Walrus binary will then be called with this configuration to perform actions on Walrus.
+    /// Can be specified as a CLI argument or in the config.
+    #[arg(long)]
+    #[serde(default = "default::walrus_binary")]
+    pub(crate) walrus_binary: Option<String>,
+    /// The path to the configuration for the Walrus client.
+    ///
+    /// This will be passed to the calls to the Walrus binary.
+    /// Can be specified as a CLI argument or in the config.
+    #[arg(long)]
+    pub(crate) walrus_config: Option<PathBuf>,
+    /// The gas budget for the operations on Sui.
+    ///
+    /// Can be specified as a CLI argument or in the config.
+    #[arg(long)]
+    #[arg(short, long)]
+    #[serde(default = "default::gas_budget")]
+    pub(crate) gas_budget: Option<u64>,
+}
+
+impl Default for GeneralArgs {
+    fn default() -> Self {
+        Self {
+            rpc_url: None,
+            wallet: None,
+            wallet_env: None,
+            walrus_binary: default::walrus_binary(),
+            walrus_config: None,
+            gas_budget: default::gas_budget(),
+        }
+    }
+}
+
+impl GeneralArgs {
+    /// Returns the wallet context from the configuration.
+    ///
+    /// If no wallet is specified, the default wallet will be used.
+    pub fn load_wallet(&self) -> Result<WalletContext> {
+        load_wallet_context(self.wallet.as_deref(), self.wallet_env.as_deref())
+    }
+}
+
+macro_rules! merge {
+    ($self:ident, $other:ident, $field:ident) => {
+        if $other.$field.is_some() {
+            $self.$field = $other.$field.clone();
+        }
+    };
+}
+
+macro_rules! merge_fields {
+    ($self:ident, $other:ident, $($field:ident),* $(,)?) => (
+        $(
+            merge!($self, $other, $field);
+        )*
+    );
+}
+
+impl GeneralArgs {
+    /// Merges two instances of [`GeneralArgs`], keeping all the `Some` values.
+    ///
+    /// The values of `other` are taken before the values of `self`.
+    pub fn merge(&mut self, other: &Self) {
+        merge_fields!(
+            self,
+            other,
+            rpc_url,
+            wallet,
+            walrus_binary,
+            walrus_config,
+            gas_budget,
+        );
+    }
+}
+
+#[derive(Subcommand, Debug)]
+#[command(rename_all = "kebab-case")]
+pub(crate) enum Commands {
+    /// Publish a new site on Sui.
+    Publish {
+        #[command(flatten)]
+        publish_options: PublishOptions,
+        /// The name of the site.
+        #[arg(short, long, default_value = "test site")]
+        site_name: String,
+    },
+    /// Update an existing site.
+    Update {
+        #[command(flatten)]
+        publish_options: PublishOptions,
+        /// The object ID of a partially published site to be completed.
+        object_id: ObjectID,
+        #[arg(short, long)]
+        watch: bool,
+        /// Publish all resources to Sui and Walrus, even if they may be already present.
+        ///
+        /// This can be useful in case the Walrus devnet is reset, but the resources are still
+        /// available on Sui.
+        #[arg(long)]
+        force: bool,
+    },
+    /// Convert an object ID in hex format to the equivalent Base36 format.
+    ///
+    /// This command may be useful to browse a site, given it object ID.
+    Convert {
+        /// The object id (in hex format) to convert
+        object_id: ObjectID,
+    },
+    /// Show the pages composing the site at the given object ID.
+    Sitemap { object: ObjectID },
+    /// Preprocess the directory, creating and linking index files.
+    /// This command allows to publish directories as sites. Warning: Rewrites all `index.html`
+    /// files.
+    ListDirectory { path: PathBuf },
+    /// Completely destroys the site at the given object id.
+    ///
+    /// Removes all resources and routes, and destroys the site, returning the Sui storage rebate to
+    /// the owner. Warning: this action is irreversible! Re-publishing the site will generate a
+    /// different Site object ID.
+    Destroy { object: ObjectID },
+    /// Adds or updates a single resource in a site, eventually replacing any pre-existing ones.
+    ///
+    /// The ws_resource file will still be used to determine the resource's headers.
+    UpdateResource {
+        /// The path to the resource to be added.
+        #[arg(long)]
+        resource: PathBuf,
+        /// The path the resource should have in the site.
+        ///
+        /// Should be in the form `/path/to/resource.html`, with a leading `/`.
+        #[arg(long)]
+        path: String,
+        /// The object ID of the Site object on Sui, to which the resource will be added.
+        #[arg(long)]
+        site_object: ObjectID,
+        /// Common configurations.
+        #[command(flatten)]
+        common: WalrusStoreOptions,
+    },
+}
+
+#[derive(Parser, Debug, Clone)]
+pub(crate) struct PublishOptions {
+    /// The directory containing the site sources.
+    pub(crate) directory: PathBuf,
+    /// Preprocess the directory before publishing.
+    /// See the `list-directory` command. Warning: Rewrites all `index.html` files.
+    #[arg(long)]
+    pub(crate) list_directory: bool,
+    /// The maximum number of concurrent calls to the Walrus CLI for the computation of blob IDs.
+    #[arg(long)]
+    pub(crate) max_concurrent: Option<NonZeroUsize>,
+    /// The maximum number of blobs that can be stored concurrently.
+    ///
+    /// More blobs can be stored concurrently, but this will increase memory usage.
+    #[arg(long, default_value_t = default::max_parallel_stores())]
+    pub(crate) max_parallel_stores: NonZeroUsize,
+    /// Common configurations.
+    #[command(flatten)]
+    pub(crate) walrus_options: WalrusStoreOptions,
+}
+
+#[derive(Parser, Debug, Clone, Default)]
+/// Common configurations across publish, update, and update-resource commands.
+pub(crate) struct WalrusStoreOptions {
+    /// The path to the Walrus sites resources file.
+    ///
+    /// This JSON configuration file defined HTTP resource headers and other utilities for your
+    /// files. By default, the file is expected to be named `ws-resources.json` and located in the
+    /// root of the site directory.
+    ///
+    /// The configuration file _will not_ be uploaded to Walrus.
+    #[arg(long)]
+    pub(crate) ws_resources: Option<PathBuf>,
+    /// The number of epochs for which to save the resources on Walrus.
+    ///
+    /// If set to `max`, the resources are stored for the maximum number of epochs allowed on
+    /// Walrus. Otherwise, the resources are stored for the specified number of epochs. The
+    /// number of epochs must be greater than 0.
+    #[arg(long, value_parser = EpochCountOrMax::parse_epoch_count)]
+    pub(crate) epochs: EpochCountOrMax,
+    /// Make the stored resources permanent.
+    ///
+    /// By default, sites are deletable with site-builder delete command. By passing --permanent,
+    /// the site is deleted only after `epochs` expiration. Make resources permanent
+    /// (non-deletable)
+    #[arg(long, action = clap::ArgAction::SetTrue)]
+    pub(crate) permanent: bool,
+    /// Perform a dry run (you'll be asked for confirmation before committing changes).
+    #[arg(long)]
+    pub(crate) dry_run: bool,
+}
+
+/// The number of epochs to store the blobs for.
+///
+/// Can be either a non-zero number of epochs or the special value `max`, which will store the blobs
+/// for the maximum number of epochs allowed by the system object on chain.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum EpochCountOrMax {
+    /// Store the blobs for the maximum number of epochs allowed.
+    #[serde(rename = "max")]
+    Max,
+    /// The number of epochs to store the blobs for.
+    #[serde(untagged)]
+    Epochs(NonZeroU32),
+}
+
+impl Default for EpochCountOrMax {
+    fn default() -> Self {
+        Self::Epochs(NonZeroU32::new(1).unwrap())
+    }
+}
+
+impl EpochCountOrMax {
+    fn parse_epoch_count(input: &str) -> Result<Self> {
+        if input == "max" {
+            Ok(Self::Max)
+        } else {
+            let epochs = input.parse::<u32>()?;
+            Ok(Self::Epochs(NonZeroU32::new(epochs).ok_or_else(|| {
+                anyhow!("invalid epoch count; please a number >0 or `max`")
+            })?))
+        }
+    }
+
+    /// Tries to convert the `EpochCountOrMax` into an `EpochCount` value.
+    ///
+    /// If the `EpochCountOrMax` is `Max`, the `max_epochs_ahead` is used as the maximum number of
+    /// epochs that can be stored ahead.
+    #[allow(unused)]
+    pub fn try_into_epoch_count(&self, max_epochs_ahead: EpochCount) -> anyhow::Result<EpochCount> {
+        match self {
+            EpochCountOrMax::Max => Ok(max_epochs_ahead),
+            EpochCountOrMax::Epochs(epochs) => {
+                let epochs = epochs.get();
+                ensure!(
+                    epochs <= max_epochs_ahead,
+                    "blobs can only be stored for up to {} epochs ahead; {} epochs were requested",
+                    max_epochs_ahead,
+                    epochs
+                );
+                Ok(epochs)
+            }
+        }
+    }
+}
+
+mod default {
+    use std::num::NonZeroUsize;
+
+    pub(crate) fn walrus_binary() -> Option<String> {
+        Some("walrus".to_owned())
+    }
+    pub(crate) fn gas_budget() -> Option<u64> {
+        Some(500_000_000)
+    }
+    pub(crate) fn max_parallel_stores() -> NonZeroUsize {
+        NonZeroUsize::new(50).unwrap()
+    }
+}

--- a/site-builder/src/config.rs
+++ b/site-builder/src/config.rs
@@ -1,0 +1,113 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Configuration for the site builder.
+
+use std::{collections::HashMap, path::Path};
+
+use anyhow::{anyhow, Result};
+use serde::Deserialize;
+use sui_sdk::wallet_context::WalletContext;
+use sui_types::base_types::ObjectID;
+
+pub(crate) use crate::{args::GeneralArgs, walrus::Walrus};
+
+/// Configuration for the site builder, complete with separate context for networks.
+#[derive(Deserialize, Debug, Clone)]
+pub(crate) struct MultiConfig {
+    pub contexts: HashMap<String, Config>,
+    pub default_context: String,
+}
+
+pub(crate) type ConfigWithContext = Config<String>;
+
+/// The configuration for the site builder.
+#[derive(Deserialize, Debug, Clone)]
+pub(crate) struct Config<C = ()> {
+    #[serde(default = "default_portal")]
+    pub portal: String,
+    pub package: ObjectID,
+    #[serde(skip_deserializing)]
+    pub context: C,
+    #[serde(default)]
+    pub general: GeneralArgs,
+}
+
+pub(crate) fn default_portal() -> String {
+    "wal.app".to_owned()
+}
+
+impl<C> Config<C> {
+    /// Merges the other [`GeneralArgs`] (taken from the CLI) with the `general` in the struct.
+    ///
+    /// The values in `other_general` take precedence.
+    pub fn merge(&mut self, other_general: &GeneralArgs) {
+        self.general.merge(other_general);
+    }
+
+    pub fn walrus_binary(&self) -> String {
+        self.general
+            .walrus_binary
+            .as_ref()
+            .expect("serde default => binary exists")
+            .to_owned()
+    }
+
+    pub fn gas_budget(&self) -> u64 {
+        self.general
+            .gas_budget
+            .expect("serde default => gas budget exists")
+    }
+
+    /// Returns a [`WalletContext`] from the configuration.
+    pub fn load_wallet(&self) -> Result<WalletContext> {
+        self.general.load_wallet()
+    }
+
+    /// Adds the context to the configuration.
+    pub fn with_context(self, context: String) -> Config<String> {
+        let Config {
+            portal,
+            package,
+            general,
+            ..
+        } = self;
+        Config {
+            portal,
+            package,
+            general,
+            context,
+        }
+    }
+}
+
+impl Config<String> {
+    pub fn load_multi_config(path: impl AsRef<Path>, context: Option<&str>) -> Result<Self> {
+        let mut multi_config =
+            serde_yaml::from_str::<MultiConfig>(&std::fs::read_to_string(path)?)?;
+
+        let context = context.unwrap_or_else(|| &multi_config.default_context);
+        tracing::info!(?context, "loading the configuration");
+
+        let config = multi_config
+            .contexts
+            .remove(context)
+            .ok_or_else(|| anyhow!("could not find the context: {}", context))?;
+
+        let config = config.with_context(context.to_owned());
+        Ok(config)
+    }
+
+    /// Creates a Walrus client with the configuration from `self`.
+    pub fn walrus_client(&self) -> Walrus {
+        Walrus::new(
+            self.walrus_binary(),
+            self.gas_budget(),
+            self.general.rpc_url.clone(),
+            self.general.walrus_config.clone(),
+            // TODO: should we ever pass None?
+            Some(self.context.clone()),
+            self.general.wallet.clone(),
+        )
+    }
+}

--- a/site-builder/src/display.rs
+++ b/site-builder/src/display.rs
@@ -49,13 +49,3 @@ pub fn done() {
         .unwrap();
     }
 }
-
-pub fn warn<S: Display>(message: S) {
-    if cfg!(not(test)) {
-        crossterm::execute!(
-            stdout(),
-            Print(format!("\n{} {message}\n", "Warning:".yellow())),
-        )
-        .unwrap();
-    }
-}

--- a/site-builder/src/publish.rs
+++ b/site-builder/src/publish.rs
@@ -3,6 +3,7 @@
 
 use std::{
     collections::BTreeSet,
+    num::NonZeroUsize,
     path::{Path, PathBuf},
     sync::mpsc::channel,
 };
@@ -20,30 +21,25 @@ use sui_types::{
 };
 
 use crate::{
+    args::{PublishOptions, WalrusStoreOptions},
     backoff::ExponentialBackoffConfig,
+    config::ConfigWithContext,
     display,
     preprocessor::Preprocessor,
     retry_client::RetriableSuiClient,
     site::{
         builder::SitePtb,
         config::WSResources,
-        manager::{SiteIdentifier, SiteIdentifier::ExistingSite, SiteManager},
+        manager::{
+            SiteIdentifier::{self, ExistingSite},
+            SiteManager,
+        },
         resource::ResourceManager,
         RemoteSiteFactory,
         SITE_MODULE,
     },
     summary::{SiteDataDiffSummary, Summarizable},
-    util::{
-        get_site_id_from_response,
-        id_to_base36,
-        load_wallet_context,
-        path_or_defaults_if_exist,
-        sign_and_send_ptb,
-    },
-    Config,
-    EpochCountOrMax,
-    NonZeroU32,
-    PublishOptions,
+    util::{get_site_id_from_response, id_to_base36, path_or_defaults_if_exist, sign_and_send_ptb},
 };
 
 const DEFAULT_WS_RESOURCES_FILE: &str = "ws-resources.json";
@@ -102,13 +98,15 @@ pub(crate) struct EditOptions {
 }
 
 pub(crate) struct SiteEditor<E = ()> {
-    config: Config,
+    context: Option<String>,
+    config: ConfigWithContext,
     edit_options: E,
 }
 
 impl SiteEditor {
-    pub fn new(config: Config) -> Self {
+    pub fn new(context: Option<String>, config: ConfigWithContext) -> Self {
         SiteEditor {
+            context,
             config,
             edit_options: (),
         }
@@ -122,6 +120,7 @@ impl SiteEditor {
         when_upload: WhenWalrusUpload,
     ) -> SiteEditor<EditOptions> {
         SiteEditor {
+            context: self.context,
             config: self.config,
             edit_options: EditOptions {
                 publish_options,
@@ -134,7 +133,7 @@ impl SiteEditor {
 
     pub async fn destroy(&self, site_id: ObjectID) -> Result<()> {
         // Delete blobs on Walrus.
-        let wallet_walrus = load_wallet_context(&self.config.general.wallet)?;
+        let wallet_walrus = self.config.load_wallet()?;
 
         let site = RemoteSiteFactory::new(
             // TODO(giac): make the backoff configurable.
@@ -161,14 +160,14 @@ impl SiteEditor {
         if all_blobs.is_empty() {
             println!("Warning: No deletable resources found. This may be because the site was created with permanent=true");
         } else {
+            // TODO: Change the site manager not to the unnecessary info.
             let mut site_manager = SiteManager::new(
                 self.config.clone(),
                 ExistingSite(site_id),
-                EpochCountOrMax::Epochs(NonZeroU32::new(1).unwrap()),
                 WhenWalrusUpload::Always,
-                false,
-                false,
+                WalrusStoreOptions::default(),
                 None,
+                NonZeroUsize::new(1).expect("non-zero"),
             )
             .await?;
 
@@ -176,7 +175,7 @@ impl SiteEditor {
         }
 
         // Delete objects on SUI blockchain
-        let mut wallet = self.config.wallet()?;
+        let mut wallet = self.config.load_wallet()?;
         let ptb = SitePtb::new(self.config.package, Identifier::new(SITE_MODULE)?)?;
         let mut ptb = ptb.with_call_arg(&wallet.get_object_ref(site_id).await?.into())?;
         let site = RemoteSiteFactory::new(
@@ -234,7 +233,11 @@ impl SiteEditor<EditOptions> {
         }
 
         let (ws_resources, ws_resources_path) = load_ws_resources(
-            &self.edit_options.publish_options.ws_resources,
+            self.edit_options
+                .publish_options
+                .walrus_options
+                .ws_resources
+                .as_deref(),
             self.directory(),
         )?;
         if let Some(path) = ws_resources_path.as_ref() {
@@ -267,11 +270,10 @@ impl SiteEditor<EditOptions> {
         let mut site_manager = SiteManager::new(
             self.config.clone(),
             self.edit_options.site_id.clone(),
-            self.edit_options.publish_options.epochs.clone(),
             self.edit_options.when_upload.clone(),
-            self.edit_options.publish_options.permanent,
-            self.edit_options.publish_options.dry_run,
+            self.edit_options.publish_options.walrus_options.clone(),
             site_metadata,
+            self.edit_options.publish_options.max_parallel_stores,
         )
         .await?;
         let (response, summary) = site_manager.update_site(&local_site_data).await?;
@@ -313,7 +315,7 @@ impl SiteEditor<EditOptions> {
 }
 
 fn print_summary(
-    config: &Config,
+    config: &ConfigWithContext,
     address: &SuiAddress,
     site_id: &SiteIdentifier,
     response: &SuiTransactionBlockResponse,
@@ -364,7 +366,7 @@ fn print_summary(
 
 /// Gets the configuration from the provided file, or looks in the default directory.
 pub(crate) fn load_ws_resources(
-    path: &Option<PathBuf>,
+    path: Option<&Path>,
     site_dir: &Path,
 ) -> Result<(Option<WSResources>, Option<PathBuf>)> {
     let default_paths = vec![site_dir.join(DEFAULT_WS_RESOURCES_FILE)];

--- a/site-builder/src/site/content.rs
+++ b/site-builder/src/site/content.rs
@@ -7,7 +7,7 @@ use anyhow::{anyhow, Result};
 use clap::ValueEnum;
 
 #[derive(Debug, ValueEnum, Clone, Copy, PartialEq, Eq, Ord, PartialOrd)]
-#[clap(rename_all = "lowercase")]
+#[value(rename_all = "lowercase")]
 pub enum ContentEncoding {
     PlainText,
     // TODO(giac): Enable GZIP once decided what to do with the encoding.
@@ -122,9 +122,6 @@ pub enum ContentType {
 }
 
 impl ContentType {
-    // TODO: Remove the allow dead code as soon as we use this function again to infert the mime
-    // type.
-    #[allow(dead_code)]
     pub fn try_from_extension(ext: &str) -> Result<Self> {
         Ok(match ext {
             "aac" => ContentType::AudioAac,

--- a/site-builder/src/site/manager.rs
+++ b/site-builder/src/site/manager.rs
@@ -1,9 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeSet, str::FromStr, time::Duration};
+use std::{collections::BTreeSet, num::NonZeroUsize, str::FromStr, time::Duration};
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Error, Result};
 use sui_keys::keystore::AccountKeystore;
 use sui_sdk::{rpc_types::SuiTransactionBlockResponse, wallet_context::WalletContext};
 use sui_types::{
@@ -21,7 +21,9 @@ use super::{
     SITE_MODULE,
 };
 use crate::{
+    args::WalrusStoreOptions,
     backoff::ExponentialBackoffConfig,
+    config::ConfigWithContext,
     display,
     publish::WhenWalrusUpload,
     retry_client::RetriableSuiClient,
@@ -29,8 +31,6 @@ use crate::{
     types::Metadata,
     util::{get_site_id_from_response, sign_and_send_ptb},
     walrus::{types::BlobId, Walrus},
-    Config,
-    EpochCountOrMax,
 };
 
 const MAX_RESOURCES_PER_PTB: usize = 200;
@@ -47,40 +47,37 @@ pub enum SiteIdentifier {
 }
 
 pub struct SiteManager {
-    pub config: Config,
+    pub config: ConfigWithContext,
     pub walrus: Walrus,
     pub wallet: WalletContext,
     pub site_id: SiteIdentifier,
-    pub epochs: EpochCountOrMax,
     pub when_upload: WhenWalrusUpload,
     pub backoff_config: ExponentialBackoffConfig,
-    pub permanent: bool,
-    pub dry_run: bool,
     pub metadata: Option<Metadata>,
+    pub walrus_options: WalrusStoreOptions,
+    pub max_parallel_stores: NonZeroUsize,
 }
 
 impl SiteManager {
     /// Creates a new site manager.
     pub async fn new(
-        config: Config,
+        config: ConfigWithContext,
         site_id: SiteIdentifier,
-        epochs: EpochCountOrMax,
         when_upload: WhenWalrusUpload,
-        permanent: bool,
-        dry_run: bool,
+        walrus_options: WalrusStoreOptions,
         metadata: Option<Metadata>,
+        max_parallel_stores: NonZeroUsize,
     ) -> Result<Self> {
         Ok(SiteManager {
             walrus: config.walrus_client(),
-            wallet: config.wallet()?,
+            wallet: config.load_wallet()?,
             config,
             site_id,
-            epochs,
             when_upload,
             backoff_config: ExponentialBackoffConfig::default(),
-            permanent,
-            dry_run,
             metadata,
+            walrus_options,
+            max_parallel_stores,
         })
     }
 
@@ -99,8 +96,8 @@ impl SiteManager {
                 .walrus
                 .dry_run_store(
                     resource.full_path.clone(),
-                    self.epochs.clone(),
-                    !self.permanent,
+                    self.walrus_options.epochs.clone(),
+                    !self.walrus_options.permanent,
                     false,
                 )
                 .await?;
@@ -143,7 +140,7 @@ impl SiteManager {
         let walrus_updates = site_updates.get_walrus_updates(&self.when_upload);
 
         if !walrus_updates.is_empty() {
-            if self.dry_run {
+            if self.walrus_options.dry_run {
                 let total_storage_cost = self.dry_run_walrus_store(&walrus_updates).await?;
                 // Before doing the actual execution, perform a dry run
                 display::action(format!(
@@ -179,62 +176,64 @@ impl SiteManager {
 
     /// Publishes the resources to Walrus.
     async fn publish_to_walrus<'b>(&mut self, updates: &[&ResourceOp<'b>]) -> Result<()> {
-        let deletable = !self.permanent;
-
-        for update in updates.iter() {
-            let resource = update.inner();
-            tracing::debug!(
-                resource=?resource.full_path,
-                blob_id=%resource.info.blob_id,
-                unencoded_size=%resource.unencoded_size,
-                "storing new blob on Walrus"
-            );
+        for (idx, update_set) in updates.chunks(self.max_parallel_stores.get()).enumerate() {
             display::action(format!(
-                "Storing resource on Walrus: {}",
-                &resource.info.path
+                "Storing resources on Walrus: batch {} of {}",
+                idx + 1,
+                updates.len().div_ceil(self.max_parallel_stores.get()),
             ));
+            self.store_multiple_to_walrus_with_retry(update_set).await?;
+            display::done();
+        }
+        Ok(())
+    }
 
-            // Retry if the store operation fails with an os error.
-            // NOTE(giac): This can be improved when the rust sdk for the client is open sourced.
-            let mut retry_num = 0;
-            loop {
-                anyhow::ensure!(
-                    retry_num < MAX_RETRIES,
-                    "maximum number of retries exceeded"
-                );
-                tracing::debug!(retry_num, "attempting to store resource");
-                retry_num += 1;
-                let result = self
-                    .walrus
-                    .store(
-                        resource.full_path.clone(),
-                        self.epochs.clone(),
-                        false,
-                        deletable,
-                    )
-                    .await;
+    async fn store_multiple_to_walrus_with_retry<'b>(
+        &mut self,
+        update_batch: &[&ResourceOp<'b>],
+    ) -> Result<()> {
+        let deletable = !self.walrus_options.permanent;
+        let resource_paths = update_batch
+            .iter()
+            .map(|update| update.inner().full_path.clone())
+            .collect::<Vec<_>>();
 
-                match result {
-                    Ok(_) => {
-                        display::done();
-                        break;
-                    }
-                    Err(err) => {
-                        tracing::warn!(?err, "store operation failed");
-                        if !err.to_string().contains("os error 54") || retry_num >= MAX_RETRIES {
-                            return Err(err);
-                        } else if retry_num >= MAX_RETRIES {
-                            anyhow::bail!(
-                                "a network error occurred when calling the Walrus CLI, \
-                                and the maximum number of retries was exceeded"
-                            );
-                        } else {
-                            tracing::warn!(
-                                delay = ?OS_ERROR_DELAY,
-                                "calling the Walrus CLI encountered an OS network error, retrying"
-                            );
-                            tokio::time::sleep(OS_ERROR_DELAY).await;
-                        }
+        tracing::debug!(?resource_paths, "storing resource batch on Walrus",);
+
+        // Retry if the store operation fails with an os error.
+        // NOTE(giac): This can be improved when the rust sdk for the client is open sourced.
+        let mut retry_num = 0;
+        loop {
+            anyhow::ensure!(
+                retry_num < MAX_RETRIES,
+                "maximum number of retries exceeded"
+            );
+            tracing::debug!(retry_num, "attempting to store resource");
+            retry_num += 1;
+            let result = self
+                .walrus
+                .store(
+                    resource_paths.clone(),
+                    self.walrus_options.epochs.clone(),
+                    false,
+                    deletable,
+                )
+                .await;
+
+            match result {
+                Ok(_) => {
+                    break;
+                }
+                Err(error) => {
+                    if !is_retriable_error(&error) || retry_num >= MAX_RETRIES {
+                        return Err(error);
+                    } else {
+                        tracing::warn!(
+                            ?error,
+                            delay = ?OS_ERROR_DELAY,
+                            "calling the Walrus CLI encountered a retriable error, retrying"
+                        );
+                        tokio::time::sleep(OS_ERROR_DELAY).await;
                     }
                 }
             }
@@ -371,7 +370,7 @@ impl SiteManager {
             .collect::<Vec<_>>();
 
         //Perform dry run
-        if self.dry_run {
+        if self.walrus_options.dry_run {
             let total_storage_cost = self.dry_run_walrus_store(&walrus_ops).await?;
             // Before doing the actual execution, perform a dry run
             display::action(format!(
@@ -456,5 +455,18 @@ impl SiteManager {
     /// A new site needs to be transferred to the active address.
     fn needs_transfer(&self) -> bool {
         matches!(self.site_id, SiteIdentifier::NewSite(_))
+    }
+}
+
+fn is_retriable_error(error: &Error) -> bool {
+    let error_message = error.to_string();
+    if error_message.contains("os error 54") {
+        // The connection was reset by the peer -- a common RPC error under load.
+        true
+    } else if error_message.contains("response does not contain object data") {
+        // The RPC may be slow, and does not have the correct object version.
+        true
+    } else {
+        false
     }
 }

--- a/site-builder/src/util.rs
+++ b/site-builder/src/util.rs
@@ -1,6 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use std::{path::PathBuf, str};
+use std::{
+    path::{Path, PathBuf},
+    str,
+};
 
 use anyhow::{anyhow, bail, Result};
 use futures::Future;
@@ -128,8 +131,8 @@ pub fn get_site_id_from_response(
 }
 
 /// Returns the path if it is `Some` or any of the default paths if they exist (attempt in order).
-pub fn path_or_defaults_if_exist(path: &Option<PathBuf>, defaults: &[PathBuf]) -> Option<PathBuf> {
-    let mut path = path.clone();
+pub fn path_or_defaults_if_exist(path: Option<&Path>, defaults: &[PathBuf]) -> Option<PathBuf> {
+    let mut path = path.map(|p| p.to_path_buf());
     for default in defaults {
         if path.is_some() {
             break;
@@ -162,22 +165,43 @@ pub(crate) async fn type_origin_map_for_package(
         .collect())
 }
 
-/// Loads the wallet context from the given path.
+/// Loads the wallet context from the given optional wallet config (optional path and optional
+/// Sui env).
 ///
-/// If no path is provided, tries to load the configuration first from the local folder, and then
-/// from the standard Sui configuration directory.
+/// If no path is provided, tries to load the configuration first from the local folder, and
+/// then from the standard Sui configuration directory.
 // NB: When making changes to the logic, make sure to update the argument docs in
 // `crates/walrus-service/bin/client.rs`.
-#[allow(dead_code)]
-pub fn load_wallet_context(path: &Option<PathBuf>) -> Result<WalletContext> {
+pub fn load_wallet_context(path: Option<&Path>, wallet_env: Option<&str>) -> Result<WalletContext> {
     let mut default_paths = vec!["./client.yaml".into(), "./sui_config.yaml".into()];
     if let Some(home_dir) = home::home_dir() {
         default_paths.push(home_dir.join(".sui").join("sui_config").join("client.yaml"))
     }
+
     let path = path_or_defaults_if_exist(path, &default_paths)
-        .ok_or(anyhow!("Could not find a valid wallet config file."))?;
-    tracing::info!("Using wallet configuration from {}", path.display());
-    WalletContext::new(&path, None, None)
+        .ok_or(anyhow!("could not find a valid wallet config file"))?;
+    tracing::info!(conf_path = %path.display(), "using Sui wallet configuration");
+    let mut wallet_context: WalletContext = WalletContext::new(&path, None, None)?;
+    if let Some(target_env) = wallet_env {
+        if !wallet_context
+            .config
+            .envs
+            .iter()
+            .any(|env| env.alias == target_env)
+        {
+            return Err(anyhow!(
+                "Env '{}' not found in wallet config file '{}'.",
+                target_env,
+                path.display()
+            ));
+        }
+        wallet_context.config.active_env = Some(target_env.to_string());
+        tracing::info!(?target_env, "set the wallet env");
+    } else {
+        tracing::info!("no wallet env provided, using the default one");
+    }
+
+    Ok(wallet_context)
 }
 
 #[cfg(test)]

--- a/site-builder/src/walrus/command.rs
+++ b/site-builder/src/walrus/command.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 
 use super::types::BlobId;
-use crate::EpochCountOrMax;
+use crate::args::EpochCountOrMax;
 
 /// Represents a call to the JSON mode of the Walrus CLI.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -20,6 +20,9 @@ pub struct WalrusJsonCmd {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub config: Option<PathBuf>,
+    /// The configuration context to use for the client, if omitted the default_context is used.
+    #[serde(default)]
+    pub context: Option<String>,
     /// The path for the wallet to use with Walrus.
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -145,6 +148,7 @@ mod default {
 #[derive(Debug, Clone)]
 pub struct WalrusCmdBuilder<T = ()> {
     config: Option<PathBuf>,
+    context: Option<String>,
     wallet: Option<PathBuf>,
     gas_budget: u64,
     command: T,
@@ -152,9 +156,15 @@ pub struct WalrusCmdBuilder<T = ()> {
 
 impl WalrusCmdBuilder {
     /// Creates a new builder.
-    pub fn new(config: Option<PathBuf>, wallet: Option<PathBuf>, gas_budget: u64) -> Self {
+    pub fn new(
+        config: Option<PathBuf>,
+        context: Option<String>,
+        wallet: Option<PathBuf>,
+        gas_budget: u64,
+    ) -> Self {
         Self {
             config,
+            context,
             wallet,
             gas_budget,
             command: (),
@@ -165,12 +175,14 @@ impl WalrusCmdBuilder {
     pub fn with_command(self, command: Command) -> WalrusCmdBuilder<Command> {
         let Self {
             config,
+            context,
             wallet,
             gas_budget,
             ..
         } = self;
         WalrusCmdBuilder {
             config,
+            context,
             wallet,
             gas_budget,
             command,
@@ -255,12 +267,14 @@ impl WalrusCmdBuilder<Command> {
     pub fn build(self) -> WalrusJsonCmd {
         let WalrusCmdBuilder {
             config,
+            context,
             wallet,
             gas_budget,
             command,
         } = self;
         WalrusJsonCmd {
             config,
+            context,
             wallet,
             gas_budget,
             command,

--- a/sites-config.yaml
+++ b/sites-config.yaml
@@ -3,7 +3,8 @@ contexts:
     # module: site
     # portal: wal.app
     package: 0xf99aee9f21493e1590e7e5a9aea6f343a1f381031a04a732724871fc294be799
-    # general:
+    general:
+        wallet_env: testnet
     #   rpc_url: https://fullnode.testnet.sui.io:443
     #   wallet: /path/to/.sui/sui_config/client.yaml
     #   walrus_binary: /path/to/walrus
@@ -13,7 +14,8 @@ contexts:
     # module: site
     # portal: wal.app
     package: 0x26eb7ee8688da02c5f671679524e379f0b837a12f1d1d799f255b7eea260ad27
-    # general:
+    general:
+        wallet_env: mainnet
     #   rpc_url: https://fullnode.mainnet.sui.io:443
     #   wallet: /path/to/.sui/sui_config/client.yaml
     #   walrus_binary: /path/to/walrus


### PR DESCRIPTION
This PR updates deprecated `#[clap(...)]` attributes to their modern equivalents in `clap` 4.x.
The current codebase still uses outdated syntax that has been deprecated since version 4.0.
By making this update, we ensure compatibility with future versions and maintain code quality.

Replacements:

`#[clap(rename_all` to `#[command(rename_all`

`#[clap(flatten)]` to `#[command(flatten)]`

`#[clap(short, long)]` to `#[arg(short, long)]`


`cargo check --features clap/deprecated`
Error:

![Pasted Graphic 25](https://github.com/user-attachments/assets/71919acf-f527-4bb7-b1b9-4d84c11f6a0a)


After Fix :
`cargo check --features clap/deprecated`

![Pasted Graphic 28](https://github.com/user-attachments/assets/81af77c5-6389-44e0-8dd0-33bc51bd04d5)

`cargo build`

![image](https://github.com/user-attachments/assets/671b0001-4be6-4d50-a794-2ae6b0fe874c)

Note: This PR replaces #429  with a cleaner and more complete solution for updating deprecated clap attributes.

