### PR TITLE
feat(site-builder): add multi-context config

### DIFF
--- a/site-builder/src/display.rs
+++ b/site-builder/src/display.rs
@@ -49,3 +49,13 @@ pub fn done() {
         .unwrap();
     }
 }
+
+pub fn warn<S: Display>(message: S) {
+    if cfg!(not(test)) {
+        crossterm::execute!(
+            stdout(),
+            Print(format!("\n{} {message}\n", "Warning:".yellow())),
+        )
+        .unwrap();
+    }
+}

--- a/site-builder/src/main.rs
+++ b/site-builder/src/main.rs
@@ -12,8 +12,9 @@ mod types;
 mod util;
 mod walrus;
 use std::{
+    collections::HashMap,
     num::{NonZeroU32, NonZeroUsize},
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 
 use anyhow::{anyhow, ensure, Result};
@@ -50,6 +51,8 @@ struct Args {
     /// The path to the configuration file for the site builder.
     #[clap(short, long)]
     config: Option<PathBuf>,
+    #[clap(long)]
+    context: Option<String>,
     #[clap(flatten)]
     general: GeneralArgs,
     #[command(subcommand)]
@@ -259,6 +262,13 @@ pub struct PublishOptions {
     dry_run: bool,
 }
 
+/// Configuration for the site builder, complete with separate context for networks.
+#[derive(Deserialize, Debug, Clone)]
+pub(crate) struct MultiConfig {
+    pub contexts: HashMap<String, Config>,
+    pub default_context: String,
+}
+
 /// The configuration for the site builder.
 #[derive(Deserialize, Debug, Clone)]
 pub(crate) struct Config {
@@ -270,6 +280,29 @@ pub(crate) struct Config {
 }
 
 impl Config {
+    pub fn load_multi_config(path: impl AsRef<Path>, context: Option<&str>) -> Result<Self> {
+        let mut multi_config =
+            serde_yaml::from_str::<MultiConfig>(&std::fs::read_to_string(path)?)?;
+
+        let context = context.unwrap_or_else(|| &multi_config.default_context);
+        tracing::info!(?context, "using context");
+
+        let config = multi_config
+            .contexts
+            .remove(context)
+            .ok_or_else(|| anyhow!("could not find the context: {}", context))?;
+
+        if context != multi_config.default_context {
+            display::warn(format!(
+                "using a non-default context ({}); the default context is: {}\n\
+                Please ensure that this matches your wallet and Walrus CLI context\n",
+                context, multi_config.default_context,
+            ));
+        }
+
+        Ok(config)
+    }
+
     /// Merges the other [`GeneralArgs`] (taken from the CLI) with the `general` in the struct.
     ///
     /// The values in `other_general` take precedence.
@@ -400,7 +433,7 @@ async fn run() -> Result<()> {
             consider using  the --config flag to specify the config"
         ))?;
     tracing::info!(?config_path, "loading sites configuration");
-    let mut config = serde_yaml::from_str::<Config>(&std::fs::read_to_string(config_path)?)?;
+    let mut config = Config::load_multi_config(config_path, args.context.as_deref())?;
 
     // Merge the configs and the CLI args. Serde default ensures that the `walrus_binary` and
     // `gas_budget` exist.

--- a/site-builder/src/main.rs
+++ b/site-builder/src/main.rs
@@ -289,7 +289,7 @@ impl Config {
             serde_yaml::from_str::<MultiConfig>(&std::fs::read_to_string(path)?)?;
 
         let context = context.unwrap_or_else(|| &multi_config.default_context);
-        tracing::info!(?context, "using context");
+        tracing::info!(?context, "loading the configuration");
 
         let config = multi_config
             .contexts

--- a/site-builder/src/main.rs
+++ b/site-builder/src/main.rs
@@ -51,6 +51,10 @@ struct Args {
     /// The path to the configuration file for the site builder.
     #[clap(short, long)]
     config: Option<PathBuf>,
+    /// The context with which to load the configuration.
+    ///
+    /// If specified, the context will be taken from the config file. Otherwise, the default
+    /// context, which is also specified in the config file, will be used.
     #[clap(long)]
     context: Option<String>,
     #[clap(flatten)]

--- a/sites-config.yaml
+++ b/sites-config.yaml
@@ -1,23 +1,23 @@
 contexts:
   testnet:
     # module: site
-    # portal: walrus.site
-    package: 0x9d055e60cc8012d43c396194395e8f80c54afd083d908bdfbc3c37906f59146e
+    # portal: wal.app
+    package: 0xf99aee9f21493e1590e7e5a9aea6f343a1f381031a04a732724871fc294be799
     # general:
     #   rpc_url: https://fullnode.testnet.sui.io:443
     #   wallet: /path/to/.sui/sui_config/client.yaml
     #   walrus_binary: /path/to/walrus
-    #   walrus_config: /path/to/devnet_deployment/client_config.yaml
+    #   walrus_config: /path/to/testnet/client_config.yaml
     #   gas_budget: 500000000
   mainnet:
     # module: site
-    # portal: walrus.site
+    # portal: wal.app
     package: 0x26eb7ee8688da02c5f671679524e379f0b837a12f1d1d799f255b7eea260ad27
     # general:
     #   rpc_url: https://fullnode.mainnet.sui.io:443
     #   wallet: /path/to/.sui/sui_config/client.yaml
     #   walrus_binary: /path/to/walrus
-    #   walrus_config: /path/to/devnet_deployment/client_config.yaml
+    #   walrus_config: /path/to/mainnet/client_config.yaml
     #   gas_budget: 500000000
 
 default_context: mainnet

--- a/sites-config.yaml
+++ b/sites-config.yaml
@@ -1,9 +1,23 @@
-# module: site
-# portal: wal.app
-package: 0x9d055e60cc8012d43c396194395e8f80c54afd083d908bdfbc3c37906f59146e
-# general:
-#   rpc_url: https://fullnode.testnet.sui.io:443
-#   wallet: /path/to/.sui/sui_config/client.yaml
-#   walrus_binary: /path/to/walrus
-#   walrus_config: /path/to/devnet_deployment/client_config.yaml
-#   gas_budget: 500000000
+contexts:
+  testnet:
+    # module: site
+    # portal: walrus.site
+    package: 0x9d055e60cc8012d43c396194395e8f80c54afd083d908bdfbc3c37906f59146e
+    # general:
+    #   rpc_url: https://fullnode.testnet.sui.io:443
+    #   wallet: /path/to/.sui/sui_config/client.yaml
+    #   walrus_binary: /path/to/walrus
+    #   walrus_config: /path/to/devnet_deployment/client_config.yaml
+    #   gas_budget: 500000000
+  mainnet:
+    # module: site
+    # portal: walrus.site
+    package: 0x26eb7ee8688da02c5f671679524e379f0b837a12f1d1d799f255b7eea260ad27
+    # general:
+    #   rpc_url: https://fullnode.mainnet.sui.io:443
+    #   wallet: /path/to/.sui/sui_config/client.yaml
+    #   walrus_binary: /path/to/walrus
+    #   walrus_config: /path/to/devnet_deployment/client_config.yaml
+    #   gas_budget: 500000000
+
+default_context: mainnet


### PR DESCRIPTION
Adds a new configuration which has "contexts" (`mainnet` and `testnet`, in our config).