### PR TITLE
feat(site-builder): Displaying an expiration column on a site's resources when running sitemap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5996,6 +5996,7 @@ dependencies = [
  "base64 0.22.1",
  "bcs",
  "bin-version",
+ "chrono",
  "clap",
  "crossterm",
  "dialoguer",

--- a/site-builder/Cargo.toml
+++ b/site-builder/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = "1.0.86"
 base64 = "0.22.1"
 bcs = "0.1.6"
 bin-version = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.46.2" }
+chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5.7", features = ["derive"] }
 crossterm = "0.27.0"
 dialoguer = "0.11.0"

--- a/site-builder/src/config.rs
+++ b/site-builder/src/config.rs
@@ -32,6 +32,7 @@ pub(crate) struct Config {
     pub package: ObjectID,
     #[serde(default)]
     pub general: GeneralArgs,
+    pub staking_object: Option<ObjectID>,
 }
 
 pub(crate) fn default_portal() -> String {

--- a/site-builder/src/site/contracts.rs
+++ b/site-builder/src/site/contracts.rs
@@ -249,3 +249,14 @@ pub mod suins {
     contract_ident!(struct name_record::NameRecord);
     contract_ident!(struct domain::Domain);
 }
+
+pub mod staking {
+    use super::*;
+
+    contract_ident!(struct staking::Staking);
+}
+pub mod staking_inner {
+    use super::*;
+
+    contract_ident!(struct staking_inner::StakingInnerV1);
+}

--- a/sites-config.yaml
+++ b/sites-config.yaml
@@ -3,6 +3,7 @@ contexts:
     # module: site
     # portal: wal.app
     package: 0xf99aee9f21493e1590e7e5a9aea6f343a1f381031a04a732724871fc294be799
+    staking_object: 0xbe46180321c30aab2f8b3501e24048377287fa708018a5b7c2792b35fe339ee3
     general:
        wallet_env: testnet
        walrus_context: testnet # Assumes a Walrus CLI setup with a multi-config containing the "testnet" context.
@@ -17,6 +18,7 @@ contexts:
     # module: site
     # portal: wal.app
     package: 0x26eb7ee8688da02c5f671679524e379f0b837a12f1d1d799f255b7eea260ad27
+    staking_object: 0x10b9d30c28448939ce6c4d6c6e0ffce4a7f8a4ada8248bdad09ef8b70e4a3904
     general:
        wallet_env: mainnet
        walrus_context: mainnet # Assumes a Walrus CLI setup with a multi-config containing the "mainnet" context.


### PR DESCRIPTION
This pull request introduces support for staking objects in the `site-builder` project, enabling enhanced functionality tied to staking parameters and expiration dates. The changes include updates to configuration files, new types and methods for handling staking objects, and modifications to existing logic to incorporate staking-related data.

### Staking Object Integration:

* **Added `staking_object` field to `Config` struct**: Enables configuration of staking objects in `site-builder`. (`[site-builder/src/config.rsR35](diffhunk://#diff-2edbdfaec5661afb741e137ff2960e8c7b76bbbf8573d12a1f3d1c74a1d6f569R35)`)
* **Introduced `Staking` and `StakingInnerV1` types**: Represents staking objects and their inner state, including epoch duration, committees, and storage parameters. (`[site-builder/src/types.rsR353-R444](diffhunk://#diff-1f98318629ab524ef4536b9721d5018ed13493b62f3e089cd3b1489406b721cdR353-R444)`)
* **Implemented `get_staking_object` utility function**: Fetches staking object data from the Sui blockchain, including dynamic fields for inner staking state. (`[site-builder/src/util.rsR328-R357](diffhunk://#diff-f8b1da3aad1f3dd4938dce70a16df3c4f4548754270ecc2be07060b2ca20025bR328-R357)`)

### Configuration Updates:

* **Updated `sites-config.yaml`**: Added `staking_object` entries for both testnet and mainnet contexts. (`[[1]](diffhunk://#diff-e3d36b257a479658cf0dc5a3f28b37f91fbcad4bda1c259a41f87fade9d5e67fR6)`, `[[2]](diffhunk://#diff-e3d36b257a479658cf0dc5a3f28b37f91fbcad4bda1c259a41f87fade9d5e67fR21)`)

### Sitemap Enhancements:

* **Modified `SiteMapTable` to include expiration dates**: Calculates expiration dates for blobs based on staking object parameters and displays them in the sitemap table. (`[[1]](diffhunk://#diff-8139b6ee3187d2d3c1c19e033a449f7216382c00ba46eea29df7179fc2c31086L96-R140)`, `[[2]](diffhunk://#diff-8139b6ee3187d2d3c1c19e033a449f7216382c00ba46eea29df7179fc2c31086L132-R196)`)
* **Updated `display_sitemap` function**: Integrates staking object retrieval and uses it to populate the sitemap table. (`[site-builder/src/sitemap.rsL60-R68](diffhunk://#diff-8139b6ee3187d2d3c1c19e033a449f7216382c00ba46eea29df7179fc2c31086L60-R68)`)