### PR TITLE
fix(site-builder): using dry run throws error for publish quilts 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3262,6 +3262,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3488,6 +3499,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "gag"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a713bee13966e9fbffdf7193af71d54a6b35a0bb34997cd6c9519ebeb5005972"
+dependencies = [
+ "filedescriptor",
+ "tempfile",
 ]
 
 [[package]]
@@ -8646,6 +8667,7 @@ dependencies = [
  "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto)",
  "flate2",
  "futures",
+ "gag",
  "glob",
  "hex",
  "home",

--- a/deny.toml
+++ b/deny.toml
@@ -9,12 +9,18 @@ ignore = [
     "RUSTSEC-2024-0320",
     # proc-macro-error is not maintained, but is a dependency in many of our packages.
     "RUSTSEC-2024-0370",
+    # allow unmaintained instant crate used in transitive dependencies (backoff, cached, fastrand, parking_lot_*)
+    "RUSTSEC-2024-0384",
     # `derivative` is unmaintained.
     "RUSTSEC-2024-0388",
-    # Crash due to uncontrolled recursion in `protobuf` crate.
-    "RUSTSEC-2024-0437",
     # `paste` is unmaintained.
     "RUSTSEC-2024-0436",
+    # Crash due to uncontrolled recursion in `protobuf` crate.
+    "RUSTSEC-2024-0437",
+    # `backoff` is unmaintained - no safe upgrade available
+    "RUSTSEC-2025-0012",
+    # fxhash not maintained
+    "RUSTSEC-2025-0057",
 ]
 
 # This section is considered when running `cargo deny check licenses`
@@ -66,17 +72,16 @@ ignore = true
 # Lint level for when multiple versions of the same crate are detected
 multiple-versions = "deny"
 skip = [
-  { name = "funty", version = "1.1.0" }, # Sui depends on both 1.1.0 and 2.0.0.
-  { name = "itertools", version = "<=12.1" },
-  { name = "radium", version = "0.6.2" }, # Sui depends on both 0.6.2 and 0.7.0.
-  { name = "synstructure", version = "0.12.6" },
-  { name = "hermit-abi", version = "0.3.9" }, # Prettytable conflicts with sui.
+    { name = "funty", version = "1.1.0" },         # Sui depends on both 1.1.0 and 2.0.0.
+    { name = "itertools", version = "<=12.1" },
+    { name = "radium", version = "0.6.2" },        # Sui depends on both 0.6.2 and 0.7.0.
+    { name = "synstructure", version = "0.12.6" },
 ]
 skip-tree = [
     # Mysten's libraries pull in several conflicting repo versions.
     { name = "fastcrypto", depth = 4 },
-    { name = "sui-rest-api", depth = 6},
-    { name = "sui-sdk", depth = 6},
+    { name = "sui-rest-api", depth = 6 },
+    { name = "sui-sdk", depth = 6 },
     # several crates depend on an older version of windows-sys
     { name = "windows-sys", depth = 3, version = "0.48" },
     # Several crates depend on older windows versions
@@ -105,6 +110,4 @@ allow-git = [
 
 [sources.allow-org]
 # github.com organizations to allow git sources for
-github = [
-    "MystenLabs",
-]
+github = ["MystenLabs"]

--- a/site-builder/Cargo.toml
+++ b/site-builder/Cargo.toml
@@ -52,6 +52,7 @@ tracing-subscriber = "0.3.18"
 walrus-core = { git = "https://github.com/MystenLabs/walrus", rev = "testnet-v1.32.0" }
 
 [dev-dependencies]
+gag = "1.0.0"
 sui-move-build = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.55.0" }
 tempfile = "3.20.0"
 walrus-sdk = { git = "https://github.com/MystenLabs/walrus", tag = "testnet-v1.32.0" }

--- a/site-builder/Cargo.toml
+++ b/site-builder/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 
 [features]
 quilts-experimental = []
+_testing-dry-run = []
 
 [dependencies]
 anyhow = "1.0.86"
@@ -39,7 +40,12 @@ sui-keys = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.55.0" 
 sui-sdk = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.55.0" }
 sui-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.55.0" }
 thiserror = "1.0.61"
-tokio = { version = "1.46.1", features = ["rt", "rt-multi-thread", "macros", "process"] }
+tokio = { version = "1.46.1", features = [
+    "rt",
+    "rt-multi-thread",
+    "macros",
+    "process",
+] }
 toml = "0.8.14"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
@@ -49,6 +55,8 @@ walrus-core = { git = "https://github.com/MystenLabs/walrus", rev = "testnet-v1.
 sui-move-build = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.55.0" }
 tempfile = "3.20.0"
 walrus-sdk = { git = "https://github.com/MystenLabs/walrus", tag = "testnet-v1.32.0" }
-walrus-service = { git = "https://github.com/MystenLabs/walrus", tag = "testnet-v1.32.0", features = ["test-utils"] }
+walrus-service = { git = "https://github.com/MystenLabs/walrus", tag = "testnet-v1.32.0", features = [
+    "test-utils",
+] }
 walrus-sui = { git = "https://github.com/MystenLabs/walrus", tag = "testnet-v1.32.0" }
 walrus-test-utils = { git = "https://github.com/MystenLabs/walrus", tag = "testnet-v1.32.0" }

--- a/site-builder/src/site/manager.rs
+++ b/site-builder/src/site/manager.rs
@@ -143,24 +143,8 @@ impl SiteManager {
             None => SiteData::empty(),
         };
         tracing::debug!(?existing_site, "checked existing site");
-        tracing::debug!(
-            "Local site data has {} resources",
-            local_site_data.resources.inner.len()
-        );
-        tracing::debug!(
-            "Existing site has {} resources",
-            existing_site.resources.inner.len()
-        );
 
         let site_updates = local_site_data.diff(&existing_site);
-        tracing::debug!(
-            "Diff produced {} resource operations",
-            site_updates.resource_ops.len()
-        );
-        tracing::debug!(
-            "site_updates.has_updates() = {}",
-            site_updates.has_updates()
-        );
 
         let store_blobs = !using_quilts;
         if store_blobs {
@@ -223,21 +207,13 @@ impl SiteManager {
 
                 // Add user confirmation prompt.
                 display::action("Waiting for user confirmation...");
-                #[cfg(not(feature = "_testing-dry-run"))]
+                if !dialoguer::Confirm::new()
+                    .with_prompt("Do you want to proceed with these updates?")
+                    .default(true)
+                    .interact()?
                 {
-                    if !dialoguer::Confirm::new()
-                        .with_prompt("Do you want to proceed with these updates?")
-                        .default(true)
-                        .interact()?
-                    {
-                        display::error("Update cancelled by user");
-                        return Err(anyhow!("Update cancelled by user"));
-                    }
-                }
-                #[cfg(feature = "_testing-dry-run")]
-                {
-                    // In tests, automatically proceed without prompting
-                    println!("Test mode: automatically proceeding with updates");
+                    display::error("Update cancelled by user");
+                    return Err(anyhow!("Update cancelled by user"));
                 }
             }
             self.store_single_blob_resources_to_walrus(&walrus_updates)
@@ -490,21 +466,13 @@ impl SiteManager {
             ));
             // Add user confirmation prompt.
             display::action("Waiting for user confirmation...");
-            #[cfg(not(feature = "_testing-dry-run"))]
+            if !dialoguer::Confirm::new()
+                .with_prompt("Do you want to proceed with these updates?")
+                .default(true)
+                .interact()?
             {
-                if !dialoguer::Confirm::new()
-                    .with_prompt("Do you want to proceed with these updates?")
-                    .default(true)
-                    .interact()?
-                {
-                    display::error("Update cancelled by user");
-                    return Err(anyhow!("Update cancelled by user"));
-                }
-            }
-            #[cfg(feature = "_testing-dry-run")]
-            {
-                // In tests, automatically proceed without prompting
-                println!("Test mode: automatically proceeding with updates");
+                display::error("Update cancelled by user");
+                return Err(anyhow!("Update cancelled by user"));
             }
         }
         self.store_single_blob_resources_to_walrus(&walrus_ops)

--- a/site-builder/src/site/manager.rs
+++ b/site-builder/src/site/manager.rs
@@ -3,12 +3,14 @@
 
 use std::{
     collections::{BTreeSet, HashSet},
+    io::{stdin, stdout},
     num::NonZeroUsize,
     str::FromStr,
     time::Duration,
 };
 
 use anyhow::{anyhow, Error, Result};
+use dialoguer::console::Term;
 use sui_keys::keystore::AccountKeystore;
 use sui_sdk::{
     rpc_types::{
@@ -227,10 +229,11 @@ impl SiteManager {
 
                 // Add user confirmation prompt.
                 display::action("Waiting for user confirmation...");
+                let term = Term::read_write_pair(stdin(), stdout());
                 if !dialoguer::Confirm::new()
                     .with_prompt("Do you want to proceed with these updates?")
                     .default(true)
-                    .interact()?
+                    .interact_on(&term)?
                 {
                     display::error("Update cancelled by user");
                     return Err(anyhow!("Update cancelled by user"));
@@ -486,10 +489,11 @@ impl SiteManager {
             ));
             // Add user confirmation prompt.
             display::action("Waiting for user confirmation...");
+            let term = Term::read_write_pair(stdin(), stdout());
             if !dialoguer::Confirm::new()
                 .with_prompt("Do you want to proceed with these updates?")
                 .default(true)
-                .interact()?
+                .interact_on(&term)?
             {
                 display::error("Update cancelled by user");
                 return Err(anyhow!("Update cancelled by user"));

--- a/site-builder/src/site/manager.rs
+++ b/site-builder/src/site/manager.rs
@@ -143,8 +143,28 @@ impl SiteManager {
             None => SiteData::empty(),
         };
         tracing::debug!(?existing_site, "checked existing site");
+        tracing::debug!(
+            "Local site data has {} resources",
+            local_site_data.resources.inner.len()
+        );
+        tracing::debug!(
+            "Existing site has {} resources",
+            existing_site.resources.inner.len()
+        );
 
         let site_updates = local_site_data.diff(&existing_site);
+        tracing::debug!(
+            "Diff produced {} resource operations",
+            site_updates.resource_ops.len()
+        );
+        tracing::debug!(
+            "site_updates.has_updates() = {}",
+            site_updates.has_updates()
+        );
+
+        for (idx, op) in site_updates.resource_ops.iter().enumerate() {
+            tracing::debug!("  Resource op {}: {:?}", idx + 1, op);
+        }
 
         let store_blobs = !using_quilts;
         if store_blobs {

--- a/site-builder/src/site/manager.rs
+++ b/site-builder/src/site/manager.rs
@@ -164,10 +164,6 @@ impl SiteManager {
             site_updates.has_updates()
         );
 
-        for (idx, op) in site_updates.resource_ops.iter().enumerate() {
-            tracing::debug!("  Resource op {}: {:?}", idx + 1, op);
-        }
-
         let store_blobs = !using_quilts;
         if store_blobs {
             let walrus_candidate_set = if self.blob_options.is_check_extend() {

--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -437,6 +437,27 @@ impl ResourceManager {
         )))
     }
 
+    ///  Derives the HTTP headers for a resource based on the ws-resources.yaml.
+    ///
+    ///  Matches the path of the resource to the wildcard paths in the configuration to
+    ///  determine the headers to be added to the HTTP response.
+    pub fn derive_http_headers(
+        ws_resources: &Option<WSResources>,
+        resource_path: &str,
+    ) -> VecMap<String, String> {
+        ws_resources
+            .as_ref()
+            .and_then(|config| config.headers.as_ref())
+            .and_then(|headers| {
+                headers
+                    .iter()
+                    .filter(|(path, _)| is_pattern_match(path, resource_path))
+                    .max_by_key(|(path, _)| path.split('/').count())
+                    .map(|(_, header_map)| header_map.0.clone())
+            })
+            .unwrap_or_default()
+    }
+
     /// Filters resource_paths, and prepares their ResourceData, while also grouping them into a
     /// single Quilt.
     fn prepare_local_resources(
@@ -723,30 +744,6 @@ impl ResourceManager {
                 .as_ref()
                 .and_then(|config| config.site_name.clone()),
         )
-    }
-}
-
-// Static methods that don't depend on the generic parameter
-impl ResourceManager {
-    ///  Derives the HTTP headers for a resource based on the ws-resources.yaml.
-    ///
-    ///  Matches the path of the resource to the wildcard paths in the configuration to
-    ///  determine the headers to be added to the HTTP response.
-    pub fn derive_http_headers(
-        ws_resources: &Option<WSResources>,
-        resource_path: &str,
-    ) -> VecMap<String, String> {
-        ws_resources
-            .as_ref()
-            .and_then(|config| config.headers.as_ref())
-            .and_then(|headers| {
-                headers
-                    .iter()
-                    .filter(|(path, _)| is_pattern_match(path, resource_path))
-                    .max_by_key(|(path, _)| path.split('/').count())
-                    .map(|(_, header_map)| header_map.0.clone())
-            })
-            .unwrap_or_default()
     }
 }
 

--- a/site-builder/src/site/resource.rs
+++ b/site-builder/src/site/resource.rs
@@ -7,13 +7,14 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     fmt::{self, Debug, Display},
     fs,
-    io::Write,
+    io::{stdin, stdout, Write},
     num::{NonZeroU16, NonZeroUsize},
     path::{Path, PathBuf},
 };
 
 use anyhow::{anyhow, bail, Context, Result};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use dialoguer::console::Term;
 use fastcrypto::hash::{HashFunction, Sha256};
 use flate2::{write::GzEncoder, Compression};
 use futures::{stream, StreamExt};
@@ -688,10 +689,11 @@ impl ResourceManager {
 
             // Add user confirmation prompt.
             display::action("Waiting for user confirmation...");
+            let term = Term::read_write_pair(stdin(), stdout());
             if !dialoguer::Confirm::new()
                 .with_prompt("Do you want to proceed with these updates?")
                 .default(true)
-                .interact()?
+                .interact_on(&term)?
             {
                 display::error("Update cancelled by user");
                 return Err(anyhow!("Update cancelled by user"));

--- a/site-builder/tests/quilts_dry_run_regression.rs
+++ b/site-builder/tests/quilts_dry_run_regression.rs
@@ -1,0 +1,239 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for quilts dry-run functionality regression.
+//!
+//! These tests specifically target the bug that was fixed where dry-run mode
+//! would consume the chunks iterator during cost estimation, causing resource
+//! processing to fail after user confirmation with "Transaction effects not found".
+
+#![cfg(feature = "quilts-experimental")]
+
+use std::{
+    fs::File,
+    io::Write,
+    path::PathBuf,
+    process::{Command, Stdio},
+};
+
+use site_builder::site_config::WSResources;
+
+#[allow(dead_code)]
+mod localnode;
+use localnode::TestSetup;
+
+mod helpers;
+
+/// Test dry-run mode with snake example (small site) - subprocess with simulated user input.
+#[tokio::test]
+async fn dry_run_snake_with_simulated_yes_input() -> anyhow::Result<()> {
+    test_subprocess_dry_run("snake", true, 4).await // Snake has ~4 files
+}
+
+/// Test dry-run mode with snake example (small site) - subprocess without input (should timeout).
+#[tokio::test]
+async fn dry_run_snake_without_input() -> anyhow::Result<()> {
+    test_subprocess_dry_run("snake", false, 4).await
+}
+
+/// Test dry-run mode with large site (150 files) - subprocess with simulated user input.
+#[tokio::test]
+async fn dry_run_large_site_with_simulated_yes_input() -> anyhow::Result<()> {
+    test_subprocess_dry_run("large", true, 150).await
+}
+
+/// Test dry-run mode with large site (150 files) - subprocess without input (should timeout).
+#[tokio::test]
+async fn dry_run_large_site_without_input() -> anyhow::Result<()> {
+    test_subprocess_dry_run("large", false, 150).await
+}
+
+/// Helper function to test dry-run subprocess execution.
+async fn test_subprocess_dry_run(
+    site_type: &str,
+    provide_input: bool,
+    expected_file_count: usize,
+) -> anyhow::Result<()> {
+    let cluster = TestSetup::start_local_test_cluster().await?;
+    let temp_dir = tempfile::tempdir()?;
+    let directory = temp_dir.path().to_path_buf();
+
+    // Create test site based on type
+    match site_type {
+        "snake" => {
+            // Copy snake example
+            let snake_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .unwrap()
+                .join("examples")
+                .join("snake");
+            helpers::copy_dir(snake_dir.as_path(), directory.as_path())?;
+        }
+        "large" => {
+            // Create a large site with many files
+            create_large_test_site(directory.as_path(), expected_file_count)?;
+        }
+        _ => panic!("Unknown site type: {site_type}"),
+    }
+
+    // Reset object_id for new site creation
+    let ws_resources_path = directory.join("ws-resources.json");
+    let mut ws_resources: WSResources = if ws_resources_path.exists() {
+        serde_json::from_reader(File::open(ws_resources_path.as_path())?)?
+    } else {
+        // Create default ws-resources.json for large site
+        WSResources {
+            headers: None,
+            routes: None,
+            metadata: None,
+            site_name: Some(format!("Test {site_type} Site")),
+            object_id: None,
+            ignore: None,
+        }
+    };
+    ws_resources.object_id = None; // Ensure this is treated as a new site
+    serde_json::to_writer_pretty(File::create(ws_resources_path.as_path())?, &ws_resources)?;
+
+    // Spawn the subprocess
+    let mut child = Command::new("cargo")
+        .args([
+            "run",
+            "--features",
+            "quilts-experimental",
+            "--",
+            "--config",
+            cluster.sites_config_path().to_str().unwrap(),
+            "publish-quilts",
+            "--epochs",
+            "1",
+            "--dry-run",
+            directory.to_str().unwrap(), // directory is a positional argument
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    // Provide input if requested
+    if provide_input {
+        if let Some(stdin) = child.stdin.as_mut() {
+            stdin.write_all(b"y\n")?;
+            stdin.flush()?;
+        }
+    }
+
+    let output = child.wait_with_output()?;
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    println!("=== Test: {site_type} site, input: {provide_input} ===");
+    println!("Exit status: {:?}", output.status);
+    println!("Stdout: {stdout}");
+    println!("Stderr: {stderr}");
+
+    if provide_input {
+        // When we provide input, the command should either succeed or fail gracefully
+        // but NOT with the specific bugs we're testing for
+        if !output.status.success() {
+            // Check for the iterator consumption bug (affects large sites)
+            assert!(
+                !stderr.contains("Transaction effects not found"),
+                "Command failed with iterator consumption bug: {stderr}"
+            );
+
+            // Check for the object ID panic (affects small sites)
+            assert!(
+                !stderr.contains("could not find the object ID for the created Walrus site"),
+                "Command failed with object ID panic: {stderr}"
+            );
+
+            // General panic check
+            assert!(!stderr.contains("panic"), "Command panicked: {stderr}");
+        }
+    } else {
+        // When we don't provide input, it should fail due to terminal/IO issues
+        // but still NOT with the specific bugs we're testing for
+        assert!(
+            !output.status.success(),
+            "Expected command to fail without input"
+        );
+
+        // Should fail with terminal/IO error, not with our specific bugs
+        assert!(
+            !stderr.contains("Transaction effects not found"),
+            "Command failed with iterator consumption bug even without user input: {stderr}"
+        );
+
+        // The process should reach the confirmation prompt before failing
+        assert!(
+            stderr.contains("Waiting for user confirmation")
+                || stdout.contains("Waiting for user confirmation"),
+            "Should reach confirmation prompt: stdout: {stdout} stderr: {stderr}"
+        );
+    }
+
+    Ok(())
+}
+
+/// Helper function to create a large test site with many files.
+fn create_large_test_site(directory: &std::path::Path, file_count: usize) -> anyhow::Result<()> {
+    // Create main index file
+    let mut index_file = File::create(directory.join("index.html"))?;
+    writeln!(index_file, "<!DOCTYPE html>")?;
+    writeln!(
+        index_file,
+        "<html><head><title>Large Test Site</title></head>"
+    )?;
+    writeln!(
+        index_file,
+        "<body><h1>Large Test Site with {file_count} files</h1>"
+    )?;
+    writeln!(index_file, "<ul>")?;
+
+    // Create many HTML files
+    for i in 1..file_count {
+        let file_name = format!("page_{i:03}.html");
+        let file_path = directory.join(&file_name);
+
+        let mut file = File::create(&file_path)?;
+        writeln!(file, "<!DOCTYPE html>")?;
+        writeln!(file, "<html><head><title>Page {i}</title></head>")?;
+        writeln!(file, "<body>")?;
+        writeln!(file, "<h1>This is page number {i}</h1>")?;
+        writeln!(
+            file,
+            "<p>This is a test page with some content to make it non-trivial.</p>"
+        )?;
+        writeln!(
+            file,
+            "<p>Page generated for testing dry-run functionality with large sites.</p>"
+        )?;
+        writeln!(file, "<a href=\"index.html\">Back to main page</a>")?;
+        writeln!(file, "</body></html>")?;
+
+        // Add to index
+        writeln!(
+            index_file,
+            "<li><a href=\"{file_name}\">{file_name}</a></li>"
+        )?;
+    }
+
+    writeln!(index_file, "</ul></body></html>")?;
+
+    // Create a CSS file
+    let mut css_file = File::create(directory.join("style.css"))?;
+    writeln!(
+        css_file,
+        "body {{ font-family: Arial, sans-serif; margin: 20px; }}"
+    )?;
+    writeln!(css_file, "h1 {{ color: #333; }}")?;
+    writeln!(css_file, "a {{ color: #0066cc; text-decoration: none; }}")?;
+    writeln!(css_file, "a:hover {{ text-decoration: underline; }}")?;
+
+    println!(
+        "Created large test site with {} files in {}",
+        file_count,
+        directory.display()
+    );
+    Ok(())
+}


### PR DESCRIPTION
- fix: on `resource.rs/read_dir_and_store_quilts` an issue with the chunks being consumed with `unzip()` in the dry_run block which resulted in a bug.
- test: add the `quilts_dry_run_regression.rs` testing the snake site as well as a dummy large site, with the `publish-quilts —dry-run` command.

- Note1: added some `tracing:debug! `statements, not sure if we want to keep them
- Note2: I tried implementing a cleaner solution with a “ConfirmationProvider” Trait, that wraps the dialoguer, so that we could mock it with a programmatic one, so that we can test the dry-run without the “subprocess” hack. However, it felt like we have too much tight coupling in our codebase, which requires a huge refactor in order to enable this sort of dependency injection. So I went back to the “subprocess” hack for testing. 