### PR TITLE
fix(site-builder): Enforce site_name field and set a better default name

### DIFF
--- a/examples/snake/ws-resources.json
+++ b/examples/snake/ws-resources.json
@@ -19,6 +19,6 @@
 	   "project_url": "https://github.com/MystenLabs/walrus-sites/",
 	   "creator": "MystenLabs"
 	},
-  "site-name": "Walrus Snake Game",
+  "site_name": "Walrus Snake Game",
   "ignore": ["/private/*", "/secret.txt"]
 }

--- a/site-builder/src/main.rs
+++ b/site-builder/src/main.rs
@@ -116,7 +116,7 @@ async fn run() -> Result<()> {
             let site_name = site_name.unwrap_or_else(|| {
                 ws_resources
                     .and_then(|res| res.site_name)
-                    .unwrap_or_else(|| "Test Site".to_string())
+                    .unwrap_or_else(|| "My Walrus Site".to_string())
             });
 
             SiteEditor::new(args.context, config)


### PR DESCRIPTION
- On WSResources change the site-name field(with a dash) to site_name
- On WSResources add the #[serde(deny_unknown_fields)] so that we throw an error. 
- On main.rs change the default site name from 'Test Site' to 'My Walrus Site'
- On config.rs add a test case for the invalid/valid site_name field.