### PR TITLE
chore(release): Bump site-builder, server, and worker versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8633,7 +8633,7 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "site-builder"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/portal/bun.lock
+++ b/portal/bun.lock
@@ -33,7 +33,7 @@
     },
     "server": {
       "name": "server",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@amplitude/analytics-node": "^1.3.6",
         "@logtape/logtape": "^0.11.0",
@@ -58,7 +58,7 @@
     },
     "worker": {
       "name": "worker",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@mysten/sui": "^1.12.0",
         "common": "workspace:common",

--- a/portal/package.json
+++ b/portal/package.json
@@ -3,8 +3,8 @@
   "description": "Central point of the walrus-sites portal workspace.",
   "workspaces": [
     "common",
-	"worker",
-	"server"
+    "worker",
+    "server"
   ],
   "keywords": ["walrus", "sui", "sui-ns", "sites"],
   "author": "Mysten Labs",

--- a/portal/server/package.json
+++ b/portal/server/package.json
@@ -1,7 +1,7 @@
 {
     "name": "server",
     "description": "The server based implementation of the Walrus Sites portal.",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "private": true,
     "scripts": {
         "start": "bun --hot run index.ts"

--- a/portal/worker/package.json
+++ b/portal/worker/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "worker",
 	"description": "The service-worker based implementation of the Walrus Sites portal.",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"dependencies": {
 		"@mysten/sui": "^1.12.0",
 		"common": "workspace:common",

--- a/site-builder/Cargo.toml
+++ b/site-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "site-builder"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Bump versions to 1.2.0 for the new release.