### PR TITLE
fix(site-builder): Fix blob_id calculation causing rate limits

### DIFF
--- a/examples/gen_files.sh
+++ b/examples/gen_files.sh
@@ -1,0 +1,132 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+#!/usr/bin/env bash
+
+# Utilize this script to generate a folder with random files,
+# so we can test deployment of a site with multiple files
+
+set -euo pipefail
+shopt -s nullglob
+
+# === GLOBAL VARIABLES ===
+OUTPUT_DIR="./random_txt_files"
+WORD_SOURCE="/usr/share/dict/words"
+FILENAME_LENGTH=12
+RANDOM_SUFFIX_DIGITS=6
+TOTAL_FILES=0
+PROGRESS_WIDTH=40
+
+# === FUNCTION DEFINITIONS ===
+
+parse_arguments() {
+    if [[ $# -ne 1 ]] || [[ ! "$1" =~ ^[1-9][0-9]*$ ]]; then
+        printf "Usage: %s <total_number_of_files>\n" "$0" >&2
+        return 1
+    fi
+    TOTAL_FILES="$1"
+}
+
+generate_random_suffix() {
+    local suffix;
+    suffix=$(jot -r 1 100000 999999 2>/dev/null || printf "%06d" $((RANDOM % 900000 + 100000)))
+    printf "%s" "$suffix"
+}
+
+generate_random_filename() {
+    local base suffix filename;
+    base=$(LC_CTYPE=C LC_ALL=C tr -dc 'a-zA-Z0-9' </dev/urandom | head -c "$FILENAME_LENGTH")
+    if [[ -z "$base" ]] || [[ "$base" =~ [^a-zA-Z0-9] ]]; then
+        printf "Error: Generated invalid base for filename\n" >&2
+        return 1
+    fi
+    suffix=$(generate_random_suffix)
+    filename="${base}_${suffix}.txt"
+    printf "%s" "$filename"
+}
+
+get_random_word() {
+    local word suffix;
+    if ! word=$(shuf -n 1 "$WORD_SOURCE" 2>/dev/null); then
+        if ! word=$(awk 'BEGIN {srand()} {lines[NR]=$0} END {print lines[int(rand()*NR)+1]}' "$WORD_SOURCE"); then
+            printf "Error: Failed to extract random word from %s\n" "$WORD_SOURCE" >&2
+            return 1
+        fi
+    fi
+    if [[ -z "${word// /}" ]]; then
+        printf "Warning: Extracted empty word, skipping\n" >&2
+        return 1
+    fi
+    suffix=$(generate_random_suffix)
+    printf "%s_%s" "$word" "$suffix"
+}
+
+create_random_file() {
+    local filepath word;
+    filepath="$1"
+    if ! word=$(get_random_word); then
+        return 1
+    fi
+    if ! printf "%s\n" "$word" > "$filepath"; then
+        printf "Error: Failed to write to file '%s'\n" "$filepath" >&2
+        return 1
+    fi
+}
+
+prepare_output_directory() {
+    mkdir -p "$OUTPUT_DIR"
+}
+
+draw_progress_bar() {
+    local current=$1
+    local total=$2
+    local width=$PROGRESS_WIDTH
+    local percent=$(( (current * 100 + total - 1) / total ))  # ceil percentage
+
+    # ceil version of filled bar
+    local filled=$(( (current * width + total - 1) / total ))
+    local empty=$(( width - filled ))
+
+    local bar_filled bar_empty bar;
+    bar_filled=$(printf "%0.s#" $(seq 1 "$filled"))
+    bar_empty=$(printf "%0.s-" $(seq 1 "$empty"))
+    bar="${bar_filled}${bar_empty}"
+
+    printf "\r[%s] %3d%% (%d/%d)" "$bar" "$percent" "$current" "$total"
+}
+
+generate_files() {
+    local i=0 filename filepath;
+    while [[ $i -lt $TOTAL_FILES ]]; do
+        if ! filename=$(generate_random_filename); then
+            continue
+        fi
+        filepath="$OUTPUT_DIR/$filename"
+        if [[ -e "$filepath" ]]; then
+            continue
+        fi
+        if create_random_file "$filepath"; then
+            ((i++))
+            draw_progress_bar "$i" "$TOTAL_FILES"
+        fi
+    done
+    bar=$(printf "%0.s#" $(seq 1 "$PROGRESS_WIDTH"))
+    printf "\r[%s] %3d%% (%d/%d)" "$bar" "100" "$i" "$TOTAL_FILES"
+    printf "\n"
+}
+
+validate_word_source() {
+    if [[ ! -f "$WORD_SOURCE" ]] || [[ ! -r "$WORD_SOURCE" ]]; then
+        printf "Error: Word source file '%s' not found or not readable\n" "$WORD_SOURCE" >&2
+        return 1
+    fi
+}
+
+main() {
+    parse_arguments "$@" || return 1
+    validate_word_source || return 1
+    prepare_output_directory
+    generate_files
+}
+
+main "$@"

--- a/examples/snake/ws-resources.json
+++ b/examples/snake/ws-resources.json
@@ -20,7 +20,7 @@
     "creator": "MystenLabs"
   },
   "site_name": "Walrus Snake Game",
-  "object_id": "0xe382ebbe37ca5c12ac67c107abe46e67aa62a3ed36a3dbdf65e895bd76cc5887",
+  "object_id": "0x87b3c120dcb4f5e08b6ebeee9b7d3d320692815f25259d5222168139828cacc2",
   "ignore": [
     "/private/*",
     "/secret.txt"

--- a/site-builder/src/walrus.rs
+++ b/site-builder/src/walrus.rs
@@ -20,7 +20,10 @@ use tokio::process::Command as CliCommand;
 use self::types::BlobId;
 use crate::{
     args::EpochArg,
-    walrus::{command::WalrusCmdBuilder, output::DestroyOutput},
+    walrus::{
+        command::{EncodingTypeArg, WalrusCmdBuilder},
+        output::DestroyOutput,
+    },
 };
 pub mod command;
 pub mod output;
@@ -124,7 +127,14 @@ impl Walrus {
         file: PathBuf,
         n_shards: Option<NonZeroU16>,
     ) -> Result<BlobIdOutput> {
-        create_command!(self, blob_id, file, n_shards, self.rpc_arg())
+        create_command!(
+            self,
+            blob_id,
+            file,
+            n_shards,
+            self.rpc_arg(),
+            self.encoding_type_arg()
+        )
     }
 
     /// Issues an `info` JSON command to the Walrus CLI, returning the number of shards.
@@ -153,5 +163,9 @@ impl Walrus {
         RpcArg {
             rpc_url: self.rpc_url.clone(),
         }
+    }
+
+    fn encoding_type_arg(&self) -> EncodingTypeArg {
+        EncodingTypeArg::default()
     }
 }

--- a/site-builder/src/walrus/command.rs
+++ b/site-builder/src/walrus/command.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 
 use super::types::BlobId;
-use crate::args::EpochArg;
+use crate::{args::EpochArg, walrus::output::EncodingType};
 
 /// Represents a call to the JSON mode of the Walrus CLI.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -101,6 +101,9 @@ pub enum Command {
         /// The RPC endpoint to which the Walrus CLI should connect to.
         #[serde(flatten)]
         rpc_arg: RpcArg,
+        /// The Walrus Encoding Type.
+        #[serde(flatten)]
+        encoding_type: EncodingTypeArg,
     },
     Info {
         /// The URL of the Sui RPC node to use.
@@ -119,6 +122,15 @@ pub struct RpcArg {
     /// The RPC URL of a Sui full node.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rpc_url: Option<String>,
+}
+
+/// Represents the Walrus EncodingType argument.
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EncodingTypeArg {
+    /// The Walrus EncodingType
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub encoding_type: Option<EncodingType>,
 }
 
 /// Subcommands for the `info` command.
@@ -242,11 +254,13 @@ impl WalrusCmdBuilder {
         file: PathBuf,
         n_shards: Option<NonZeroU16>,
         rpc_arg: RpcArg,
+        encoding_type: EncodingTypeArg,
     ) -> WalrusCmdBuilder<Command> {
         let command = Command::BlobId {
             file,
             n_shards,
             rpc_arg,
+            encoding_type,
         };
         self.with_command(command)
     }

--- a/site-builder/src/walrus/output.rs
+++ b/site-builder/src/walrus/output.rs
@@ -6,7 +6,7 @@
 use std::{num::NonZeroU16, path::PathBuf, process::Output};
 
 use anyhow::{anyhow, Context, Result};
-use serde::{de::DeserializeOwned, Deserialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_with::{base64::Base64, serde_as, DisplayFromStr};
 use sui_types::{base_types::ObjectID, event::EventID};
 
@@ -123,12 +123,13 @@ pub struct BlobStoreResultWithPath {
 }
 
 /// Supported Walrus encoding types.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Deserialize)]
+#[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Deserialize, Serialize)]
 #[repr(u8)]
 pub enum EncodingType {
     /// Original RedStuff encoding using the RaptorQ erasure code.
     RedStuffRaptorQ = 0,
     /// RedStuff using the Reed-Solomon erasure code.
+    #[default]
     RS2 = 1,
 }
 

--- a/site-builder/tests/publish.rs
+++ b/site-builder/tests/publish.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::path::PathBuf;
+use std::{fs, path::PathBuf};
 
 use site_builder::args::{Commands, EpochCountOrMax};
 
@@ -21,14 +21,19 @@ async fn publish_snake() -> anyhow::Result<()> {
         .unwrap()
         .join("examples")
         .join("snake");
-    let ws_resources = directory.join("ws-resources.json");
+    let original_ws_resources = directory.join("ws-resources.json");
+
+    // Create a temp file copy so the original doesn't get mutated
+    let temp_dir = tempfile::tempdir()?;
+    let temp_ws_resources = temp_dir.path().join("ws-resources.json");
+    fs::copy(&original_ws_resources, &temp_ws_resources)?;
 
     let args = ArgsBuilder::default()
         .with_config(Some(cluster.sites_config.inner.1))
         .with_command(Commands::Publish {
             publish_options: PublishOptionsBuilder::default()
                 .with_directory(directory)
-                .with_ws_resources(Some(ws_resources))
+                .with_ws_resources(Some(temp_ws_resources))
                 .with_epoch_count_or_max(EpochCountOrMax::Max)
                 .build()?,
             site_name: None,


### PR DESCRIPTION
Looking at the [implementation](https://github.com/MystenLabs/walrus/blob/main/crates/walrus-service/src/client/cli/runner.rs#L1035) of the walrus blob_id method,
it seems that calls to the rpc client are  happening if we do not provide the n_shards or the encoding_type. 

We [do](https://github.com/MystenLabs/walrus-sites/blob/main/site-builder/src/site/resource.rs#L424) provide the n_shards, but not the encoding_type. 

However, as you can see here: [get_sui_read_client_from_rpc_node_or_wallet](https://github.com/MystenLabs/walrus/blob/429d070f72d9fb20e7a8a20fc0dd757938f66bae/crates/walrus-service/src/client/cli/runner.rs#L1049)  a DEFAULT_ENCODING constant is used, so we could potentially open a small PR on walrus as well, so that it doesn't try to setup an rpc client in this case.