### PR TITLE
chore: Minor, add #[ignore] in integration tests

### DIFF
--- a/site-builder/tests/update_quilts.rs
+++ b/site-builder/tests/update_quilts.rs
@@ -24,6 +24,7 @@ use localnode::{
 mod helpers;
 
 #[tokio::test]
+#[ignore]
 async fn quilts_update_snake() -> anyhow::Result<()> {
     let cluster = TestSetup::start_local_test_cluster().await?;
     let directory = PathBuf::from(env!("CARGO_MANIFEST_DIR"))


### PR DESCRIPTION
As this is the approach for long-running tests currently