### PR TITLE
feat(site-builder): Support --end-epoch or --earliest-expiry-time when for defining resources' end-epochs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6003,6 +6003,7 @@ dependencies = [
  "flate2",
  "futures",
  "home",
+ "humantime",
  "move-core-types",
  "notify",
  "prettytable",

--- a/site-builder/Cargo.toml
+++ b/site-builder/Cargo.toml
@@ -17,6 +17,7 @@ fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto" }
 flate2 = "1.0.30"
 futures = "0.3.30"
 home = "0.5.9"
+humantime = "2.2.0"
 move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.46.2" }
 notify = "6.1.1"
 prettytable = "0.10.0"

--- a/site-builder/src/args.rs
+++ b/site-builder/src/args.rs
@@ -384,11 +384,9 @@ pub(crate) struct WalrusStoreOptions {
     /// The configuration file _will not_ be uploaded to Walrus.
     #[clap(long)]
     pub(crate) ws_resources: Option<PathBuf>,
-    /// The number of epochs for which to save the resources on Walrus.
+    /// The epoch argument to specify either the number of epochs to store the blob, or the
+    /// end epoch, or the earliest expiry time in rfc3339 format.
     ///
-    /// If set to `max`, the resources are stored for the maximum number of epochs allowed on
-    /// Walrus. Otherwise, the resources are stored for the specified number of epochs. The
-    /// number of epochs must be greater than 0.
     #[command(flatten)]
     pub(crate) epoch_arg: EpochArg,
     // pub(crate) epochs: EpochCountOrMax,
@@ -404,6 +402,7 @@ pub(crate) struct WalrusStoreOptions {
     pub(crate) dry_run: bool,
 }
 
+/// The number of epochs to store the blob for.
 #[derive(Parser, Debug, Clone, Default, Serialize, Deserialize)]
 #[clap(group(
     ArgGroup::new("epoch_arg")
@@ -412,17 +411,22 @@ pub(crate) struct WalrusStoreOptions {
 ))]
 #[serde(rename_all = "camelCase")]
 pub struct EpochArg {
-    /// Set number of epochs
+    /// The number of epochs the blob is stored for.
+    ///
+    /// If set to `max`, the blob is stored for the maximum number of epochs allowed by the
+    /// system object on chain. Otherwise, the blob is stored for the specified number of
+    /// epochs. The number of epochs must be greater than 0.
     #[arg(long, value_parser = EpochCountOrMax::parse_epoch_count)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub epochs: Option<EpochCountOrMax>,
 
-    /// Set earliest expiry time
+    /// The earliest time when the blob can expire, in RFC3339 format (e.g., "2024-03-20T15:00:00Z")
+    /// or a more relaxed format (e.g., "2024-03-20 15:00:00").
     #[arg(long, value_parser = humantime::parse_rfc3339_weak)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub earliest_expiry_time: Option<SystemTime>,
 
-    /// Set end epoch
+    /// The end epoch for the blob.
     #[clap(long = "end-epoch")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub end_epoch: Option<NonZeroU32>,

--- a/site-builder/src/args.rs
+++ b/site-builder/src/args.rs
@@ -390,7 +390,7 @@ pub(crate) struct WalrusStoreOptions {
     /// Walrus. Otherwise, the resources are stored for the specified number of epochs. The
     /// number of epochs must be greater than 0.
     #[command(flatten)]
-    pub(crate) target_range: EpochArg,
+    pub(crate) epoch_arg: EpochArg,
     // pub(crate) epochs: EpochCountOrMax,
     /// Make the stored resources permanent.
     ///
@@ -406,7 +406,7 @@ pub(crate) struct WalrusStoreOptions {
 
 #[derive(Parser, Debug, Clone, Default, Serialize, Deserialize)]
 #[clap(group(
-    ArgGroup::new("target_range")
+    ArgGroup::new("epoch_arg")
         .args(&["epochs", "earliest_expiry_time", "end_epoch"])
         .required(true)
 ))]

