### PR TITLE
fix(site-builder): rollback quilt json_input hack

### DIFF
--- a/site-builder/src/walrus.rs
+++ b/site-builder/src/walrus.rs
@@ -48,7 +48,17 @@ pub struct Walrus {
 
 macro_rules! create_command {
     ($self:ident, $name:ident, $($arg:expr),*) => {{
-        let json_input = $self.builder().$name($($arg),*).build().to_json()?;
+    	let mut json_input = $self.builder().$name($($arg),*).build().to_json()?;
+
+     	// TODO(nikos): Remove when the bug requiring paths in json input is fixed.
+        // TMP HACK
+    	if json_input.contains("storeQuilt") {
+            let Some(pos) = json_input.find("]") else {
+                panic!("No blobs in storeQuilt");
+            };
+            const PATHS: &str = r#","paths":[]"#;
+            json_input.insert_str(pos + 1, PATHS);
+        }
 
         let output = $self
             .base_command()


### PR DESCRIPTION
Running `cargo run --features quilts-experimental -- --context=testnet publish-quilts examples/snake --epochs=1` resulted in an error. This was due to the removal of the temporary hack along with the walrus version bump to v.1.32.0. 

I am re-introducing the hack to the code to fix it. 