### PR TITLE
fix(site-builder): use active env, not envs.first(), for sitemap RPC

### DIFF
--- a/site-builder/src/sitemap.rs
+++ b/site-builder/src/sitemap.rs
@@ -47,8 +47,8 @@ pub(crate) async fn display_sitemap(
     let sui_client = new_retriable_sui_client(
         &wallet
             .config
-            .get_env(&None)
-            .context("no default network env specified in wallet config")?
+            .get_active_env()
+            .context("no active env specified in wallet config")?
             .rpc,
         ExponentialBackoffConfig::default(),
     )?;

--- a/site-builder/src/suins.rs
+++ b/site-builder/src/suins.rs
@@ -3,7 +3,7 @@
 
 //! Utilities to resolve SuiNS addresses.
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use sui_types::{base_types::ObjectID, TypeTag};
 
 use crate::{
@@ -74,7 +74,16 @@ impl SuiNsClient {
         suins_object_id: ObjectID,
         package_id: ObjectID,
     ) -> Result<Self> {
-        let type_map = client.type_origin_map_for_package(package_id).await?;
+        let type_map = client
+            .type_origin_map_for_package(package_id)
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to fetch SuiNS package {package_id}; \
+                     ensure --context (or the wallet's active env) points at the \
+                     Sui network where this SuiNS name is registered"
+                )
+            })?;
         Ok(Self {
             client,
             suins_object_id,

--- a/site-builder/src/unit_tests/site.manager.tests.rs
+++ b/site-builder/src/unit_tests/site.manager.tests.rs
@@ -247,7 +247,7 @@ async fn test_site_manager_cache_protects_against_stale_fullnode() {
     // Create a RetriableSuiClient pointing to main (non-stale) fullnode for execution
     // using the original manager's wallet which still points to main fullnode
     let main_retry_client = new_retriable_sui_client(
-        &manager.wallet.config.get_env(&None).unwrap().rpc,
+        &manager.wallet.config.get_active_env().unwrap().rpc,
         ExponentialBackoffConfig::default(),
     )
     .unwrap();


### PR DESCRIPTION
SuiClientConfig::get_env(&None) returns envs.first(), not the active env. In sitemap this caused the Sui client to hit whichever env happened to be listed first in the user's wallet config instead of the one selected via --context / --wallet-env, surfacing as a misleading "Walrus package not found" error from the SDK.