### PR TITLE
fix(common-lib): nullish coalescing for range header building

### DIFF
--- a/portal/common/lib/src/types/index.ts
+++ b/portal/common/lib/src/types/index.ts
@@ -60,9 +60,9 @@ function isRangeValid(range: Range): boolean {
  */
 function rangeToHttpHeader(range: Range): string {
     if (!isRangeValid(range)) {
-        throw new Error(`Invalid range: start ${range.start} end ${range.end}`);
+        throw new Error(`Invalid range: start=${range.start} end=${range.end}`);
     }
-    return `bytes=${range.start || ""}-${range.end || ""}`;
+    return `bytes=${range.start ?? ""}-${range.end ?? ""}`;
 }
 
 export function optionalRangeToHeaders(range: Range | null): { [key: string]: string } {

--- a/portal/common/lib/tests/crypto.test.ts
+++ b/portal/common/lib/tests/crypto.test.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { sha256 } from "@lib/crypto";
+import { toBase64 } from "@mysten/bcs";
+
+describe("sha256", () => {
+	it("hashing the a string should always yield the same result", async () => {
+		const arrayBuffer = new TextEncoder().encode("Decentralise the web!").buffer as ArrayBuffer;
+		const res = await sha256(arrayBuffer)
+		const resString = toBase64(res);
+		expect(resString).toEqual("yml5ecL3vnssrx78HsvpBypPVrsyhtk0XPGrVOYTNT4=");
+	});
+});

--- a/portal/common/lib/tests/types.test.ts
+++ b/portal/common/lib/tests/types.test.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { optionalRangeToHeaders, Range } from "@lib/types/index";
+import { describe, it, expect } from "vitest";
+
+describe("happy paths of optionalRangeToHeaders should", () => {
+    it.each([
+        [{ start: 0, end: 10 }, "bytes=0-10"],
+        [{ start: null, end: 10 }, "bytes=-10"],
+        [{ start: 10, end: null }, "bytes=10-"],
+        [null, undefined],
+    ])('convert range %o into "%s"', (range, expected) => {
+        expect(optionalRangeToHeaders(range as Range).range).toBe(expected);
+    });
+});
+
+describe("cases where optionalRangeToHeaders should", () => {
+    it.each([
+        [null, null],
+        [null, -1],
+        [-1, null],
+        [2, 1]
+    ])('throw error when start = %s and end = %s "', (start, end) => {
+        expect(() => optionalRangeToHeaders({ start, end } as Range)).toThrowError(
+            `Invalid range: start=${start} end=${end}`,
+        );
+    });
+});

--- a/portal/common/lib/tests/types.test.ts
+++ b/portal/common/lib/tests/types.test.ts
@@ -1,29 +1,77 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { optionalRangeToHeaders, Range } from "@lib/types/index";
+import { isResource, optionalRangeToHeaders, Range } from "@lib/types/index";
 import { describe, it, expect } from "vitest";
 
 describe("happy paths of optionalRangeToHeaders should", () => {
-    it.each([
-        [{ start: 0, end: 10 }, "bytes=0-10"],
-        [{ start: null, end: 10 }, "bytes=-10"],
-        [{ start: 10, end: null }, "bytes=10-"],
-        [null, undefined],
-    ])('convert range %o into "%s"', (range, expected) => {
-        expect(optionalRangeToHeaders(range as Range).range).toBe(expected);
-    });
+	it.each([
+		[{ start: 0, end: 10 }, "bytes=0-10"],
+		[{ start: null, end: 10 }, "bytes=-10"],
+		[{ start: 10, end: null }, "bytes=10-"],
+		[null, undefined],
+	])('convert range %o into "%s"', (range, expected) => {
+		expect(optionalRangeToHeaders(range as Range).range).toBe(expected);
+	});
 });
 
 describe("cases where optionalRangeToHeaders should", () => {
-    it.each([
-        [null, null],
-        [null, -1],
-        [-1, null],
-        [2, 1]
-    ])('throw error when start = %s and end = %s "', (start, end) => {
-        expect(() => optionalRangeToHeaders({ start, end } as Range)).toThrowError(
-            `Invalid range: start=${start} end=${end}`,
-        );
-    });
+	it.each([
+		[null, null],
+		[null, -1],
+		[-1, null],
+		[2, 1]
+	])('throw error when start = %s and end = %s "', (start, end) => {
+		expect(() => optionalRangeToHeaders({ start, end } as Range)).toThrowError(
+			`Invalid range: start=${start} end=${end}`,
+		);
+	});
 });
+
+describe("isResource", () => {
+	it("should return true when it's definitely a resource", () => {
+		expect(isResource({
+			"path": "index.html",
+			"headers": { "cache-control": "public, max-age=86400" },
+			"blob_id": "9Jws-C9zE99FwWex6dsVbpaaaaaIk7Ko7No-8mKfgRk",
+			"blob_hash": "O1NaFqZZkVOp+2hJfbf6s+a02JHMiJh7q0DZ+Dyp8og",
+			"range": null,
+		})).toBeTruthy()
+	})
+	it("should return false when path is a number", () => {
+		expect(isResource({
+			"path": 123,
+			"headers": { "cache-control": "public, max-age=86400" },
+			"blob_id": "9Jws-C9zE99FwWex6dsVbpaaaaaIk7Ko7No-8mKfgRk",
+			"blob_hash": "O1NaFqZZkVOp+2hJfbf6s+a02JHMiJh7q0DZ+Dyp8og",
+			"range": null,
+		})).toBeFalsy()
+	})
+	it("should return false when blob_id is a number", () => {
+		expect(isResource({
+			"path": "index.html",
+			"headers": { "cache-control": "public, max-age=86400" },
+			"blob_id": 123,
+			"blob_hash": "O1NaFqZZkVOp+2hJfbf6s+a02JHMiJh7q0DZ+Dyp8og",
+			"range": null,
+		})).toBeFalsy()
+	})
+	it("should return false when headers is not an object", () => {
+		expect(isResource({
+			"path": "index.html",
+			"headers": "not an object",
+			"blob_id": "9Jws-C9zE99FwWex6dsVbpaaaaaIk7Ko7No-8mKfgRk",
+			"blob_hash": "O1NaFqZZkVOp+2hJfbf6s+a02JHMiJh7q0DZ+Dyp8og",
+			"range": null,
+		})).toBeFalsy()
+	})
+	it("should return false when blob_hash is not a string", () => {
+		expect(isResource({
+			"path": "index.html",
+			"headers": { "cache-control": "public, max-age=86400" },
+			"blob_id": "9Jws-C9zE99FwWex6dsVbpaaaaaIk7Ko7No-8mKfgRk",
+			"blob_hash": 123,
+			"range": null,
+		})).toBeFalsy()
+	})
+})

--- a/portal/common/lib/tests/types.test.ts
+++ b/portal/common/lib/tests/types.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { isResource, optionalRangeToHeaders, Range } from "@lib/types/index";
+import { isResource, isVersionedResource, optionalRangeToHeaders, Range } from "@lib/types/index";
 import { describe, it, expect } from "vitest";
 
 describe("happy paths of optionalRangeToHeaders should", () => {
@@ -72,6 +72,40 @@ describe("isResource", () => {
 			"blob_id": "9Jws-C9zE99FwWex6dsVbpaaaaaIk7Ko7No-8mKfgRk",
 			"blob_hash": 123,
 			"range": null,
+		})).toBeFalsy()
+	})
+})
+
+describe("isVersionedResource", () => {
+	it("should return true when it's definitely a resource AND versioned!", () => {
+		expect(isVersionedResource({
+			"path": "index.html",
+			"headers": { "cache-control": "public, max-age=86400" },
+			"blob_id": "9Jws-C9zE99FwWex6dsVbpaaaaaIk7Ko7No-8mKfgRk",
+			"blob_hash": "O1NaFqZZkVOp+2hJfbf6s+a02JHMiJh7q0DZ+Dyp8og",
+			"range": null,
+			"version": 1,
+			"objectId": "0xf7060e42698c5124afba30354abc845c97d3a841df887b2b6b68f4b689f863bd"
+		})).toBeTruthy()
+	})
+	it("should return false when version is missing!", () => {
+		expect(isVersionedResource({
+			"path": "index.html",
+			"headers": { "cache-control": "public, max-age=86400" },
+			"blob_id": "9Jws-C9zE99FwWex6dsVbpaaaaaIk7Ko7No-8mKfgRk",
+			"blob_hash": "O1NaFqZZkVOp+2hJfbf6s+a02JHMiJh7q0DZ+Dyp8og",
+			"range": null,
+			"objectId": "0xf7060e42698c5124afba30354abc845c97d3a841df887b2b6b68f4b689f863bd"
+		})).toBeFalsy()
+	})
+	it("should return false when objectId is missing!", () => {
+		expect(isVersionedResource({
+			"path": "index.html",
+			"headers": { "cache-control": "public, max-age=86400" },
+			"blob_id": "9Jws-C9zE99FwWex6dsVbpaaaaaIk7Ko7No-8mKfgRk",
+			"blob_hash": "O1NaFqZZkVOp+2hJfbf6s+a02JHMiJh7q0DZ+Dyp8og",
+			"range": null,
+			"version": 1,
 		})).toBeFalsy()
 	})
 })

