### PR TITLE
chore(portal): sew 234 add versions to sw and sp portals

### DIFF
--- a/portal/server/package.json
+++ b/portal/server/package.json
@@ -1,6 +1,7 @@
 {
     "name": "server",
-    "version": "0.1.0",
+    "description": "The server based implementation of the Walrus Sites portal.",
+    "version": "1.0.0",
     "private": true,
     "scripts": {
         "start": "bun --hot run index.ts"

--- a/portal/worker/package.json
+++ b/portal/worker/package.json
@@ -1,5 +1,7 @@
 {
 	"name": "worker",
+	"description": "The service-worker based implementation of the Walrus Sites portal.",
+	"version": "0.1.0",
 	"dependencies": {
 		"@mysten/sui": "^1.12.0",
 		"common": "workspace:common",


### PR DESCRIPTION
#### Service Worker
The service worker and the server portal should each have a version associated with it.
We don't host a service worker, and we don't put much effort into it to be regarded as production ready, so I set it to 0.1.0.

#### Server Portal
The server portal on the other hand is production ready and battle tested, so I set it to 1.0.0.