### PR TITLE
fix(portal): Typo, not passing args in getPropertiesWithContext

### DIFF
--- a/portal/server/custom_logger.ts
+++ b/portal/server/custom_logger.ts
@@ -42,7 +42,7 @@ export async function setupTapelog() {
 	logger.setErrorPredicate((...args: any[]) => {
 		// If args contains only one element, pass undefined as structured data
 		const message = args[0];
-		tapeLogger.error(message, getPropertiesWithContext(), logger.context);
+		tapeLogger.error(message, getPropertiesWithContext(...args), logger.context);
 	});
 }
 


### PR DESCRIPTION
Typo in setting up error predicate in logs resulted in not printing additional context given by the developer.