--- a/site-builder/src/site/manager.rs
+++ b/site-builder/src/site/manager.rs
@@ -96,7 +96,7 @@ impl SiteManager {
                 .walrus
                 .dry_run_store(
                     resource.full_path.clone(),
-                    self.walrus_options.epochs.clone(),
+                    self.walrus_options.target_range.clone(),
                     !self.walrus_options.permanent,
                     false,
                 )
@@ -234,7 +234,7 @@ impl SiteManager {
                 .walrus
                 .store(
                     resource_paths.clone(),
-                    self.walrus_options.epochs.clone(),
+                    self.walrus_options.target_range.clone(),
                     false,
                     deletable,
                 )

--- a/site-builder/src/site/manager.rs
+++ b/site-builder/src/site/manager.rs
@@ -96,7 +96,7 @@ impl SiteManager {
                 .walrus
                 .dry_run_store(
                     resource.full_path.clone(),
-                    self.walrus_options.target_range.clone(),
+                    self.walrus_options.epoch_arg.clone(),
                     !self.walrus_options.permanent,
                     false,
                 )
@@ -234,7 +234,7 @@ impl SiteManager {
                 .walrus
                 .store(
                     resource_paths.clone(),
-                    self.walrus_options.target_range.clone(),
+                    self.walrus_options.epoch_arg.clone(),
                     false,
                     deletable,
                 )

--- a/site-builder/src/walrus.rs
+++ b/site-builder/src/walrus.rs
@@ -19,7 +19,7 @@ use tokio::process::Command as CliCommand;
 
 use self::types::BlobId;
 use crate::{
-    args::EpochCountOrMax,
+    args::EpochArg,
     walrus::{command::WalrusCmdBuilder, output::DestroyOutput},
 };
 pub mod command;
@@ -89,11 +89,11 @@ impl Walrus {
     pub async fn store(
         &mut self,
         files: Vec<PathBuf>,
-        epochs: EpochCountOrMax,
+        target_range: EpochArg,
         force: bool,
         deletable: bool,
     ) -> Result<StoreOutput> {
-        create_command!(self, store, files, epochs, force, deletable, false)
+        create_command!(self, store, files, target_range, force, deletable, false)
     }
 
     /// Issues a `delete` JSON command to the Walrus CLI, returning the parsed output.
@@ -105,11 +105,19 @@ impl Walrus {
     pub async fn dry_run_store(
         &mut self,
         file: PathBuf,
-        epochs: EpochCountOrMax,
+        target_range: EpochArg,
         deletable: bool,
         force: bool,
     ) -> Result<Vec<DryRunOutput>> {
-        create_command!(self, store, vec![file], epochs, force, deletable, true)
+        create_command!(
+            self,
+            store,
+            vec![file],
+            target_range,
+            force,
+            deletable,
+            true
+        )
     }
 
     /// Issues a `read` JSON command to the Walrus CLI, returning the parsed output.

--- a/site-builder/src/walrus.rs
+++ b/site-builder/src/walrus.rs
@@ -89,11 +89,11 @@ impl Walrus {
     pub async fn store(
         &mut self,
         files: Vec<PathBuf>,
-        target_range: EpochArg,
+        epoch_arg: EpochArg,
         force: bool,
         deletable: bool,
     ) -> Result<StoreOutput> {
-        create_command!(self, store, files, target_range, force, deletable, false)
+        create_command!(self, store, files, epoch_arg, force, deletable, false)
     }
 
     /// Issues a `delete` JSON command to the Walrus CLI, returning the parsed output.
@@ -105,19 +105,11 @@ impl Walrus {
     pub async fn dry_run_store(
         &mut self,
         file: PathBuf,
-        target_range: EpochArg,
+        epoch_arg: EpochArg,
         deletable: bool,
         force: bool,
     ) -> Result<Vec<DryRunOutput>> {
-        create_command!(
-            self,
-            store,
-            vec![file],
-            target_range,
-            force,
-            deletable,
-            true
-        )
+        create_command!(self, store, vec![file], epoch_arg, force, deletable, true)
     }
 
     /// Issues a `read` JSON command to the Walrus CLI, returning the parsed output.

--- a/site-builder/src/walrus/command.rs
+++ b/site-builder/src/walrus/command.rs
@@ -52,7 +52,7 @@ pub enum Command {
         files: Vec<PathBuf>,
         /// The number of epochs for which to store the file.
         #[serde(flatten)]
-        target_range: EpochArg,
+        epoch_arg: EpochArg,
         /// Do not check for the blob status before storing it.
         ///
         /// This will create a new blob even if the blob is already certified for a sufficient
@@ -194,14 +194,14 @@ impl WalrusCmdBuilder {
     pub fn store(
         self,
         files: Vec<PathBuf>,
-        target_range: EpochArg,
+        epoch_arg: EpochArg,
         force: bool,
         deletable: bool,
         dry_run: bool,
     ) -> WalrusCmdBuilder<Command> {
         let command = Command::Store {
             files,
-            target_range,
+            epoch_arg,
             force,
             deletable,
             dry_run,

--- a/site-builder/src/walrus/command.rs
+++ b/site-builder/src/walrus/command.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 
 use super::types::BlobId;
-use crate::args::EpochCountOrMax;
+use crate::args::EpochArg;
 
 /// Represents a call to the JSON mode of the Walrus CLI.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -51,7 +51,8 @@ pub enum Command {
         /// The path to the file to be stored.
         files: Vec<PathBuf>,
         /// The number of epochs for which to store the file.
-        epochs: EpochCountOrMax,
+        #[serde(flatten)]
+        target_range: EpochArg,
         /// Do not check for the blob status before storing it.
         ///
         /// This will create a new blob even if the blob is already certified for a sufficient
@@ -193,14 +194,14 @@ impl WalrusCmdBuilder {
     pub fn store(
         self,
         files: Vec<PathBuf>,
-        epochs: EpochCountOrMax,
+        target_range: EpochArg,
         force: bool,
         deletable: bool,
         dry_run: bool,
     ) -> WalrusCmdBuilder<Command> {
         let command = Command::Store {
             files,
-            epochs,
+            target_range,
             force,
             deletable,
             dry_run,

--- a/site-builder/src/walrus/command.rs
+++ b/site-builder/src/walrus/command.rs
@@ -50,7 +50,9 @@ pub enum Command {
     Store {
         /// The path to the file to be stored.
         files: Vec<PathBuf>,
-        /// The number of epochs for which to store the file.
+        /// The epoch argument to specify either the number of epochs to store the blob, or the
+        /// end epoch, or the earliest expiry time in rfc3339 format.
+        ///
         #[serde(flatten)]
         epoch_arg: EpochArg,
         /// Do not check for the blob status before storing it.


### PR DESCRIPTION
Release Notes:
- Backwards compatible interface change: Support defining epochs to store the site by using either `--epochs` or `--end-epoch` or `--earliest-expiry-time`.