### PR TITLE
feat(site-builder): add config for wallet address, walrus context, singleton config

### DIFF
--- a/site-builder/src/config.rs
+++ b/site-builder/src/config.rs
@@ -5,7 +5,7 @@
 
 use std::{collections::HashMap, path::Path};
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 use serde::Deserialize;
 use sui_sdk::wallet_context::WalletContext;
 use sui_types::base_types::ObjectID;
@@ -14,12 +14,17 @@ pub(crate) use crate::{args::GeneralArgs, walrus::Walrus};
 
 /// Configuration for the site builder, complete with separate context for networks.
 #[derive(Deserialize, Debug, Clone)]
-pub(crate) struct MultiConfig {
-    pub contexts: HashMap<String, Config>,
-    pub default_context: String,
+#[serde(untagged)]
+#[allow(clippy::large_enum_variant)]
+pub(crate) enum MultiConfig {
+    SingletonConfig(Config),
+    MultiConfig {
+        contexts: HashMap<String, Config>,
+        default_context: String,
+    },
 }
 
-pub(crate) type ConfigWithContext = Config<String>;
+pub(crate) type ConfigWithContext = Config<Option<String>>;
 
 /// The configuration for the site builder.
 #[derive(Deserialize, Debug, Clone)]
@@ -65,7 +70,7 @@ impl<C> Config<C> {
     }
 
     /// Adds the context to the configuration.
-    pub fn with_context(self, context: String) -> Config<String> {
+    pub fn with_context(self, context: Option<String>) -> ConfigWithContext {
         let Config {
             portal,
             package,
@@ -81,21 +86,35 @@ impl<C> Config<C> {
     }
 }
 
-impl Config<String> {
-    pub fn load_multi_config(path: impl AsRef<Path>, context: Option<&str>) -> Result<Self> {
-        let mut multi_config =
-            serde_yaml::from_str::<MultiConfig>(&std::fs::read_to_string(path)?)?;
+impl ConfigWithContext {
+    pub fn load_from_multi_config(path: impl AsRef<Path>, context: Option<&str>) -> Result<Self> {
+        let multi_config =
+            serde_yaml::from_str::<MultiConfig>(&std::fs::read_to_string(path.as_ref())?)?;
 
-        let context = context.unwrap_or_else(|| &multi_config.default_context);
-        tracing::info!(?context, "loading the configuration");
-
-        let config = multi_config
-            .contexts
-            .remove(context)
-            .ok_or_else(|| anyhow!("could not find the context: {}", context))?;
-
-        let config = config.with_context(context.to_owned());
-        Ok(config)
+        match multi_config {
+            MultiConfig::SingletonConfig(config) => {
+                if let Some(context) = context {
+                    bail!(
+                        "cannot specify contex when using a single config file \
+                        (config_filename={}, context={})",
+                        path.as_ref().display(),
+                        context
+                    );
+                }
+                Ok(config.with_context(None))
+            }
+            MultiConfig::MultiConfig {
+                mut contexts,
+                default_context,
+            } => {
+                let context = context.unwrap_or(&default_context);
+                tracing::info!(?context, "loading the configuration");
+                let config = contexts
+                    .remove(context)
+                    .ok_or_else(|| anyhow!("could not find the context: {}", context))?;
+                Ok(config.with_context(Some(context.to_owned())))
+            }
+        }
     }
 
     /// Creates a Walrus client with the configuration from `self`.
@@ -105,8 +124,7 @@ impl Config<String> {
             self.gas_budget(),
             self.general.rpc_url.clone(),
             self.general.walrus_config.clone(),
-            // TODO: should we ever pass None?
-            Some(self.context.clone()),
+            self.context.clone(),
             self.general.wallet.clone(),
         )
     }

--- a/site-builder/src/main.rs
+++ b/site-builder/src/main.rs
@@ -147,7 +147,7 @@ async fn run() -> Result<()> {
         // Add a path to be watched. All files and directories at that path and
         // below will be monitored for changes.
         Commands::Sitemap { object } => {
-            let site_data = RemoteSiteFactory::new(
+            let all_dynamic_fields = RemoteSiteFactory::new(
                 // TODO(giac): make the backoff configurable.
                 &RetriableSuiClient::new_from_wallet(
                     &config.load_wallet()?,
@@ -157,30 +157,12 @@ async fn run() -> Result<()> {
                 config.package,
             )
             .await?
-            .get_from_chain(object)
+            .get_existing_resources(object)
             .await?;
-
             println!("Pages in site at object id: {}", object);
-
-            let blob_ids = site_data
-                .resources()
-                .into_iter()
-                .map(|res| res.info.blob_id)
-                .collect::<Vec<_>>();
-
-            for blob in blob_ids {
-                println!("{}", blob);
+            for (name, id) in all_dynamic_fields {
+                println!("  - {:<40} {:?}", name, id);
             }
-
-            // list the blobs owed by the current wallet
-
-            //for resoruce in site_data.resources() {
-            //    println!("  - {:<40} {}", resoruce.info.path, resoruce.info.blob_id);
-            //}
-
-            //for (name, id) in all_dynamic_fields {
-            //    println!("  - {:<40} {:?}", name, id);
-            //}
         }
         Commands::Convert { object_id } => println!("{}", id_to_base36(&object_id)?),
         Commands::ListDirectory { path } => {

--- a/site-builder/src/main.rs
+++ b/site-builder/src/main.rs
@@ -83,6 +83,7 @@ async fn run() -> Result<()> {
     tracing::info!("initializing site builder");
 
     let args = Args::parse();
+    tracing::info!(?args, "command line arguments");
     let config_path =
         path_or_defaults_if_exist(args.config.as_deref(), &sites_config_default_paths()).ok_or(
             anyhow!(
@@ -90,8 +91,10 @@ async fn run() -> Result<()> {
             consider using  the --config flag to specify the config"
             ),
         )?;
+
     tracing::info!(?config_path, "loading sites configuration");
     let mut config = Config::load_from_multi_config(config_path, args.context.as_deref())?;
+    tracing::debug!(?config, "configuration before merging");
 
     // Merge the configs and the CLI args. Serde default ensures that the `walrus_binary` and
     // `gas_budget` exist.
@@ -103,7 +106,7 @@ async fn run() -> Result<()> {
             publish_options,
             site_name,
         } => {
-            // Use the passed, name, or load the ws-resources file, if it exsists, to take the site
+            // Use the passed, name, or load the ws-resources file, if it exists, to take the site
             // name from it or use the default one.
             let (ws_resources, _) = load_ws_resources(
                 publish_options.walrus_options.ws_resources.as_deref(),

--- a/site-builder/src/main.rs
+++ b/site-builder/src/main.rs
@@ -91,7 +91,7 @@ async fn run() -> Result<()> {
             ),
         )?;
     tracing::info!(?config_path, "loading sites configuration");
-    let mut config = Config::load_multi_config(config_path, args.context.as_deref())?;
+    let mut config = Config::load_from_multi_config(config_path, args.context.as_deref())?;
 
     // Merge the configs and the CLI args. Serde default ensures that the `walrus_binary` and
     // `gas_budget` exist.

--- a/site-builder/src/main.rs
+++ b/site-builder/src/main.rs
@@ -21,7 +21,7 @@ use backoff::ExponentialBackoffConfig;
 use clap::Parser;
 use config::Config;
 use futures::TryFutureExt;
-use publish::{ContinuousEditing, SiteEditor, WhenWalrusUpload};
+use publish::{load_ws_resources, ContinuousEditing, SiteEditor, WhenWalrusUpload};
 use retry_client::RetriableSuiClient;
 use site::{
     config::WSResources,
@@ -103,31 +103,22 @@ async fn run() -> Result<()> {
             publish_options,
             site_name,
         } => {
-            let ws_res_path = publish_options
-                .clone()
-                .walrus_options
-                .ws_resources
-                .unwrap_or_else(|| {
-                    std::path::PathBuf::from(format!(
-                        "{}/ws-resources.json",
-                        publish_options.clone().directory.to_str().unwrap_or("")
-                    ))
-                });
-            let ws_resources = WSResources::read(ws_res_path);
-            // If site_name is passed as CLI argument, use it,
-            // otherwise use the site name from ws-resources.json,
-            // else, use the default "test site".
-            let default_site_name = "Test Site".to_string();
-            let final_site_name = site_name.unwrap_or_else(|| {
+            // Use the passed, name, or load the ws-resources file, if it exsists, to take the site
+            // name from it or use the default one.
+            let (ws_resources, _) = load_ws_resources(
+                publish_options.walrus_options.ws_resources.as_deref(),
+                publish_options.directory.as_path(),
+            )?;
+            let site_name = site_name.unwrap_or_else(|| {
                 ws_resources
-                    .ok()
                     .and_then(|res| res.site_name)
-                    .unwrap_or(default_site_name)
+                    .unwrap_or_else(|| "Test Site".to_string())
             });
+
             SiteEditor::new(args.context, config)
                 .with_edit_options(
                     publish_options,
-                    SiteIdentifier::NewSite(final_site_name),
+                    SiteIdentifier::NewSite(site_name),
                     ContinuousEditing::Once,
                     WhenWalrusUpload::Modified,
                 )

--- a/site-builder/src/publish.rs
+++ b/site-builder/src/publish.rs
@@ -23,7 +23,7 @@ use sui_types::{
 use crate::{
     args::{PublishOptions, WalrusStoreOptions},
     backoff::ExponentialBackoffConfig,
-    config::ConfigWithContext,
+    config::Config,
     display,
     preprocessor::Preprocessor,
     retry_client::RetriableSuiClient,
@@ -99,12 +99,12 @@ pub(crate) struct EditOptions {
 
 pub(crate) struct SiteEditor<E = ()> {
     context: Option<String>,
-    config: ConfigWithContext,
+    config: Config,
     edit_options: E,
 }
 
 impl SiteEditor {
-    pub fn new(context: Option<String>, config: ConfigWithContext) -> Self {
+    pub fn new(context: Option<String>, config: Config) -> Self {
         SiteEditor {
             context,
             config,
@@ -313,7 +313,7 @@ impl SiteEditor<EditOptions> {
 }
 
 fn print_summary(
-    config: &ConfigWithContext,
+    config: &Config,
     address: &SuiAddress,
     site_id: &SiteIdentifier,
     response: &SuiTransactionBlockResponse,

--- a/site-builder/src/site/manager.rs
+++ b/site-builder/src/site/manager.rs
@@ -23,7 +23,7 @@ use super::{
 use crate::{
     args::WalrusStoreOptions,
     backoff::ExponentialBackoffConfig,
-    config::ConfigWithContext,
+    config::Config,
     display,
     publish::WhenWalrusUpload,
     retry_client::RetriableSuiClient,
@@ -47,7 +47,7 @@ pub enum SiteIdentifier {
 }
 
 pub struct SiteManager {
-    pub config: ConfigWithContext,
+    pub config: Config,
     pub walrus: Walrus,
     pub wallet: WalletContext,
     pub site_id: SiteIdentifier,
@@ -61,7 +61,7 @@ pub struct SiteManager {
 impl SiteManager {
     /// Creates a new site manager.
     pub async fn new(
-        config: ConfigWithContext,
+        config: Config,
         site_id: SiteIdentifier,
         when_upload: WhenWalrusUpload,
         walrus_options: WalrusStoreOptions,

--- a/site-builder/src/util.rs
+++ b/site-builder/src/util.rs
@@ -205,7 +205,10 @@ pub fn load_wallet_context(
         wallet_context.config.active_env = Some(target_env.to_string());
         tracing::info!(?target_env, "set the wallet env");
     } else {
-        tracing::info!("no wallet env provided, using the default one");
+        tracing::info!(
+            active_env=?wallet_context.config.active_env,
+            "no wallet env provided, using the default one"
+        );
     }
 
     if let Some(target_address) = wallet_address {
@@ -225,7 +228,10 @@ pub fn load_wallet_context(
         wallet_context.config.active_address = Some(*target_address);
         tracing::info!(?target_address, "set the wallet address");
     } else {
-        tracing::info!("no wallet address provided, using the default one");
+        tracing::info!(
+            active_address=?wallet_context.config.active_address,
+            "no wallet address provided, using the default one"
+        );
     }
 
     Ok(wallet_context)

--- a/site-builder/src/util.rs
+++ b/site-builder/src/util.rs
@@ -7,6 +7,7 @@ use std::{
 
 use anyhow::{anyhow, bail, Result};
 use futures::Future;
+use sui_keys::keystore::AccountKeystore;
 use sui_sdk::{
     rpc_types::{
         Page,
@@ -173,7 +174,11 @@ pub(crate) async fn type_origin_map_for_package(
 /// then from the standard Sui configuration directory.
 // NB: When making changes to the logic, make sure to update the argument docs in
 // `crates/walrus-service/bin/client.rs`.
-pub fn load_wallet_context(path: Option<&Path>, wallet_env: Option<&str>) -> Result<WalletContext> {
+pub fn load_wallet_context(
+    path: Option<&Path>,
+    wallet_env: Option<&str>,
+    wallet_address: Option<&SuiAddress>,
+) -> Result<WalletContext> {
     let mut default_paths = vec!["./client.yaml".into(), "./sui_config.yaml".into()];
     if let Some(home_dir) = home::home_dir() {
         default_paths.push(home_dir.join(".sui").join("sui_config").join("client.yaml"))
@@ -183,6 +188,7 @@ pub fn load_wallet_context(path: Option<&Path>, wallet_env: Option<&str>) -> Res
         .ok_or(anyhow!("could not find a valid wallet config file"))?;
     tracing::info!(conf_path = %path.display(), "using Sui wallet configuration");
     let mut wallet_context: WalletContext = WalletContext::new(&path, None, None)?;
+
     if let Some(target_env) = wallet_env {
         if !wallet_context
             .config
@@ -200,6 +206,26 @@ pub fn load_wallet_context(path: Option<&Path>, wallet_env: Option<&str>) -> Res
         tracing::info!(?target_env, "set the wallet env");
     } else {
         tracing::info!("no wallet env provided, using the default one");
+    }
+
+    if let Some(target_address) = wallet_address {
+        if !wallet_context
+            .config
+            .keystore
+            .addresses()
+            .iter()
+            .any(|address| address == target_address)
+        {
+            return Err(anyhow!(
+                "Address '{}' not found in wallet config file '{}'.",
+                target_address,
+                path.display()
+            ));
+        }
+        wallet_context.config.active_address = Some(*target_address);
+        tracing::info!(?target_address, "set the wallet address");
+    } else {
+        tracing::info!("no wallet address provided, using the default one");
     }
 
     Ok(wallet_context)

--- a/sites-config.mainnet-singleton.yaml
+++ b/sites-config.mainnet-singleton.yaml
@@ -1,0 +1,14 @@
+# This is an example singleton config for testnet.
+
+# module: site
+# portal: wal.app
+package: 0x26eb7ee8688da02c5f671679524e379f0b837a12f1d1d799f255b7eea260ad27
+general:
+   wallet_env: mainnet
+   walrus_context: mainnet # Assumes a Walrus CLI setup with a multi-config containing the "mainnet" context.
+   # wallet_address: 0x1234...
+   # rpc_url: https://fullnode.mainnet.sui.io:443
+   # wallet: /path/to/.sui/sui_config/client.yaml
+   # walrus_binary: /path/to/walrus
+   # walrus_config: /path/to/mainnet/client_config.yaml
+   # gas_budget: 500000000

--- a/sites-config.testnet-singleton.yaml
+++ b/sites-config.testnet-singleton.yaml
@@ -1,0 +1,14 @@
+# This is an example singleton config for testnet.
+
+# module: site
+# portal: wal.app
+package: 0xf99aee9f21493e1590e7e5a9aea6f343a1f381031a04a732724871fc294be799
+general:
+   wallet_env: testnet
+   walrus_context: testnet # Assumes a Walrus CLI setup with a multi-config containing the "testnet" context.
+   # wallet_address: 0x1234...
+   # rpc_url: https://fullnode.testnet.sui.io:443
+   # wallet: /path/to/.sui/sui_config/client.yaml
+   # walrus_binary: /path/to/walrus
+   # walrus_config: /path/to/testnet/client_config.yaml
+   # gas_budget: 500000000

--- a/sites-config.yaml
+++ b/sites-config.yaml
@@ -4,22 +4,26 @@ contexts:
     # portal: wal.app
     package: 0xf99aee9f21493e1590e7e5a9aea6f343a1f381031a04a732724871fc294be799
     general:
-        wallet_env: testnet
-    #   rpc_url: https://fullnode.testnet.sui.io:443
-    #   wallet: /path/to/.sui/sui_config/client.yaml
-    #   walrus_binary: /path/to/walrus
-    #   walrus_config: /path/to/testnet/client_config.yaml
-    #   gas_budget: 500000000
+       wallet_env: testnet
+       walrus_context: testnet # Assumes a Walrus CLI setup with a multi-config containing the "testnet" context.
+       # wallet_address: 0x1234...
+       # rpc_url: https://fullnode.testnet.sui.io:443
+       # wallet: /path/to/.sui/sui_config/client.yaml
+       # walrus_binary: /path/to/walrus
+       # walrus_config: /path/to/testnet/client_config.yaml
+       # gas_budget: 500000000
   mainnet:
     # module: site
     # portal: wal.app
     package: 0x26eb7ee8688da02c5f671679524e379f0b837a12f1d1d799f255b7eea260ad27
     general:
-        wallet_env: mainnet
-    #   rpc_url: https://fullnode.mainnet.sui.io:443
-    #   wallet: /path/to/.sui/sui_config/client.yaml
-    #   walrus_binary: /path/to/walrus
-    #   walrus_config: /path/to/mainnet/client_config.yaml
-    #   gas_budget: 500000000
+       wallet_env: mainnet
+       walrus_context: mainnet # Assumes a Walrus CLI setup with a multi-config containing the "mainnet" context.
+       # wallet_address: 0x1234...
+       # rpc_url: https://fullnode.mainnet.sui.io:443
+       # wallet: /path/to/.sui/sui_config/client.yaml
+       # walrus_binary: /path/to/walrus
+       # walrus_config: /path/to/mainnet/client_config.yaml
+       # gas_budget: 500000000
 
 default_context: mainnet


### PR DESCRIPTION
- adds the option to specify a separate `walrus_context`
- adds the option to specify which `wallet_address` to use
- adds the option to specify a singleton config