### PR TITLE
feat(portal): derive `quiltpatchid` for resource retrieval

### DIFF
--- a/portal/common/lib/quilt.test.ts
+++ b/portal/common/lib/quilt.test.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from 'vitest'
+import { Range } from './types'
+import { QuiltPatch } from './quilt'
+
+describe('derive quilt patch id from range', () => {
+	it('happy path', () => {
+		const cases = [
+			{
+				patch_id: "jkZ5UWT2SPN46czhU-brz4JmQlc-bJlD14MiBzldouUBAQACAA",
+				base_id: "jkZ5UWT2SPN46czhU-brz4JmQlc-bJlD14MiBzldouU"
+			},
+			{
+				patch_id: "jkZ5UWT2SPN46czhU-brz4JmQlc-bJlD14MiBzldouUBAgADAA",
+				base_id: "jkZ5UWT2SPN46czhU-brz4JmQlc-bJlD14MiBzldouU"
+			}
+		];
+
+		for (const { patch_id, base_id } of cases) {
+			const range = extract_range(patch_id);
+			const patch = new QuiltPatch(
+				base_id,
+				range
+			);
+
+			expect(
+				patch.derive_id()
+			).toBe(patch_id);
+		}
+	})
+})
+
+/**
+ * Helper function to create the expected values of the tests QuiltPatch.derive_id tests.
+ */
+function extract_range(patch_id: string) {
+	const identifier_buffer = Buffer.from(patch_id, 'base64')
+	const dv = new DataView(identifier_buffer.buffer, identifier_buffer.byteOffset)
+	const range = {
+		start: dv.getUint16(33, true),
+		end: dv.getUint16(35, true),
+	} as Range
+	return range
+}

--- a/portal/common/lib/quilt.ts
+++ b/portal/common/lib/quilt.ts
@@ -3,16 +3,17 @@
 
 import { base64UrlSafeEncode } from "./url_safe_base64";
 
-// This is also a constant at the Walrus core code.
-export const QUILT_VERSION_BYTE = 0x1;
-
 export class QuiltPatch {
 	constructor(
-		public quilt_blob_id: string,
-		public quilt_patch_internal_id: string
+		private quilt_blob_id: string,
+		private quilt_patch_internal_id: string
 	) { }
 
-	/// Derive the base64 equivalent of the internal quilt patch id.
+	/**
+	* Derives the base64 URL-safe equivalent of the internal quilt patch ID.
+	* This ID is created by combining the quilt blob ID with the internal patch identifier,
+	* which includes the version, start index, and end index bytes.
+	*/
 	public derive_id(): string {
 		// 1 version byte + 2 start index bytes + 2 index bytes
 		const little_endian = true
@@ -49,6 +50,11 @@ export class QuiltPatch {
 		return base64String.slice(0, 50)
 	}
 
+	/**
+	* Converts a hexadecimal string to an ArrayBuffer.
+	* @param hex - The hexadecimal string to convert.
+	* @returns An ArrayBuffer representing the bytes of the input hex string.
+	*/
 	public static hexToBuffer(hex: string): ArrayBuffer {
 		const bytes = new Uint8Array(hex.length / 2);
 		for (let i = 0; i < hex.length; i += 2) {

--- a/portal/common/lib/quilt.ts
+++ b/portal/common/lib/quilt.ts
@@ -1,0 +1,54 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import base from "base-x";
+import { Range } from "./types";
+import { base64UrlSafeEncode } from "./url_safe_base64";
+
+// This is also a constant at the Walrus core code.
+export const QUILT_VERSION_BYTE = 0x1;
+
+export class QuiltPatch {
+	public quilt_blob_id: string
+	public version: number
+	public start_index: number
+	public end_index: number
+
+	constructor(quilt_blob_id: string, range: Range) {
+		this.quilt_blob_id = quilt_blob_id;
+		this.version = QUILT_VERSION_BYTE
+		this.start_index = range.start
+		this.end_index = range.end
+	}
+
+	/// Derive the base64 equivalent of the internal quilt patch id.
+	public derive_id(): string {
+		// 1 version byte + 2 start index bytes + 2 index bytes
+		const little_endian = true
+
+		// Decode the quilt id to a buffer so that it is
+		// also included in the base64 encoding.
+		const buffer = Buffer.alloc(37);
+		const blobIdBuffer = Buffer.from(this.quilt_blob_id, 'base64');
+		blobIdBuffer.copy(buffer, 0, 0, Math.min(blobIdBuffer.length, 32));
+
+		// Use a data view which makes it easier to work with endians.
+		const view = new DataView(buffer.buffer, buffer.byteOffset);
+
+		// Include to the buffer the version, start and end index bytes.
+		const version_offset = 32
+		view.setUint8(version_offset, this.version);
+		const start_index_offset = 33
+		view.setUint16(start_index_offset, this.start_index, little_endian);
+		const end_index_offset = 35
+		view.setUint16(end_index_offset, this.end_index, little_endian);
+
+		// Finally convert to base64.
+		const base64String = base64UrlSafeEncode(new Uint8Array(buffer))
+
+		// Some times there is padding `=` added to base64
+		// Make sure that we do not surpass the 50 characters of the quilt id
+		// with accidental padding.
+		return base64String.slice(0, 50)
+	}
+}

--- a/portal/common/lib/quilt.ts
+++ b/portal/common/lib/quilt.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import base from "base-x";
 import { Range } from "./types";
 import { base64UrlSafeEncode } from "./url_safe_base64";
 


### PR DESCRIPTION
Given a custom **resource header** like `"x-quilt-patch-internal-id": "0x0101000200"` (where `0x0101000200` in hex, the internal quilt patch identifier), and a **blob_id**, derive the **quilt patch id** in order to retrieve its contents from the aggregator endpoint.

e.g. 
```text
blob_id: jkZ5UWT2SPN46czhU-brz4JmQlc-bJlD14MiBzldouU
"x-quilt-patch-internal-id": "0x0101000200"

quilt patch id: jkZ5UWT2SPN46czhU-brz4JmQlc-bJlD14MiBzldouUBAQACAA
```

This PR is related to the Quilt integration with Walrus Sites.