### PR TITLE
refactor(site-builder): replace SiteIdentifier with Option<ObjectID>

### DIFF
--- a/site-builder/src/lib.rs
+++ b/site-builder/src/lib.rs
@@ -99,6 +99,7 @@ async fn run_internal(
                 .with_edit_options(
                     publish_options,
                     identifier,
+                    site_name,
                     continuous_editing,
                     blob_management,
                 )
@@ -120,6 +121,7 @@ async fn run_internal(
                 .with_edit_options(
                     publish_options,
                     None,
+                    site_name,
                     ContinuousEditing::Once,
                     BlobManagementOptions::no_status_check(),
                 )
@@ -144,6 +146,7 @@ async fn run_internal(
                 .with_edit_options(
                     publish_options,
                     Some(object_id),
+                    None,
                     ContinuousEditing::from_watch_flag(watch),
                     // Check the extension if either `check_extend` is true or `force` is true.
                     // This is for backwards compatibility.

--- a/site-builder/src/publish.rs
+++ b/site-builder/src/publish.rs
@@ -91,6 +91,7 @@ impl BlobManagementOptions {
 pub(crate) struct EditOptions {
     pub publish_options: PublishOptions,
     pub site_id: Option<ObjectID>,
+    pub site_name: Option<String>,
     pub continuous_editing: ContinuousEditing,
     pub blob_options: BlobManagementOptions,
 }
@@ -114,6 +115,7 @@ impl SiteEditor {
         self,
         publish_options: PublishOptions,
         site_id: Option<ObjectID>,
+        site_name: Option<String>,
         continuous_editing: ContinuousEditing,
         blob_options: BlobManagementOptions,
     ) -> SiteEditor<EditOptions> {
@@ -123,6 +125,7 @@ impl SiteEditor {
             edit_options: EditOptions {
                 publish_options,
                 site_id,
+                site_name,
                 continuous_editing,
                 blob_options,
             },
@@ -276,7 +279,7 @@ impl SiteEditor<EditOptions> {
             self.edit_options.blob_options.clone(),
             self.edit_options.publish_options.walrus_options.clone(),
             site_metadata,
-            site_name,
+            self.edit_options.site_name.clone().or(site_name),
             self.edit_options.publish_options.max_parallel_stores,
         )
         .await?;
@@ -442,7 +445,7 @@ fn persist_site_identifier(
             );
             let name = ws_resources
                 .as_ref()
-                .and_then(|r| r.site_name.clone())
+                .and_then(|r| site_manager.site_name.clone().or(r.site_name.clone()))
                 .unwrap_or_else(|| "My Walrus Site".to_string());
 
             persist_site_id_and_name(new_site_object_id, Some(name.clone()), ws_resources, path)?;

--- a/site-builder/src/site/manager.rs
+++ b/site-builder/src/site/manager.rs
@@ -37,20 +37,11 @@ const MAX_RESOURCES_PER_PTB: usize = 200;
 const OS_ERROR_DELAY: Duration = Duration::from_secs(1);
 const MAX_RETRIES: u32 = 10;
 
-/// The identifier for the new or existing site.
-///
-/// Either object ID (existing site) or name (new site).
-#[derive(Debug, Clone)]
-pub enum SiteIdentifier {
-    ExistingSite(ObjectID),
-    NewSite(String),
-}
-
 pub struct SiteManager {
     pub config: Config,
     pub walrus: Walrus,
     pub wallet: WalletContext,
-    pub site_id: SiteIdentifier,
+    pub site_id: Option<ObjectID>,
     pub blob_options: BlobManagementOptions,
     pub backoff_config: ExponentialBackoffConfig,
     pub metadata: Option<Metadata>,
@@ -63,7 +54,7 @@ impl SiteManager {
     /// Creates a new site manager.
     pub async fn new(
         config: Config,
-        site_id: SiteIdentifier,
+        site_id: Option<ObjectID>,
         blob_options: BlobManagementOptions,
         walrus_options: WalrusStoreOptions,
         metadata: Option<Metadata>,
@@ -124,13 +115,13 @@ impl SiteManager {
         tracing::debug!(?self.site_id, "creating or updating site");
         let retriable_client = self.sui_client().await?;
         let existing_site = match &self.site_id {
-            SiteIdentifier::ExistingSite(site_id) => {
+            Some(site_id) => {
                 RemoteSiteFactory::new(&retriable_client, self.config.package)
                     .await?
                     .get_from_chain(*site_id)
                     .await?
             }
-            SiteIdentifier::NewSite(_) => SiteData::empty(),
+            None => SiteData::empty(),
         };
         tracing::debug!(?existing_site, "checked existing site");
 
@@ -313,7 +304,7 @@ impl SiteManager {
 
         // Add the call arg if we are updating a site, or add the command to create a new site.
         let mut ptb = match &self.site_id {
-            SiteIdentifier::ExistingSite(site_id) => {
+            Some(site_id) => {
                 let ptb = ptb.with_call_arg(&self.wallet.get_object_ref(*site_id).await?.into())?;
                 // Also update metadata if there is a diff
                 match updates.metadata_op {
@@ -323,9 +314,10 @@ impl SiteManager {
                     MetadataOp::Noop => ptb,
                 }
             }
-            SiteIdentifier::NewSite(site_name) => {
-                ptb.with_create_site(site_name, self.metadata.clone())?
-            }
+            None => ptb.with_create_site(
+                self.site_name.as_deref().unwrap_or("My Walrus Site"),
+                self.metadata.clone(),
+            )?,
         };
 
         if let Some(site_name) = &self.site_name {
@@ -359,8 +351,8 @@ impl SiteManager {
             .await?;
 
         let site_object_id = match &self.site_id {
-            SiteIdentifier::ExistingSite(site_id) => *site_id,
-            SiteIdentifier::NewSite(_) => {
+            Some(site_id) => *site_id,
+            None => {
                 let resp = result
                     .effects
                     .as_ref()
@@ -398,7 +390,7 @@ impl SiteManager {
             Identifier::from_str(SITE_MODULE).expect("the str provided is valid"),
         )?;
 
-        let SiteIdentifier::ExistingSite(site_id) = &self.site_id else {
+        let Some(site_id) = &self.site_id else {
             anyhow::bail!("`add_single_resource` is only supported for existing sites");
         };
         let mut ptb = ptb.with_call_arg(&self.wallet.get_object_ref(*site_id).await?.into())?;
@@ -506,7 +498,7 @@ impl SiteManager {
     ///
     /// A new site needs to be transferred to the active address.
     fn needs_transfer(&self) -> bool {
-        matches!(self.site_id, SiteIdentifier::NewSite(_))
+        matches!(self.site_id, None)
     }
 }
 


### PR DESCRIPTION
This makes the code more clean since everything gets filtered through the ws-resources.json. 

**Bonus**: Fixes `--site-name` to take precedence over `ws-resources.json > "site-name": ...`.