### PR TITLE
fix: SEW-295 update Move.lock to point at the latest testnet packageId

### DIFF
--- a/.github/workflows/move-tests.yml
+++ b/.github/workflows/move-tests.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Download Sui
         run: |
-          VERSION=testnet-v1.45.0
+          VERSION=testnet-v1.51.3
           curl -L "https://github.com/MystenLabs/sui/releases/download/$VERSION/sui-$VERSION-ubuntu-x86_64.tgz" -o sui.tgz
           sudo tar -xvzf sui.tgz -C /usr/local/bin
 

--- a/move/walrus_site/Move.lock
+++ b/move/walrus_site/Move.lock
@@ -36,6 +36,6 @@ published-version = "1"
 
 [env.testnet]
 chain-id = "4c78adac"
-original-published-id = "0x9d055e60cc8012d43c396194395e8f80c54afd083d908bdfbc3c37906f59146e"
-latest-published-id = "0x9d055e60cc8012d43c396194395e8f80c54afd083d908bdfbc3c37906f59146e"
+original-published-id = "0xf99aee9f21493e1590e7e5a9aea6f343a1f381031a04a732724871fc294be799"
+latest-published-id = "0xf99aee9f21493e1590e7e5a9aea6f343a1f381031a04a732724871fc294be799"
 published-version = "1"


### PR DESCRIPTION
Without fixing this it's not possible using the walrus sites smart contract as a dependency to another contract.