### PR TITLE
feat(portal): Retrieve quilt based resources

### DIFF
--- a/portal/bun.lock
+++ b/portal/bun.lock
@@ -36,6 +36,7 @@
       "dependencies": {
         "@amplitude/analytics-node": "^1.3.6",
         "@logtape/logtape": "^0.11.0",
+        "@vercel/edge-config": "^1.4.0",
         "common": "workspace:common",
         "cookie": "^1.0.2",
         "psl": "^1.15.0",
@@ -346,6 +347,10 @@
     "@types/yargs": ["@types/yargs@17.0.33", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA=="],
 
     "@types/yargs-parser": ["@types/yargs-parser@21.0.3", "", {}, "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="],
+
+    "@vercel/edge-config": ["@vercel/edge-config@1.4.0", "", { "dependencies": { "@vercel/edge-config-fs": "0.1.0" }, "peerDependencies": { "@opentelemetry/api": "^1.7.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-69Wg5gw9DzwnyUmnjToSeLRm1nm8mCPgN0kflX8EHRHyqvzH80wPem5A8rI2LXPb2Y9tJNoqN3vXPcQhS2Wh5g=="],
+
+    "@vercel/edge-config-fs": ["@vercel/edge-config-fs@0.1.0", "", {}, "sha512-NRIBwfcS0bUoUbRWlNGetqjvLSwgYH/BqKqDN7vK1g32p7dN96k0712COgaz6VFizAm9b0g6IG6hR6+hc0KCPg=="],
 
     "@vitest/expect": ["@vitest/expect@2.1.9", "", { "dependencies": { "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw=="],
 

--- a/portal/bun.lock
+++ b/portal/bun.lock
@@ -36,8 +36,6 @@
       "dependencies": {
         "@amplitude/analytics-node": "^1.3.6",
         "@logtape/logtape": "^0.11.0",
-        "@vercel/analytics": "^1.4.1",
-        "@vercel/edge-config": "^1.4.0",
         "common": "workspace:common",
         "cookie": "^1.0.2",
         "psl": "^1.15.0",
@@ -95,8 +93,6 @@
 
     "@discoveryjs/json-ext": ["@discoveryjs/json-ext@0.5.7", "", {}, "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw=="],
 
-    "@emnapi/runtime": ["@emnapi/runtime@1.3.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw=="],
-
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
 
     "@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
@@ -149,44 +145,6 @@
 
     "@graphql-typed-document-node/core": ["@graphql-typed-document-node/core@3.2.0", "", { "peerDependencies": { "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ=="],
 
-    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.0.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ=="],
-
-    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.0.4" }, "os": "darwin", "cpu": "x64" }, "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q=="],
-
-    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg=="],
-
-    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ=="],
-
-    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.0.5", "", { "os": "linux", "cpu": "arm" }, "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g=="],
-
-    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA=="],
-
-    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.0.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA=="],
-
-    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw=="],
-
-    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA=="],
-
-    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw=="],
-
-    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.0.5" }, "os": "linux", "cpu": "arm" }, "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ=="],
-
-    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.0.4" }, "os": "linux", "cpu": "arm64" }, "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA=="],
-
-    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.0.4" }, "os": "linux", "cpu": "s390x" }, "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q=="],
-
-    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA=="],
-
-    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.0.4" }, "os": "linux", "cpu": "arm64" }, "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g=="],
-
-    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw=="],
-
-    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.33.5", "", { "dependencies": { "@emnapi/runtime": "^1.2.0" }, "cpu": "none" }, "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg=="],
-
-    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.33.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ=="],
-
-    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.33.5", "", { "os": "win32", "cpu": "x64" }, "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg=="],
-
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
     "@jest/schemas": ["@jest/schemas@29.6.3", "", { "dependencies": { "@sinclair/typebox": "^0.27.8" } }, "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA=="],
@@ -220,24 +178,6 @@
     "@mysten/sui": ["@mysten/sui@1.18.1", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.2.0", "@mysten/bcs": "1.2.1", "@noble/curves": "^1.4.2", "@noble/hashes": "^1.4.0", "@scure/bip32": "^1.4.0", "@scure/bip39": "^1.3.0", "@simplewebauthn/typescript-types": "^7.4.0", "@suchipi/femver": "^1.0.0", "bech32": "^2.0.0", "gql.tada": "^1.8.2", "graphql": "^16.9.0", "jose": "^5.6.3", "poseidon-lite": "^0.2.0", "valibot": "^0.36.0" } }, "sha512-ccMVOHM4KQhUvbBirE1rkn9THDJUX7y7W1cDMoCKnlPsIwTtQifZc7ysyBNjCMAS42y8Kq4VpiRagPjf13Am5A=="],
 
     "@mysten/suins": ["@mysten/suins@0.6.3", "", { "dependencies": { "@mysten/sui": "1.18.1", "@pythnetwork/pyth-sui-js": "2.1.0" } }, "sha512-qCd0RTnLCBLLwZV5OVUCKDYIiaVQGn6JsXcJLt2BI0GL9t2K+5VyaXL6BNfxVisEXQ3OxRBS7J+pVwrY/laAZg=="],
-
-    "@next/env": ["@next/env@15.2.2", "", {}, "sha512-yWgopCfA9XDR8ZH3taB5nRKtKJ1Q5fYsTOuYkzIIoS8TJ0UAUKAGF73JnGszbjk2ufAQDj6mDdgsJAFx5CLtYQ=="],
-
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.2.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-HNBRnz+bkZ+KfyOExpUxTMR0Ow8nkkcE6IlsdEa9W/rI7gefud19+Sn1xYKwB9pdCdxIP1lPru/ZfjfA+iT8pw=="],
-
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.2.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-mJOUwp7al63tDpLpEFpKwwg5jwvtL1lhRW2fI1Aog0nYCPAhxbJsaZKdoVyPZCy8MYf/iQVNDuk/+i29iLCzIA=="],
-
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.2.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-5ZZ0Zwy3SgMr7MfWtRE7cQWVssfOvxYfD9O7XHM7KM4nrf5EOeqwq67ZXDgo86LVmffgsu5tPO57EeFKRnrfSQ=="],
-
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.2.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-cgKWBuFMLlJ4TWcFHl1KOaVVUAF8vy4qEvX5KsNd0Yj5mhu989QFCq1WjuaEbv/tO1ZpsQI6h/0YR8bLwEi+nA=="],
-
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.2.2", "", { "os": "linux", "cpu": "x64" }, "sha512-c3kWSOSsVL8rcNBBfOq1+/j2PKs2nsMwJUV4icUxRgGBwUOfppeh7YhN5s79enBQFU+8xRgVatFkhHU1QW7yUA=="],
-
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.2.2", "", { "os": "linux", "cpu": "x64" }, "sha512-PXTW9PLTxdNlVYgPJ0equojcq1kNu5NtwcNjRjHAB+/sdoKZ+X8FBu70fdJFadkxFIGekQTyRvPMFF+SOJaQjw=="],
-
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.2.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-nG644Es5llSGEcTaXhnGWR/aThM/hIaz0jx4MDg4gWC8GfTCp8eDBWZ77CVuv2ha/uL9Ce+nPTfYkSLG67/sHg=="],
-
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.2.2", "", { "os": "win32", "cpu": "x64" }, "sha512-52nWy65S/R6/kejz3jpvHAjZDPKIbEQu4x9jDBzmB9jJfuOy5rspjKu4u77+fI4M/WzLXrrQd57hlFGzz1ubcQ=="],
 
     "@noble/curves": ["@noble/curves@1.8.1", "", { "dependencies": { "@noble/hashes": "1.7.1" } }, "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ=="],
 
@@ -335,10 +275,6 @@
 
     "@suchipi/femver": ["@suchipi/femver@1.0.0", "", {}, "sha512-bprE8+K5V+DPX7q2e2K57ImqNBdfGHDIWaGI5xHxZoxbKOuQZn4wzPiUxOAHnsUr3w3xHrWXwN7gnG/iIuEMIg=="],
 
-    "@swc/counter": ["@swc/counter@0.1.3", "", {}, "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="],
-
-    "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
-
     "@trysound/sax": ["@trysound/sax@0.2.0", "", {}, "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA=="],
 
     "@types/body-parser": ["@types/body-parser@1.19.5", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg=="],
@@ -410,12 +346,6 @@
     "@types/yargs": ["@types/yargs@17.0.33", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA=="],
 
     "@types/yargs-parser": ["@types/yargs-parser@21.0.3", "", {}, "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="],
-
-    "@vercel/analytics": ["@vercel/analytics@1.5.0", "", { "peerDependencies": { "@remix-run/react": "^2", "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@remix-run/react", "@sveltejs/kit", "next", "react", "svelte", "vue", "vue-router"] }, "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g=="],
-
-    "@vercel/edge-config": ["@vercel/edge-config@1.4.0", "", { "dependencies": { "@vercel/edge-config-fs": "0.1.0" }, "peerDependencies": { "@opentelemetry/api": "^1.7.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-69Wg5gw9DzwnyUmnjToSeLRm1nm8mCPgN0kflX8EHRHyqvzH80wPem5A8rI2LXPb2Y9tJNoqN3vXPcQhS2Wh5g=="],
-
-    "@vercel/edge-config-fs": ["@vercel/edge-config-fs@0.1.0", "", {}, "sha512-NRIBwfcS0bUoUbRWlNGetqjvLSwgYH/BqKqDN7vK1g32p7dN96k0712COgaz6VFizAm9b0g6IG6hR6+hc0KCPg=="],
 
     "@vitest/expect": ["@vitest/expect@2.1.9", "", { "dependencies": { "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw=="],
 
@@ -545,8 +475,6 @@
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
-    "busboy": ["busboy@1.6.0", "", { "dependencies": { "streamsearch": "^1.1.0" } }, "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA=="],
-
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
@@ -579,21 +507,15 @@
 
     "clean-css": ["clean-css@5.3.3", "", { "dependencies": { "source-map": "~0.6.0" } }, "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg=="],
 
-    "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
-
     "clone-deep": ["clone-deep@4.0.1", "", { "dependencies": { "is-plain-object": "^2.0.4", "kind-of": "^6.0.2", "shallow-clone": "^3.0.0" } }, "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ=="],
 
     "clone-regexp": ["clone-regexp@3.0.0", "", { "dependencies": { "is-regexp": "^3.0.0" } }, "sha512-ujdnoq2Kxb8s3ItNBtnYeXdm07FcU0u8ARAT1lQ2YdMwQC+cdiXX8KoqMVuglztILivceTtp4ivqGSmEmhBUJw=="],
 
     "cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
 
-    "color": ["color@4.2.3", "", { "dependencies": { "color-convert": "^2.0.1", "color-string": "^1.9.0" } }, "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A=="],
-
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
-
-    "color-string": ["color-string@1.9.1", "", { "dependencies": { "color-name": "^1.0.0", "simple-swizzle": "^0.2.2" } }, "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg=="],
 
     "colord": ["colord@2.9.3", "", {}, "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw=="],
 
@@ -674,8 +596,6 @@
     "destroy": ["destroy@1.2.0", "", {}, "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="],
 
     "detect-europe-js": ["detect-europe-js@0.1.2", "", {}, "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow=="],
-
-    "detect-libc": ["detect-libc@2.0.3", "", {}, "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw=="],
 
     "detect-node": ["detect-node@2.1.0", "", {}, "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="],
 
@@ -875,8 +795,6 @@
 
     "is-arguments": ["is-arguments@1.2.0", "", { "dependencies": { "call-bound": "^1.0.2", "has-tostringtag": "^1.0.2" } }, "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA=="],
 
-    "is-arrayish": ["is-arrayish@0.3.2", "", {}, "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="],
-
     "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
 
     "is-callable": ["is-callable@1.2.7", "", {}, "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="],
@@ -1008,8 +926,6 @@
     "negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
 
     "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
-
-    "next": ["next@15.2.2", "", { "dependencies": { "@next/env": "15.2.2", "@swc/counter": "0.1.3", "@swc/helpers": "0.5.15", "busboy": "1.6.0", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.2.2", "@next/swc-darwin-x64": "15.2.2", "@next/swc-linux-arm64-gnu": "15.2.2", "@next/swc-linux-arm64-musl": "15.2.2", "@next/swc-linux-x64-gnu": "15.2.2", "@next/swc-linux-x64-musl": "15.2.2", "@next/swc-win32-arm64-msvc": "15.2.2", "@next/swc-win32-x64-msvc": "15.2.2", "sharp": "^0.33.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.41.2", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-dgp8Kcx5XZRjMw2KNwBtUzhngRaURPioxoNIVl5BOyJbhi9CUgEtKDO7fx5wh8Z8vOVX1nYZ9meawJoRrlASYA=="],
 
     "no-case": ["no-case@3.0.4", "", { "dependencies": { "lower-case": "^2.0.2", "tslib": "^2.0.3" } }, "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg=="],
 
@@ -1183,10 +1099,6 @@
 
     "raw-body": ["raw-body@2.5.2", "", { "dependencies": { "bytes": "3.1.2", "http-errors": "2.0.0", "iconv-lite": "0.4.24", "unpipe": "1.0.0" } }, "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA=="],
 
-    "react": ["react@19.0.0", "", {}, "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ=="],
-
-    "react-dom": ["react-dom@19.0.0", "", { "dependencies": { "scheduler": "^0.25.0" }, "peerDependencies": { "react": "^19.0.0" } }, "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ=="],
-
     "read-cache": ["read-cache@1.0.0", "", { "dependencies": { "pify": "^2.3.0" } }, "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA=="],
 
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
@@ -1227,8 +1139,6 @@
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
-    "scheduler": ["scheduler@0.25.0", "", {}, "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA=="],
-
     "schema-utils": ["schema-utils@4.3.0", "", { "dependencies": { "@types/json-schema": "^7.0.9", "ajv": "^8.9.0", "ajv-formats": "^2.1.1", "ajv-keywords": "^5.1.0" } }, "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g=="],
 
     "select-hose": ["select-hose@2.0.0", "", {}, "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg=="],
@@ -1253,8 +1163,6 @@
 
     "shallow-clone": ["shallow-clone@3.0.1", "", { "dependencies": { "kind-of": "^6.0.2" } }, "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA=="],
 
-    "sharp": ["sharp@0.33.5", "", { "dependencies": { "color": "^4.2.3", "detect-libc": "^2.0.3", "semver": "^7.6.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.33.5", "@img/sharp-darwin-x64": "0.33.5", "@img/sharp-libvips-darwin-arm64": "1.0.4", "@img/sharp-libvips-darwin-x64": "1.0.4", "@img/sharp-libvips-linux-arm": "1.0.5", "@img/sharp-libvips-linux-arm64": "1.0.4", "@img/sharp-libvips-linux-s390x": "1.0.4", "@img/sharp-libvips-linux-x64": "1.0.4", "@img/sharp-libvips-linuxmusl-arm64": "1.0.4", "@img/sharp-libvips-linuxmusl-x64": "1.0.4", "@img/sharp-linux-arm": "0.33.5", "@img/sharp-linux-arm64": "0.33.5", "@img/sharp-linux-s390x": "0.33.5", "@img/sharp-linux-x64": "0.33.5", "@img/sharp-linuxmusl-arm64": "0.33.5", "@img/sharp-linuxmusl-x64": "0.33.5", "@img/sharp-wasm32": "0.33.5", "@img/sharp-win32-ia32": "0.33.5", "@img/sharp-win32-x64": "0.33.5" } }, "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw=="],
-
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
@@ -1272,8 +1180,6 @@
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
-
-    "simple-swizzle": ["simple-swizzle@0.2.2", "", { "dependencies": { "is-arrayish": "^0.3.1" } }, "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg=="],
 
     "slash": ["slash@5.1.0", "", {}, "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg=="],
 
@@ -1299,8 +1205,6 @@
 
     "stream-http": ["stream-http@3.2.0", "", { "dependencies": { "builtin-status-codes": "^3.0.0", "inherits": "^2.0.4", "readable-stream": "^3.6.0", "xtend": "^4.0.2" } }, "sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A=="],
 
-    "streamsearch": ["streamsearch@1.1.0", "", {}, "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="],
-
     "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
@@ -1310,8 +1214,6 @@
     "strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
 
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "styled-jsx": ["styled-jsx@5.1.6", "", { "dependencies": { "client-only": "0.0.1" }, "peerDependencies": { "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0" } }, "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA=="],
 
     "stylehacks": ["stylehacks@7.0.4", "", { "dependencies": { "browserslist": "^4.23.3", "postcss-selector-parser": "^6.1.2" }, "peerDependencies": { "postcss": "^8.4.31" } }, "sha512-i4zfNrGMt9SB4xRK9L83rlsFCgdGANfeDAYacO1pkqcE7cRHPdWHwnKZVz7WY17Veq/FvyYsRAU++Ga+qDFIww=="],
 
@@ -1510,8 +1412,6 @@
     "html-minifier-terser/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
     "html-minimizer-webpack-plugin/html-minifier-terser": ["html-minifier-terser@7.2.0", "", { "dependencies": { "camel-case": "^4.1.2", "clean-css": "~5.3.2", "commander": "^10.0.0", "entities": "^4.4.0", "param-case": "^3.0.4", "relateurl": "^0.2.7", "terser": "^5.15.1" }, "bin": { "html-minifier-terser": "cli.js" } }, "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA=="],
-
-    "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "postcss-calc/postcss-selector-parser": ["postcss-selector-parser@7.1.0", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA=="],
 

--- a/portal/common/lib/aggregator.test.ts
+++ b/portal/common/lib/aggregator.test.ts
@@ -1,0 +1,53 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from 'vitest';
+import { blobAggregatorEndpoint, quiltAggregatorEndpoint } from './aggregator';
+
+describe('blobAggregatorEndpoint', () => {
+    it('builds the correct URL without trailing slash on base', () => {
+        const url = blobAggregatorEndpoint('abc123', 'https://agg.example.com');
+        expect(url).toBeInstanceOf(URL);
+        expect(url.toString()).toBe('https://agg.example.com/v1/blobs/abc123');
+    });
+
+    it('builds the correct URL with trailing slash on base', () => {
+        const url = blobAggregatorEndpoint('abc123', 'https://agg.example.com/');
+        expect(url).toBeInstanceOf(URL);
+        expect(url.toString()).toBe('https://agg.example.com/v1/blobs/abc123');
+    });
+
+    it('URL-encodes the blob_id', () => {
+        const blobId = 'a/b c?d=e&f';
+        const url = blobAggregatorEndpoint(blobId, 'https://agg.example.com');
+        expect(url.toString()).toBe(
+            `https://agg.example.com/v1/blobs/${encodeURIComponent(blobId)}`
+        );
+    });
+});
+
+describe('quiltAggregatorEndpoint', () => {
+    it('builds the correct URL without trailing slash on base', () => {
+        const url = quiltAggregatorEndpoint('patch-001', 'https://agg.example.com');
+        expect(url).toBeInstanceOf(URL);
+        expect(url.toString()).toBe(
+            'https://agg.example.com/v1/blobs/by-quilt-patch-id/patch-001'
+        );
+    });
+
+    it('builds the correct URL with trailing slash on base', () => {
+        const url = quiltAggregatorEndpoint('patch-001', 'https://agg.example.com/');
+        expect(url).toBeInstanceOf(URL);
+        expect(url.toString()).toBe(
+            'https://agg.example.com/v1/blobs/by-quilt-patch-id/patch-001'
+        );
+    });
+
+    it('URL-encodes the quilt_patch_id', () => {
+        const patchId = 'patch id/with?special=chars&and spaces';
+        const url = quiltAggregatorEndpoint(patchId, 'https://agg.example.com');
+        expect(url.toString()).toBe(
+            `https://agg.example.com/v1/blobs/by-quilt-patch-id/${encodeURIComponent(patchId)}`
+        );
+    });
+});

--- a/portal/common/lib/aggregator.ts
+++ b/portal/common/lib/aggregator.ts
@@ -8,10 +8,8 @@
  * @param aggregatorUrl - The aggregator URL string.
  */
 export function blobAggregatorEndpoint(blob_id: string, aggregatorUrl: string): URL {
-    if (aggregatorUrl.endsWith("/")) {
-        throw new Error("Aggregator URL must not end with a slash.");
-    }
-    return new URL(`${aggregatorUrl}/v1/blobs/${encodeURIComponent(blob_id)}`) as URL;
+	const cleanAggregatorUrl = aggregatorUrl.endsWith("/") ? aggregatorUrl.slice(0, -1) : aggregatorUrl;
+	return new URL(`${cleanAggregatorUrl}/v1/blobs/${encodeURIComponent(blob_id)}`) as URL;
 }
 
 /**
@@ -21,10 +19,8 @@ export function blobAggregatorEndpoint(blob_id: string, aggregatorUrl: string): 
  * @param aggregatorUrl - The aggregator URL string.
  */
 export function quiltAggregatorEndpoint(quilt_patch_id: string, aggregatorUrl: string): URL {
-    if (aggregatorUrl.endsWith("/")) {
-        throw new Error("Aggregator URL must not end with a slash.");
-    }
-    return new URL(
-        `${aggregatorUrl}/v1/blobs/by-quilt-patch-id/${encodeURIComponent(quilt_patch_id)}`,
-    ) as URL;
+	const cleanAggregatorUrl = aggregatorUrl.endsWith("/") ? aggregatorUrl.slice(0, -1) : aggregatorUrl;
+	return new URL(
+		`${cleanAggregatorUrl}/v1/blobs/by-quilt-patch-id/${encodeURIComponent(quilt_patch_id)}`,
+	) as URL;
 }

--- a/portal/common/lib/aggregator.ts
+++ b/portal/common/lib/aggregator.ts
@@ -11,7 +11,7 @@ export function blobAggregatorEndpoint(blob_id: string, aggregatorUrl: string): 
     if (aggregatorUrl.endsWith("/")) {
         throw new Error("Aggregator URL must not end with a slash.");
     }
-    return new URL(`${aggregatorUrl}/v1/blobs/${encodeURIComponent(blob_id)}`) as unknown as URL;
+    return new URL(`${aggregatorUrl}/v1/blobs/${encodeURIComponent(blob_id)}`) as URL;
 }
 
 /**
@@ -26,5 +26,5 @@ export function quiltAggregatorEndpoint(quilt_patch_id: string, aggregatorUrl: s
     }
     return new URL(
         `${aggregatorUrl}/v1/blobs/by-quilt-patch-id/${encodeURIComponent(quilt_patch_id)}`,
-    ) as unknown as URL;
+    ) as URL;
 }

--- a/portal/common/lib/aggregator.ts
+++ b/portal/common/lib/aggregator.ts
@@ -7,9 +7,24 @@
  * @param blob_id - The blob ID to fetch from the aggregator.
  * @param aggregatorUrl - The aggregator URL string.
  */
-export function aggregatorEndpoint(blob_id: string, aggregatorUrl: string): URL {
+export function blobAggregatorEndpoint(blob_id: string, aggregatorUrl: string): URL {
     if (aggregatorUrl.endsWith("/")) {
         throw new Error("Aggregator URL must not end with a slash.");
     }
     return new URL(`${aggregatorUrl}/v1/blobs/${encodeURIComponent(blob_id)}`) as unknown as URL;
+}
+
+/**
+ * Returns the URL to fetch the blob by quilt patch ID from the aggregator/cache.
+ *
+ * @param quilt_patch_id - The quilt patch ID to fetch from the aggregator.
+ * @param aggregatorUrl - The aggregator URL string.
+ */
+export function quiltAggregatorEndpoint(quilt_patch_id: string, aggregatorUrl: string): URL {
+    if (aggregatorUrl.endsWith("/")) {
+        throw new Error("Aggregator URL must not end with a slash.");
+    }
+    return new URL(
+        `${aggregatorUrl}/v1/blobs/by-quilt-patch-id/${encodeURIComponent(quilt_patch_id)}`,
+    ) as unknown as URL;
 }

--- a/portal/common/lib/quilt.test.ts
+++ b/portal/common/lib/quilt.test.ts
@@ -18,10 +18,12 @@ describe('derive quilt patch id from internal identifier', () => {
 		];
 
 		for (const { patch_id, base_id } of cases) {
-			const range = extract_internal_identifier(patch_id);
+			// internal identifier is extracted from the custom header x-wal-quilt-patch-internal-id
+			const internal_identifier = extract_internal_identifier(patch_id);
+			console.log(internal_identifier)
 			const patch = new QuiltPatch(
 				base_id,
-				range
+				internal_identifier
 			);
 
 			expect(
@@ -78,8 +80,8 @@ function extract_internal_identifier(patch_id: string): string {
 	const internal_id_buf = Buffer.alloc(5)
 	const dv_internal_id = new DataView(internal_id_buf.buffer, internal_id_buf.byteOffset)
 	dv_internal_id.setUint8(0, dv.getUint16(32, true));
-	dv_internal_id.setUint16(1, dv.getUint16(33, true));
-	dv_internal_id.setUint16(3, dv.getUint16(35, true));
+	dv_internal_id.setUint16(1, dv.getUint16(33, true), true);
+	dv_internal_id.setUint16(3, dv.getUint16(35, true), true);
 	const hex = bufferToHex(dv_internal_id.buffer)
 	return hex
 }

--- a/portal/common/lib/quilt.test.ts
+++ b/portal/common/lib/quilt.test.ts
@@ -1,73 +1,103 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect } from 'vitest'
-import { QuiltPatch } from './quilt'
+import { describe, it, expect } from "vitest";
+import { QuiltPatch } from "./quilt";
 
-describe('derive quilt patch id from internal identifier', () => {
-	it('happy path', () => {
+describe("derive quilt patch id from internal identifier", () => {
+	it("happy path", () => {
 		const cases = [
 			{
 				patch_id: "jkZ5UWT2SPN46czhU-brz4JmQlc-bJlD14MiBzldouUBAQACAA",
-				base_id: "jkZ5UWT2SPN46czhU-brz4JmQlc-bJlD14MiBzldouU"
+				base_id: "jkZ5UWT2SPN46czhU-brz4JmQlc-bJlD14MiBzldouU",
 			},
 			{
 				patch_id: "jkZ5UWT2SPN46czhU-brz4JmQlc-bJlD14MiBzldouUBAgADAA",
-				base_id: "jkZ5UWT2SPN46czhU-brz4JmQlc-bJlD14MiBzldouU"
-			}
+				base_id: "jkZ5UWT2SPN46czhU-brz4JmQlc-bJlD14MiBzldouU",
+			},
+			{
+				patch_id: "zHQTGUBR_e_87X3UIJwBTZRngDUNLKXnzrf5j6dWNAMBBQAGAA",
+				base_id: "zHQTGUBR_e_87X3UIJwBTZRngDUNLKXnzrf5j6dWNAM",
+			},
 		];
 
 		for (const { patch_id, base_id } of cases) {
 			// internal identifier is extracted from the custom header x-wal-quilt-patch-internal-id
 			const internal_identifier = extract_internal_identifier(patch_id);
-			console.log(internal_identifier)
-			const patch = new QuiltPatch(
-				base_id,
-				internal_identifier
-			);
-
-			expect(
-				patch.derive_id()
-			).toBe(patch_id);
+			const patch = new QuiltPatch(base_id, internal_identifier);
+			expect(patch.derive_id()).toBe(patch_id);
 		}
-	})
-})
-
-describe('bufferToHex', () => {
-	it('should convert ArrayBuffer to hex string', () => {
-		const buf = new Uint8Array([1, 0, 255, 16]).buffer;
-		expect(bufferToHex(buf)).toBe('0100ff10');
-	});
-
-	it('should handle empty buffer', () => {
-		const buf = new Uint8Array([]).buffer;
-		expect(bufferToHex(buf)).toBe('');
 	});
 });
 
-describe('hexToBuffer', () => {
-	it('should convert hex string to ArrayBuffer', () => {
-		const hex = '0100ff10';
+describe("bufferToHex", () => {
+	it("should convert ArrayBuffer to hex string", () => {
+		const buf = new Uint8Array([1, 0, 255, 16]).buffer;
+		expect(bufferToHex(buf)).toBe("0100ff10");
+	});
+
+	it("should handle empty buffer", () => {
+		const buf = new Uint8Array([]).buffer;
+		expect(bufferToHex(buf)).toBe("");
+	});
+});
+
+describe("hexToBuffer", () => {
+	it("should convert hex string to ArrayBuffer", () => {
+		const hex = "0100ff10";
 		const buf = QuiltPatch.hexToBuffer(hex);
 		expect(Array.from(new Uint8Array(buf))).toEqual([1, 0, 255, 16]);
 	});
 
-	it('should convert hex string to ArrayBuffer real patch 1', () => {
-		const hex = '0100010002';
+	it("should convert hex string to ArrayBuffer real patch 1", () => {
+		const hex = "0100010002";
 		const buf = QuiltPatch.hexToBuffer(hex);
 		expect(Array.from(new Uint8Array(buf))).toEqual([0x01, 0x00, 0x01, 0x0, 0x02]);
 	});
 
-	it('should convert hex string to ArrayBuffer real patch 2', () => {
-		const hex = '0100010003';
+	it("should convert hex string to ArrayBuffer real patch 2", () => {
+		const hex = "0100010003";
 		const buf = QuiltPatch.hexToBuffer(hex);
 		expect(Array.from(new Uint8Array(buf))).toEqual([0x01, 0x00, 0x01, 0x0, 0x03]);
 	});
 
-
-	it('should handle empty hex string', () => {
-		const buf = QuiltPatch.hexToBuffer('');
+	it("should handle empty hex string", () => {
+		const buf = QuiltPatch.hexToBuffer("");
 		expect(Array.from(new Uint8Array(buf))).toEqual([]);
+	});
+});
+
+describe("extract_internal_identifier", () => {
+	it("extracts internal id from patch id", () => {
+		const cases = [
+			{
+				patch_id: "zHQTGUBR_e_87X3UIJwBTZRngDUNLKXnzrf5j6dWNAMBAQAEAA",
+				internal_id: "0x0101000400",
+			},
+			{
+				patch_id: "zHQTGUBR_e_87X3UIJwBTZRngDUNLKXnzrf5j6dWNAMBBAAFAA",
+				internal_id: "0x0104000500",
+			},
+			{
+				patch_id: "zHQTGUBR_e_87X3UIJwBTZRngDUNLKXnzrf5j6dWNAMBBQAGAA",
+				internal_id: "0x0105000600",
+			},
+			{
+				patch_id: "zHQTGUBR_e_87X3UIJwBTZRngDUNLKXnzrf5j6dWNAMBBgAHAA",
+				internal_id: "0x0106000700",
+			},
+			{
+				patch_id: "zHQTGUBR_e_87X3UIJwBTZRngDUNLKXnzrf5j6dWNAMBBwAIAA",
+				internal_id: "0x0107000800",
+			},
+			{
+				patch_id: "zHQTGUBR_e_87X3UIJwBTZRngDUNLKXnzrf5j6dWNAMBCAAJAA",
+				internal_id: "0x0108000900",
+			},
+		];
+		for (const { patch_id, internal_id } of cases) {
+			expect(extract_internal_identifier(patch_id)).toBe(internal_id);
+		}
 	});
 });
 
@@ -75,20 +105,20 @@ describe('hexToBuffer', () => {
  * Helper function to create the expected values of the tests QuiltPatch.derive_id tests.
  */
 function extract_internal_identifier(patch_id: string): string {
-	const identifier_buffer = Buffer.from(patch_id, 'base64')
-	const dv = new DataView(identifier_buffer.buffer, identifier_buffer.byteOffset)
-	const internal_id_buf = Buffer.alloc(5)
-	const dv_internal_id = new DataView(internal_id_buf.buffer, internal_id_buf.byteOffset)
+	const identifier_buffer = Buffer.from(patch_id, "base64");
+	const dv = new DataView(identifier_buffer.buffer, identifier_buffer.byteOffset);
+	const internal_id_buf = Buffer.alloc(5);
+	const dv_internal_id = new DataView(internal_id_buf.buffer, internal_id_buf.byteOffset);
 	dv_internal_id.setUint8(0, dv.getUint16(32, true));
 	dv_internal_id.setUint16(1, dv.getUint16(33, true), true);
 	dv_internal_id.setUint16(3, dv.getUint16(35, true), true);
-	const hex = bufferToHex(dv_internal_id.buffer)
-	return hex
+	const hex = bufferToHex(dv_internal_id.buffer);
+	return "0x" + hex;
 }
 
 function bufferToHex(buffer: ArrayBuffer) {
 	const uint8Array = new Uint8Array(buffer);
 	return Array.from(uint8Array)
-		.map(b => b.toString(16).padStart(2, '0'))
-		.join('');
+		.map((b) => b.toString(16).padStart(2, "0"))
+		.join("");
 }

--- a/portal/common/lib/quilt.ts
+++ b/portal/common/lib/quilt.ts
@@ -15,6 +15,11 @@ export class QuiltPatch {
 	* which includes the version, start index, and end index bytes.
 	*/
 	public derive_id(): string {
+		// If quilt_blob_id starts with '0x', remove it.
+		const quilt_patch_internal_id = this.quilt_patch_internal_id.startsWith('0x')
+			? this.quilt_patch_internal_id.slice(2)
+			: this.quilt_patch_internal_id;
+
 		// 1 version byte + 2 start index bytes + 2 index bytes
 		const little_endian = true
 
@@ -27,7 +32,7 @@ export class QuiltPatch {
 		// Use a data view which makes it easier to work with endians.
 		const view = new DataView(buffer.buffer, buffer.byteOffset);
 
-		const quilt_patch_internal_id_buf = QuiltPatch.hexToBuffer(this.quilt_patch_internal_id)
+		const quilt_patch_internal_id_buf = QuiltPatch.hexToBuffer(quilt_patch_internal_id)
 		const internal_identifier_dv = new DataView(quilt_patch_internal_id_buf)
 		const version = internal_identifier_dv.getInt8(0)
 		const start_index = internal_identifier_dv.getInt16(1, little_endian)

--- a/portal/common/lib/quilt.ts
+++ b/portal/common/lib/quilt.ts
@@ -15,7 +15,6 @@ export class QuiltPatch {
 	* which includes the version, start index, and end index bytes.
 	*/
 	public derive_id(): string {
-		// If quilt_blob_id starts with '0x', remove it.
 		const quilt_patch_internal_id = this.quilt_patch_internal_id.startsWith('0x')
 			? this.quilt_patch_internal_id.slice(2)
 			: this.quilt_patch_internal_id;

--- a/portal/common/lib/quilt.ts
+++ b/portal/common/lib/quilt.ts
@@ -30,8 +30,8 @@ export class QuiltPatch {
 		const quilt_patch_internal_id_buf = QuiltPatch.hexToBuffer(this.quilt_patch_internal_id)
 		const internal_identifier_dv = new DataView(quilt_patch_internal_id_buf)
 		const version = internal_identifier_dv.getInt8(0)
-		const start_index = internal_identifier_dv.getInt16(1)
-		const end_index = internal_identifier_dv.getInt16(3)
+		const start_index = internal_identifier_dv.getInt16(1, little_endian)
+		const end_index = internal_identifier_dv.getInt16(3, little_endian)
 
 		// Include to the buffer the version, start and end index bytes.
 		const version_offset = 32

--- a/portal/common/lib/redirects.test.ts
+++ b/portal/common/lib/redirects.test.ts
@@ -33,7 +33,7 @@ const redirectToPortalURLTestCases: [string, DomainDetails, string][] = [
 describe("redirectToPortalURLResponse", () => {
     redirectToPortalURLTestCases.forEach(([input, path, expected]) => {
         test(`${input} with subdomain: ${path.subdomain} and path: ${path.path} -> ${expected}`, () => {
-            const scope = new URL(input);
+            const scope = new URL(input) as URL;
             const response = redirectToPortalURLResponse(scope, path);
             expect(response.status).toBe(302);
             expect(response.headers.get("Location")).toBe(expected);
@@ -62,8 +62,7 @@ const redirectToAggregatorUrlTestCases: [string, string, string][] = [
 describe("redirectToAggregatorUrlResponse", () => {
     redirectToAggregatorUrlTestCases.forEach(([input, blobId, expected]) => {
         test(`${input} with blobId: ${blobId} -> ${expected}`, () => {
-            const scope = new URL(input);
-            const response = redirectToAggregatorUrlResponse(scope, blobId, mockAggregatorUrl);
+            const response = redirectToAggregatorUrlResponse(blobId, mockAggregatorUrl);
             expect(response.status).toBe(302);
             expect(response.headers.get("Location")).toBe(expected);
         });

--- a/portal/common/lib/redirects.ts
+++ b/portal/common/lib/redirects.ts
@@ -25,7 +25,6 @@ export function redirectToPortalURLResponse(
  * Redirects to the aggregator URL.
  */
 export function redirectToAggregatorUrlResponse(
-    scope: URL,
     blobId: string,
     aggregatorUrl: string,
 ): Response {
@@ -65,7 +64,7 @@ function makeRedirectResponse(url: string): Response {
  * Returns the url for the Portal, given a subdomain and a path.
  */
 function getPortalUrl(path: DomainDetails, scope: string, portalDomainNameLength?: number): string {
-    const scopeUrl = new URL(scope);
+    const scopeUrl = new URL(scope) as URL;
     const portalDomain = getDomain(scopeUrl, portalDomainNameLength);
     let portString = "";
     if (scopeUrl.port) {

--- a/portal/common/lib/redirects.ts
+++ b/portal/common/lib/redirects.ts
@@ -3,7 +3,7 @@
 
 import { DomainDetails } from "./types/index";
 import { getDomain } from "./domain_parsing";
-import { aggregatorEndpoint } from "./aggregator";
+import { blobAggregatorEndpoint } from "./aggregator";
 import { SuiObjectResponse } from "@mysten/sui/client";
 import logger from "./logger";
 
@@ -11,7 +11,9 @@ import logger from "./logger";
  * Redirects to the portal URL.
  */
 export function redirectToPortalURLResponse(
-    scope: URL, path: DomainDetails, portalDomainNameLength?: number
+    scope: URL,
+    path: DomainDetails,
+    portalDomainNameLength?: number,
 ): Response {
     // Redirect to the walrus site for the specified domain and path
     const redirectUrl = getPortalUrl(path, scope.href, portalDomainNameLength);
@@ -22,9 +24,13 @@ export function redirectToPortalURLResponse(
 /**
  * Redirects to the aggregator URL.
  */
-export function redirectToAggregatorUrlResponse(scope: URL, blobId: string, aggregatorUrl: string): Response {
+export function redirectToAggregatorUrlResponse(
+    scope: URL,
+    blobId: string,
+    aggregatorUrl: string,
+): Response {
     // Redirect to the walrus site for the specified domain and path
-    const redirectUrl = aggregatorEndpoint(blobId, aggregatorUrl);
+    const redirectUrl = blobAggregatorEndpoint(blobId, aggregatorUrl);
     logger.info("Redirecting to the Walrus Blob link", { redirectUrl: redirectUrl });
     return makeRedirectResponse(redirectUrl.href);
 }
@@ -33,7 +39,9 @@ export function redirectToAggregatorUrlResponse(scope: URL, blobId: string, aggr
  * Checks if the object has a redirect in its Display representation.
  */
 export function checkRedirect(object: SuiObjectResponse): string | null {
-	logger.info("Checking if the request should be redirected (existing Display object)", {objectId: object.data.objectId})
+    logger.info("Checking if the request should be redirected (existing Display object)", {
+        objectId: object.data.objectId,
+    });
     if (object.data && object.data.display) {
         let display = object.data.display;
         // Check if "walrus site address" is set in the display field.
@@ -56,10 +64,7 @@ function makeRedirectResponse(url: string): Response {
 /**
  * Returns the url for the Portal, given a subdomain and a path.
  */
-function getPortalUrl(path: DomainDetails,
-    scope: string,
-    portalDomainNameLength?: number
-): string {
+function getPortalUrl(path: DomainDetails, scope: string, portalDomainNameLength?: number): string {
     const scopeUrl = new URL(scope);
     const portalDomain = getDomain(scopeUrl, portalDomainNameLength);
     let portString = "";

--- a/portal/common/lib/url_fetcher.ts
+++ b/portal/common/lib/url_fetcher.ts
@@ -5,7 +5,7 @@ import {
     DomainDetails,
     isResource,
     optionalRangeToHeaders as optionalRangeToRequestHeaders,
-	Routes,
+    Routes,
 } from "./types/index";
 import { subdomainToObjectId, HEXtoBase36 } from "./objectId_operations";
 import { SuiNSResolver } from "./suins";
@@ -50,7 +50,7 @@ export class UrlFetcher {
         resolvedObjectId: string | null,
         blocklistChecker?: BlocklistChecker
     ): Promise<Response> {
-    	logger.info("Resolving the subdomain to an object ID and retrieving its resources", { subdomain: parsedUrl.subdomain, path: parsedUrl.path });
+        logger.info("Resolving the subdomain to an object ID and retrieving its resources", { subdomain: parsedUrl.subdomain, path: parsedUrl.path });
         if (!resolvedObjectId) {
             const resolveObjectResult = await this.resolveObjectId(parsedUrl);
             const isObjectId = typeof resolveObjectResult == "string";
@@ -125,22 +125,22 @@ export class UrlFetcher {
     async resolveObjectId(
         parsedUrl: DomainDetails,
     ): Promise<string | Response> {
-   		logger.info("Resolving the subdomain to an object ID", { subdomain: parsedUrl.subdomain });
+        logger.info("Resolving the subdomain to an object ID", { subdomain: parsedUrl.subdomain });
 
-    	// Resolve to an objectId using a hard-coded subdomain.
-    	const hardCodedObjectId = this.suinsResolver.hardcodedSubdomains(parsedUrl.subdomain);
-		if (hardCodedObjectId) return hardCodedObjectId;
+        // Resolve to an objectId using a hard-coded subdomain.
+        const hardCodedObjectId = this.suinsResolver.hardcodedSubdomains(parsedUrl.subdomain);
+        if (hardCodedObjectId) return hardCodedObjectId;
 
         // If b36 subdomains are supported, resolve them by converting them to a hex object id.
-		const isSuiNSDomain = parsedUrl.subdomain.includes(".");
-		const isb36Domain = !isSuiNSDomain;
+        const isSuiNSDomain = parsedUrl.subdomain.includes(".");
+        const isb36Domain = !isSuiNSDomain;
         if (this.b36DomainResolutionSupport && isb36Domain) {
             // Try to convert the subdomain to an object ID NOTE: This effectively _disables_ any SuiNs
             // name that is the base36 encoding of an object ID (i.e., a 32-byte string). This is
             // desirable, prevents people from getting suins names that are the base36 encoding the
             // object ID of a target site (with the goal of hijacking non-suins queries).
-			const resolvedB36toHex = subdomainToObjectId(parsedUrl.subdomain);
-			if (resolvedB36toHex) return resolvedB36toHex;
+            const resolvedB36toHex = subdomainToObjectId(parsedUrl.subdomain);
+            if (resolvedB36toHex) return resolvedB36toHex;
         }
 
         // Resolve the SuiNS domain to an object id.
@@ -154,7 +154,7 @@ export class UrlFetcher {
             return noObjectIdFound();
         } catch {
             logger.error(
-            	"Unable to reach the full node during suins domain resolution",
+                "Unable to reach the full node during suins domain resolution",
                 { subdomain: parsedUrl.subdomain }
             );
             return fullNodeFail();
@@ -178,15 +178,15 @@ export class UrlFetcher {
         logger.info("Successfully fetched resource!", { fetchedResourceResult: JSON.stringify(result) });
 
         const quilt_patch_internal_id = result.headers.get("x-wal-quilt-patch-internal-id")
-		let aggregator_endpoint: URL;
+        let aggregator_endpoint: URL;
         if (quilt_patch_internal_id) {
-        	const quilt_patch = new QuiltPatch(result.blob_id, quilt_patch_internal_id)
-         	const quilt_patch_id = quilt_patch.derive_id()
-         	logger.info("Resource is stored as a quilt patch.", { quilt_patch_id })
-        	aggregator_endpoint = quiltAggregatorEndpoint(quilt_patch_id, this.aggregatorUrl)
+            const quilt_patch = new QuiltPatch(result.blob_id, quilt_patch_internal_id)
+            const quilt_patch_id = quilt_patch.derive_id()
+            logger.info("Resource is stored as a quilt patch.", { quilt_patch_id })
+            aggregator_endpoint = quiltAggregatorEndpoint(quilt_patch_id, this.aggregatorUrl)
         } else {
-			logger.info("Resource is stored as a blob.", { blob_id:  result.blob_id })
-        	aggregator_endpoint = blobAggregatorEndpoint(result.blob_id, this.aggregatorUrl)
+            logger.info("Resource is stored as a blob.", { blob_id:  result.blob_id })
+            aggregator_endpoint = blobAggregatorEndpoint(result.blob_id, this.aggregatorUrl)
         }
 
         // We have a resource, get the range header.
@@ -271,7 +271,7 @@ export class UrlFetcher {
                     totalAttempts: retries + 1,
                     error: error instanceof Error ? error.message : error,
                 });
-				lastError = error;
+                lastError = error;
             }
 
             // Wait before retrying

--- a/portal/server/package.json
+++ b/portal/server/package.json
@@ -9,6 +9,7 @@
     "dependencies": {
         "@amplitude/analytics-node": "^1.3.6",
         "@logtape/logtape": "^0.11.0",
+        "@vercel/edge-config": "^1.4.0",
         "common": "workspace:common",
         "cookie": "^1.0.2",
         "psl": "^1.15.0",

--- a/portal/worker/src/walrus-sites-sw.ts
+++ b/portal/worker/src/walrus-sites-sw.ts
@@ -71,7 +71,7 @@ self.addEventListener("fetch", async (event) => {
     // This will only work for service-worker portals.
     const walrusPath = getBlobIdLink(url);
     if (walrusPath) {
-        event.respondWith(redirectToAggregatorUrlResponse(scope, walrusPath, aggregatorUrl));
+        event.respondWith(redirectToAggregatorUrlResponse(walrusPath, aggregatorUrl));
         return;
     }
 


### PR DESCRIPTION
When a site resource is stored as a quilt patch, a different URL should be used to fetch its' contents from the aggregator. 
Therefore, I created two kinds of URL constructors for each case:
1. for blob based resources: `blobAggregatorEndpoint`
2. for quilt based resources: `quiltAggregatorEndpoint`

Bonus:
- Fix the docker image by reintroducing the `@vercel/edge-config` dependency because it was removed by mistake
from `package.json` at commit https://github.com/MystenLabs/walrus-sites/commit/f069cbe59b31c74a0cba33a5a837d09150647770