### PR TITLE
fix(portal): count every request in ws_num_requests_made_counter

### DIFF
--- a/portal/common/lib/src/instrumentation.ts
+++ b/portal/common/lib/src/instrumentation.ts
@@ -141,7 +141,7 @@ export class InstrumentationFacade {
         );
     }
 
-    public increaseRequestsMade(total: number, _requestId: string) {
+    public increaseRequestsMade(total: number) {
         this.num_requests_made_counter.add(total);
     }
 

--- a/portal/common/lib/src/url_fetcher.ts
+++ b/portal/common/lib/src/url_fetcher.ts
@@ -81,6 +81,7 @@ export class UrlFetcher {
             subdomain: parsedUrl.subdomain,
             path: parsedUrl.path,
         });
+        instrumentationFacade.increaseRequestsMade(1);
         if (!resolvedObjectId) {
             const resolveObjectResult = await this.resolveObjectId(parsedUrl);
             const isObjectId = typeof resolveObjectResult == "string";
@@ -89,7 +90,6 @@ export class UrlFetcher {
             }
             resolvedObjectId = resolveObjectResult;
         }
-        instrumentationFacade.increaseRequestsMade(1, resolvedObjectId);
 
         if (blocklistChecker && (await blocklistChecker.isBlocked(resolvedObjectId))) {
             return siteNotFound();


### PR DESCRIPTION
Move the counter bump to the top of resolveDomainAndFetchUrl so it runs before SuiNS resolution. Previously, requests that failed resolution (and returned fullNodeFail) bypassed the counter, making the full_node_fail / requests_made ratio alert measure two different populations. Also drops the unused _requestId argument.