### PR TITLE
build(site-builder): Add ubuntu-arm64 to build list

### DIFF
--- a/.github/workflows/attach-binaries-to-release.yml
+++ b/.github/workflows/attach-binaries-to-release.yml
@@ -48,6 +48,7 @@ jobs:
       matrix:
         os:
           - ubuntu-ghcloud # ubuntu-x86_64
+          - ubuntu-arm64, # ubuntu-arm64
           - windows-ghcloud # windows-x86_64
           - macos-latest-large # macos-x86_64
           - macos-latest-xlarge # macos-arm64


### PR DESCRIPTION
Adds the ubuntu-arm64 os to the list of oses to build artifacts for.