### PR TITLE
feat(site-builder): add config path to error output

### DIFF
--- a/site-builder/src/config.rs
+++ b/site-builder/src/config.rs
@@ -5,7 +5,7 @@
 
 use std::{collections::HashMap, path::Path};
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use sui_sdk::wallet_context::WalletContext;
 use sui_types::base_types::ObjectID;
@@ -73,18 +73,15 @@ impl Config {
         path: impl AsRef<Path>,
         context: Option<&str>,
     ) -> Result<(Self, Option<String>)> {
-        let config_content = std::fs::read_to_string(path.as_ref()).map_err(|e| {
-            anyhow!(
-                "could not read site builder config file '{}': {e}",
+        let config_content = std::fs::read_to_string(path.as_ref()).context(format!(
+            "could not read site builder config file '{}'",
+            path.as_ref().display()
+        ))?;
+        let multi_config =
+            serde_yaml::from_str::<MultiConfig>(&config_content).context(format!(
+                "could not parse site builder config file '{}'",
                 path.as_ref().display()
-            )
-        })?;
-        let multi_config = serde_yaml::from_str::<MultiConfig>(&config_content).map_err(|e| {
-            anyhow!(
-                "could not parse site builder config file '{}': {e}",
-                path.as_ref().display()
-            )
-        })?;
+            ))?;
 
         match multi_config {
             MultiConfig::SingletonConfig(config) => {


### PR DESCRIPTION
  Closes #176

  Description

  This PR enhances the error reporting in the site-builder by including the path to the configuration file
  in relevant error messages.

  When an error occurs while reading, parsing, or processing the site config (e.g., sites-config.yaml), the
  error output will now clearly state which file caused the problem. This helps with debugging, especially
  in environments with multiple configuration files.

  Example of new error message

   1 Error: could not parse site builder config file 'sites-config.yaml': ...