--- a/portal/common/lib/tests/types.test.ts
+++ b/portal/common/lib/tests/types.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { isResource, isVersionedResource, optionalRangeToHeaders, Range } from "@lib/types/index";
+import { isResource, isVersionedResource, optionalRangeToHeaders, Range, isRoutes } from "@lib/types/index";
 import { describe, it, expect } from "vitest";
 
 describe("happy paths of optionalRangeToHeaders should", () => {
@@ -107,5 +107,42 @@ describe("isVersionedResource", () => {
 			"range": null,
 			"version": 1,
 		})).toBeFalsy()
+	})
+})
+
+describe("isRoutes", () => {
+	it("should return true when it's definitely a routes object", () => {
+		expect(isRoutes({
+			"routes_list": new Map([
+				["/index.html", { path: "/index.html" }],
+				["/about", { path: "/about" }]
+			])
+		})).toBeTruthy()
+	})
+	it("should return false when routes_list is missing", () => {
+		expect(isRoutes({
+			"other_property": "value"
+		})).toBeFalsy()
+	})
+	it("should return false when routes_list is not a Map", () => {
+		expect(isRoutes({
+			"routes_list": {}
+		})).toBeFalsy()
+	})
+	it("should return false when routes_list is an array", () => {
+		expect(isRoutes({
+			"routes_list": []
+		})).toBeFalsy()
+	})
+	it("should return false when routes_list is a string", () => {
+		expect(isRoutes({
+			"routes_list": "not a map"
+		})).toBeFalsy()
+	})
+	it("should return false when obj is null", () => {
+		expect(isRoutes(null)).toBeFalsy()
+	})
+	it("should return false when obj is undefined", () => {
+		expect(isRoutes(undefined)).toBeFalsy()
 	})
 })

