### PR TITLE
chore(release): bump site-builder, server, and worker versions to 1.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8654,7 +8654,7 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "site-builder"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["site-builder"]
 
 [workspace.package]
-version = "1.1.0"
+version = "1.2.1"
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/portal/bun.lock
+++ b/portal/bun.lock
@@ -33,7 +33,7 @@
     },
     "server": {
       "name": "server",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "dependencies": {
         "@amplitude/analytics-node": "^1.3.6",
         "@logtape/logtape": "^0.11.0",
@@ -58,7 +58,7 @@
     },
     "worker": {
       "name": "worker",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "dependencies": {
         "@mysten/sui": "^1.12.0",
         "common": "workspace:common",

--- a/portal/server/package.json
+++ b/portal/server/package.json
@@ -1,7 +1,7 @@
 {
     "name": "server",
     "description": "The server based implementation of the Walrus Sites portal.",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "private": true,
     "scripts": {
         "start": "bun --hot run index.ts"

--- a/portal/worker/package.json
+++ b/portal/worker/package.json
@@ -1,28 +1,28 @@
 {
-	"name": "worker",
-	"description": "The service-worker based implementation of the Walrus Sites portal.",
-	"version": "1.2.0",
-	"dependencies": {
-		"@mysten/sui": "^1.12.0",
-		"common": "workspace:common",
-		"ts-loader": "^9.5.1",
-		"tsc": "^2.0.4",
-		"typescript": "^5.6.3"
-	},
-	"devDependencies": {
-		"copy-webpack-plugin": "^12.0.2",
-		"css-minimizer-webpack-plugin": "^7.0.0",
-		"html-minimizer-webpack-plugin": "^5.0.0",
-		"vitest": "^2.1.3",
-		"webpack": "^5.95.0",
-		"webpack-cli": "^5.1.4",
-		"webpack-dev-server": "^5.1.0",
-		"webpack-merge": "^6.0.1"
-	},
-	"scripts": {
-		"serve:dev": "webpack serve --config webpack.config.dev.js",
-		"serve:prod": "webpack serve --config webpack.config.prod.js",
-		"build:dev": "webpack --config webpack.config.dev.js",
-		"build:prod": "webpack --no-watch --config webpack.config.prod.js"
-	}
+    "name": "worker",
+    "description": "The service-worker based implementation of the Walrus Sites portal.",
+    "version": "1.2.1",
+    "dependencies": {
+        "@mysten/sui": "^1.12.0",
+        "common": "workspace:common",
+        "ts-loader": "^9.5.1",
+        "tsc": "^2.0.4",
+        "typescript": "^5.6.3"
+    },
+    "devDependencies": {
+        "copy-webpack-plugin": "^12.0.2",
+        "css-minimizer-webpack-plugin": "^7.0.0",
+        "html-minimizer-webpack-plugin": "^5.0.0",
+        "vitest": "^2.1.3",
+        "webpack": "^5.95.0",
+        "webpack-cli": "^5.1.4",
+        "webpack-dev-server": "^5.1.0",
+        "webpack-merge": "^6.0.1"
+    },
+    "scripts": {
+        "serve:dev": "webpack serve --config webpack.config.dev.js",
+        "serve:prod": "webpack serve --config webpack.config.prod.js",
+        "build:dev": "webpack --config webpack.config.dev.js",
+        "build:prod": "webpack --no-watch --config webpack.config.prod.js"
+    }
 }

--- a/site-builder/Cargo.toml
+++ b/site-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "site-builder"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Bump site-builder, server, and worker versions to 1.2.1