### PR TITLE
chore(site-builder): sew 387 create integration test for list directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,3 @@ env/
 temp-landing-page/
 .env*.local
 **/coverage
-#examples/snake


### PR DESCRIPTION
- [x] `site-builder --context=testnet publish --list-directory examples/snake --epochs=1` should publish a browsable site, but not the ignored fields defined in the ws-resources.json. The ignored resource paths should not be included in the index.html, and the resources should not be created on Sui/Walrus (i.e. they should not be browsable).
- [x] `site-builder --context=testnet list-directory examples/snake` should only generate a the new directory, containing the new index.html files to browse the directory, but also ignore the fields defined in ws-resources.json.