### PR TITLE
test(site-builder): add checks for the frost cost estimation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3262,6 +3262,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3488,6 +3499,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "gag"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a713bee13966e9fbffdf7193af71d54a6b35a0bb34997cd6c9519ebeb5005972"
+dependencies = [
+ "filedescriptor",
+ "tempfile",
 ]
 
 [[package]]
@@ -8646,6 +8667,7 @@ dependencies = [
  "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto)",
  "flate2",
  "futures",
+ "gag",
  "glob",
  "hex",
  "home",

--- a/site-builder/Cargo.toml
+++ b/site-builder/Cargo.toml
@@ -52,6 +52,7 @@ tracing-subscriber = "0.3.18"
 walrus-core = { git = "https://github.com/MystenLabs/walrus", rev = "testnet-v1.32.0" }
 
 [dev-dependencies]
+gag = "1.0.0"
 sui-move-build = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.55.0" }
 tempfile = "3.20.0"
 walrus-sdk = { git = "https://github.com/MystenLabs/walrus", tag = "testnet-v1.32.0" }

--- a/site-builder/tests/quilts_dry_run_regression.rs
+++ b/site-builder/tests/quilts_dry_run_regression.rs
@@ -9,7 +9,12 @@
 
 #![cfg(feature = "quilts-experimental")]
 
-use std::{fs::File, io::Write, num::NonZeroU32, path::PathBuf};
+use std::{
+    fs::File,
+    io::{Read, Write},
+    num::NonZeroU32,
+    path::PathBuf,
+};
 
 use site_builder::{
     args::{Commands, EpochCountOrMax},
@@ -24,6 +29,26 @@ use localnode::{
 };
 
 mod helpers;
+
+/// Helper function to parse estimated cost from captured output
+fn parse_estimated_cost_from_output(output: &str) -> Option<u128> {
+    // Look for "Estimated Storage Cost for this publish/update (Gas Cost Excluded): X FROST"
+    for line in output.lines() {
+        if line.contains("Estimated Storage Cost") && line.contains("FROST") {
+            // Extract the number before "FROST"
+            if let Some(frost_idx) = line.rfind("FROST") {
+                let before_frost = line[..frost_idx].trim();
+                // Get the last word which should be the number
+                if let Some(num_str) = before_frost.split_whitespace().last() {
+                    if let Ok(cost) = num_str.parse::<u128>() {
+                        return Some(cost);
+                    }
+                }
+            }
+        }
+    }
+    None
+}
 
 /// Test dry-run mode with snake example (small site).
 /// This tests that the chunks iterator is not consumed during dry-run.
@@ -41,7 +66,28 @@ async fn dry_run_large_site() -> anyhow::Result<()> {
 
 /// Helper function to test dry-run execution.
 async fn test_dry_run(site_type: &str, expected_file_count: usize) -> anyhow::Result<()> {
-    let cluster = TestSetup::start_local_test_cluster().await?;
+    let mut cluster = TestSetup::start_local_test_cluster().await?;
+
+    // Get the wallet address for balance checking
+    let wallet_address = cluster.wallet.inner.active_address()?;
+
+    // Get the Walrus coin type from the admin client
+    // The SuiContractClient should have the coin type information
+    let walrus_sui_client = cluster.cluster_state.walrus_admin_client.inner.sui_client();
+    let frost_coin_type = walrus_sui_client.read_client().wal_coin_type().to_string();
+
+    // Get initial FROST balance
+    let initial_balance = cluster
+        .client
+        .coin_read_api()
+        .get_balance(wallet_address, Some(frost_coin_type.clone()))
+        .await?;
+
+    println!(
+        "Initial FROST balance: {} FROST",
+        initial_balance.total_balance
+    );
+
     let temp_dir = tempfile::tempdir()?;
     let directory = temp_dir.path().to_path_buf();
 
@@ -97,7 +143,47 @@ async fn test_dry_run(site_type: &str, expected_file_count: usize) -> anyhow::Re
         .build()?;
 
     // This will use cfg(test) to auto-proceed past the confirmation prompt
-    let result = site_builder::run(args).await;
+    // The dry-run will print "Estimated Storage Cost: X FROST" to stdout,
+    // then proceed with actual publish after confirmation
+
+    // Capture stdout to extract the estimated cost
+    // Wrap in a scope to ensure cleanup happens
+    let (result, estimated_cost) = {
+        let mut buf = gag::BufferRedirect::stdout().unwrap_or_else(|e| {
+            panic!("Failed to redirect stdout (maybe already redirected?): {e}");
+        });
+
+        let result = site_builder::run(args).await;
+
+        // Read captured output before dropping the buffer
+        let mut output = String::new();
+        buf.read_to_string(&mut output)
+            .expect("Failed to read captured output");
+
+        // Parse the estimated cost from captured output
+        let estimated_cost = parse_estimated_cost_from_output(&output);
+
+        // Drop buffer to restore stdout BEFORE printing
+        drop(buf);
+
+        // Print the captured output so it's visible in test output
+        print!("{output}");
+
+        (result, estimated_cost)
+    };
+
+    // Get final FROST balance after publish (if successful)
+    let final_balance = if result.is_ok() {
+        Some(
+            cluster
+                .client
+                .coin_read_api()
+                .get_balance(wallet_address, Some(frost_coin_type.clone()))
+                .await?,
+        )
+    } else {
+        None
+    };
 
     // Check that we didn't hit the specific bugs we're testing for
     if let Err(e) = &result {
@@ -114,6 +200,45 @@ async fn test_dry_run(site_type: &str, expected_file_count: usize) -> anyhow::Re
             !error_msg.contains("could not find the object ID for the created Walrus site"),
             "Command failed with object ID panic: {error_msg}"
         );
+    }
+
+    // Verify FROST cost if publish was successful
+    if let Some(final_balance) = final_balance {
+        let actual_cost = initial_balance.total_balance - final_balance.total_balance;
+
+        println!("\n=== FROST Cost Verification ===");
+        println!(
+            "Initial FROST balance: {} FROST",
+            initial_balance.total_balance
+        );
+        println!(
+            "Final FROST balance:   {} FROST",
+            final_balance.total_balance
+        );
+        println!("Actual FROST cost:     {actual_cost} FROST");
+        if let Some(est) = estimated_cost {
+            println!("Estimated FROST cost:  {est} FROST");
+        }
+        println!("================================\n");
+
+        // Verify that FROST was actually spent
+        assert!(
+            actual_cost > 0,
+            "Expected FROST to be spent, but balance did not decrease. \
+             Initial: {}, Final: {}",
+            initial_balance.total_balance,
+            final_balance.total_balance
+        );
+
+        // Verify the actual cost matches the dry-run estimate
+        if let Some(est) = estimated_cost {
+            assert_eq!(
+                actual_cost, est,
+                "Actual FROST cost ({actual_cost}) does not match dry-run estimate ({est})",
+            );
+        } else {
+            eprintln!("Warning: Could not parse estimated cost from output. Skipping exact match assertion.");
+        }
     }
 
     // The test passes if we got here without hitting the specific bugs


### PR DESCRIPTION
test(site-builder): add checks for the frost cost estimation of the dry-run. 
Note1: needed the gag dev-dependency for this.
Note2: Had to put both test cases into one, due to gag BufferRedirect not working properly for parallel tests. Didn't want to add serial_test crate just for this.