--- a/portal/common/lib/tests/types.test.ts
+++ b/portal/common/lib/tests/types.test.ts
@@ -1,148 +1,157 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { isResource, isVersionedResource, optionalRangeToHeaders, Range, isRoutes } from "@lib/types/index";
+import {
+    isResource,
+    isVersionedResource,
+    optionalRangeToHeaders,
+    Range,
+    isRoutes,
+} from "@lib/types/index";
 import { describe, it, expect } from "vitest";
 
 describe("happy paths of optionalRangeToHeaders should", () => {
-	it.each([
-		[{ start: 0, end: 10 }, "bytes=0-10"],
-		[{ start: null, end: 10 }, "bytes=-10"],
-		[{ start: 10, end: null }, "bytes=10-"],
-		[null, undefined],
-	])('convert range %o into "%s"', (range, expected) => {
-		expect(optionalRangeToHeaders(range as Range).range).toBe(expected);
-	});
+    it.each([
+        [{ start: 0, end: 10 }, "bytes=0-10"],
+        [{ start: null, end: 10 }, "bytes=-10"],
+        [{ start: 10, end: null }, "bytes=10-"],
+        [null, undefined],
+    ])('convert range %o into "%s"', (range, expected) => {
+        expect(optionalRangeToHeaders(range as Range).range).toBe(expected);
+    });
 });
 
 describe("cases where optionalRangeToHeaders should", () => {
-	it.each([
-		[null, null],
-		[null, -1],
-		[-1, null],
-		[2, 1]
-	])('throw error when start = %s and end = %s "', (start, end) => {
-		expect(() => optionalRangeToHeaders({ start, end } as Range)).toThrowError(
-			`Invalid range: start=${start} end=${end}`,
-		);
-	});
+    it.each([
+        [null, null],
+        [null, -1],
+        [-1, null],
+        [2, 1],
+    ])('throw error when start = %s and end = %s "', (start, end) => {
+        expect(() => optionalRangeToHeaders({ start, end } as Range)).toThrowError(
+            `Invalid range: start=${start} end=${end}`,
+        );
+    });
 });
 
 describe("isResource", () => {
-	it("should return true when it's definitely a resource", () => {
-		expect(isResource({
-			"path": "index.html",
-			"headers": { "cache-control": "public, max-age=86400" },
-			"blob_id": "9Jws-C9zE99FwWex6dsVbpaaaaaIk7Ko7No-8mKfgRk",
-			"blob_hash": "O1NaFqZZkVOp+2hJfbf6s+a02JHMiJh7q0DZ+Dyp8og",
-			"range": null,
-		})).toBeTruthy()
-	})
-	it("should return false when path is a number", () => {
-		expect(isResource({
-			"path": 123,
-			"headers": { "cache-control": "public, max-age=86400" },
-			"blob_id": "9Jws-C9zE99FwWex6dsVbpaaaaaIk7Ko7No-8mKfgRk",
-			"blob_hash": "O1NaFqZZkVOp+2hJfbf6s+a02JHMiJh7q0DZ+Dyp8og",
-			"range": null,
-		})).toBeFalsy()
-	})
-	it("should return false when blob_id is a number", () => {
-		expect(isResource({
-			"path": "index.html",
-			"headers": { "cache-control": "public, max-age=86400" },
-			"blob_id": 123,
-			"blob_hash": "O1NaFqZZkVOp+2hJfbf6s+a02JHMiJh7q0DZ+Dyp8og",
-			"range": null,
-		})).toBeFalsy()
-	})
-	it("should return false when headers is not an object", () => {
-		expect(isResource({
-			"path": "index.html",
-			"headers": "not an object",
-			"blob_id": "9Jws-C9zE99FwWex6dsVbpaaaaaIk7Ko7No-8mKfgRk",
-			"blob_hash": "O1NaFqZZkVOp+2hJfbf6s+a02JHMiJh7q0DZ+Dyp8og",
-			"range": null,
-		})).toBeFalsy()
-	})
-	it("should return false when blob_hash is not a string", () => {
-		expect(isResource({
-			"path": "index.html",
-			"headers": { "cache-control": "public, max-age=86400" },
-			"blob_id": "9Jws-C9zE99FwWex6dsVbpaaaaaIk7Ko7No-8mKfgRk",
-			"blob_hash": 123,
-			"range": null,
-		})).toBeFalsy()
-	})
-})
+    it("should return true when it's definitely a resource", () => {
+        expect(
+            isResource({
+                path: "index.html",
+                headers: { "cache-control": "public, max-age=86400" },
+                blob_id: "9Jws-C9zE99FwWex6dsVbpaaaaaIk7Ko7No-8mKfgRk",
+                blob_hash: "O1NaFqZZkVOp+2hJfbf6s+a02JHMiJh7q0DZ+Dyp8og",
+                range: null,
+            }),
+        ).toBeTruthy();
+    });
+    it("should return false when path is a number", () => {
+        expect(
+            isResource({
+                path: 123,
+                headers: { "cache-control": "public, max-age=86400" },
+                blob_id: "9Jws-C9zE99FwWex6dsVbpaaaaaIk7Ko7No-8mKfgRk",
+                blob_hash: "O1NaFqZZkVOp+2hJfbf6s+a02JHMiJh7q0DZ+Dyp8og",
+                range: null,
+            }),
+        ).toBeFalsy();
+    });
+    it("should return false when blob_id is a number", () => {
+        expect(
+            isResource({
+                path: "index.html",
+                headers: { "cache-control": "public, max-age=86400" },
+                blob_id: 123,
+                blob_hash: "O1NaFqZZkVOp+2hJfbf6s+a02JHMiJh7q0DZ+Dyp8og",
+                range: null,
+            }),
+        ).toBeFalsy();
+    });
+    it("should return false when headers is not an object", () => {
+        expect(
+            isResource({
+                path: "index.html",
+                headers: "not an object",
+                blob_id: "9Jws-C9zE99FwWex6dsVbpaaaaaIk7Ko7No-8mKfgRk",
+                blob_hash: "O1NaFqZZkVOp+2hJfbf6s+a02JHMiJh7q0DZ+Dyp8og",
+                range: null,
+            }),
+        ).toBeFalsy();
+    });
+    it("should return false when blob_hash is not a string", () => {
+        expect(
+            isResource({
+                path: "index.html",
+                headers: { "cache-control": "public, max-age=86400" },
+                blob_id: "9Jws-C9zE99FwWex6dsVbpaaaaaIk7Ko7No-8mKfgRk",
+                blob_hash: 123,
+                range: null,
+            }),
+        ).toBeFalsy();
+    });
+});
 
 describe("isVersionedResource", () => {
-	it("should return true when it's definitely a resource AND versioned!", () => {
-		expect(isVersionedResource({
-			"path": "index.html",
-			"headers": { "cache-control": "public, max-age=86400" },
-			"blob_id": "9Jws-C9zE99FwWex6dsVbpaaaaaIk7Ko7No-8mKfgRk",
-			"blob_hash": "O1NaFqZZkVOp+2hJfbf6s+a02JHMiJh7q0DZ+Dyp8og",
-			"range": null,
-			"version": 1,
-			"objectId": "0xf7060e42698c5124afba30354abc845c97d3a841df887b2b6b68f4b689f863bd"
-		})).toBeTruthy()
-	})
-	it("should return false when version is missing!", () => {
-		expect(isVersionedResource({
-			"path": "index.html",
-			"headers": { "cache-control": "public, max-age=86400" },
-			"blob_id": "9Jws-C9zE99FwWex6dsVbpaaaaaIk7Ko7No-8mKfgRk",
-			"blob_hash": "O1NaFqZZkVOp+2hJfbf6s+a02JHMiJh7q0DZ+Dyp8og",
-			"range": null,
-			"objectId": "0xf7060e42698c5124afba30354abc845c97d3a841df887b2b6b68f4b689f863bd"
-		})).toBeFalsy()
-	})
-	it("should return false when objectId is missing!", () => {
-		expect(isVersionedResource({
-			"path": "index.html",
-			"headers": { "cache-control": "public, max-age=86400" },
-			"blob_id": "9Jws-C9zE99FwWex6dsVbpaaaaaIk7Ko7No-8mKfgRk",
-			"blob_hash": "O1NaFqZZkVOp+2hJfbf6s+a02JHMiJh7q0DZ+Dyp8og",
-			"range": null,
-			"version": 1,
-		})).toBeFalsy()
-	})
-})
+    it("should return true when it's definitely a resource AND versioned!", () => {
+        expect(
+            isVersionedResource({
+                path: "index.html",
+                headers: { "cache-control": "public, max-age=86400" },
+                blob_id: "9Jws-C9zE99FwWex6dsVbpaaaaaIk7Ko7No-8mKfgRk",
+                blob_hash: "O1NaFqZZkVOp+2hJfbf6s+a02JHMiJh7q0DZ+Dyp8og",
+                range: null,
+                version: 1,
+                objectId: "0xf7060e42698c5124afba30354abc845c97d3a841df887b2b6b68f4b689f863bd",
+            }),
+        ).toBeTruthy();
+    });
+    it("should return false when version is missing!", () => {
+        expect(
+            isVersionedResource({
+                path: "index.html",
+                headers: { "cache-control": "public, max-age=86400" },
+                blob_id: "9Jws-C9zE99FwWex6dsVbpaaaaaIk7Ko7No-8mKfgRk",
+                blob_hash: "O1NaFqZZkVOp+2hJfbf6s+a02JHMiJh7q0DZ+Dyp8og",
+                range: null,
+                objectId: "0xf7060e42698c5124afba30354abc845c97d3a841df887b2b6b68f4b689f863bd",
+            }),
+        ).toBeFalsy();
+    });
+    it("should return false when objectId is missing!", () => {
+        expect(
+            isVersionedResource({
+                path: "index.html",
+                headers: { "cache-control": "public, max-age=86400" },
+                blob_id: "9Jws-C9zE99FwWex6dsVbpaaaaaIk7Ko7No-8mKfgRk",
+                blob_hash: "O1NaFqZZkVOp+2hJfbf6s+a02JHMiJh7q0DZ+Dyp8og",
+                range: null,
+                version: 1,
+            }),
+        ).toBeFalsy();
+    });
+});
 
 describe("isRoutes", () => {
-	it("should return true when it's definitely a routes object", () => {
-		expect(isRoutes({
-			"routes_list": new Map([
-				["/index.html", { path: "/index.html" }],
-				["/about", { path: "/about" }]
-			])
-		})).toBeTruthy()
-	})
-	it("should return false when routes_list is missing", () => {
-		expect(isRoutes({
-			"other_property": "value"
-		})).toBeFalsy()
-	})
-	it("should return false when routes_list is not a Map", () => {
-		expect(isRoutes({
-			"routes_list": {}
-		})).toBeFalsy()
-	})
-	it("should return false when routes_list is an array", () => {
-		expect(isRoutes({
-			"routes_list": []
-		})).toBeFalsy()
-	})
-	it("should return false when routes_list is a string", () => {
-		expect(isRoutes({
-			"routes_list": "not a map"
-		})).toBeFalsy()
-	})
-	it("should return false when obj is null", () => {
-		expect(isRoutes(null)).toBeFalsy()
-	})
-	it("should return false when obj is undefined", () => {
-		expect(isRoutes(undefined)).toBeFalsy()
-	})
-})
+    it("should return true when it's definitely a routes object", () => {
+        expect(
+            isRoutes({
+                routes_list: new Map([
+                    ["/index.html", { path: "/index.html" }],
+                    ["/about", { path: "/about" }],
+                ]),
+            }),
+        ).toBeTruthy();
+    });
+
+    it.each([
+        [{ other_property: "value" }, "routes_list is missing"],
+        [{ routes_list: {} }, "routes_list is not a Map but an object"],
+        [{ routes_list: [] }, "routes_list is not a Map but an array"],
+        [{ routes_list: "not a map" }, "routes_list is not a Map but a string"],
+        [null, "obj is null"],
+        [undefined, "obj is undefined"],
+    ])("should return false when %s", (input, description) => {
+        expect(isRoutes(input)).toBeFalsy();
+    });
+});


### PR DESCRIPTION
Fix the optionalRangeToHeaders( start: 0, end: 10 }) so that instead of returning bytes=-10 it should
return bytes=0-10.

This way it aligns with how range headers should be constructed. https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Range

Since I am already adding tests for the type/index.ts I included more tests to improve our coverage.