### PR TITLE
fix: portal suins fn failures

### DIFF
--- a/portal/common/lib/src/rpc_selector.ts
+++ b/portal/common/lib/src/rpc_selector.ts
@@ -43,6 +43,21 @@ class WrappedSuiClient extends SuiJsonRpcClient {
     }
 }
 
+/**
+ * Returns true if the error is an ObjectError with code "notExists" from the
+ * @mysten/sui SDK. This is thrown when the FN cleanly responds that an object
+ * doesn't exist (e.g. an unregistered SuiNS name's dynamic field).
+ *
+ * We use duck-typing because ObjectError is not exported from @mysten/sui.
+ */
+function isNotExistsError(error: unknown): boolean {
+    return (
+        typeof error === "object" &&
+        error !== null &&
+        (error as { code?: unknown }).code === "notExists"
+    );
+}
+
 export class RPCSelector implements RPCSelectorInterface {
     private executor: PriorityExecutor;
     private clients: Map<string, WrappedSuiClient>;
@@ -92,11 +107,15 @@ export class RPCSelector implements RPCSelectorInterface {
                     clearTimeout(timer!);
                 }
             } catch (error) {
+                const wrappedError = error instanceof Error ? error : new Error(String(error));
+                // ObjectError(notExists) means the FN authoritatively answered
+                // "this object does not exist" — retrying won't change the
+                // answer.
+                if (isNotExistsError(error)) {
+                    return { status: "stop", error: wrappedError };
+                }
                 logger.warn("RPC call failed", { url, error: formatError(error) });
-                return {
-                    status: "retry-same",
-                    error: error instanceof Error ? error : new Error(String(error)),
-                };
+                return { status: "retry-same", error: wrappedError };
             }
         });
     }
@@ -157,6 +176,22 @@ export class RPCSelector implements RPCSelectorInterface {
 
     public async getNameRecord(name: string): Promise<NameRecord | null> {
         logger.info("RPCSelector: getNameRecord", { name });
-        return this.invokeWithFailover((client) => client.getNameRecord(name));
+        try {
+            return await this.invokeWithFailover((client) => client.getNameRecord(name));
+        } catch (error) {
+            // The executor wraps the ObjectError in: AggregateError → Error
+            // ("stop from <url>", { cause: ObjectError }). Check the cause
+            // chain for the notExists code.
+            if (
+                error instanceof AggregateError &&
+                error.errors.some((e) =>
+                    isNotExistsError((e as Error & { cause?: unknown }).cause),
+                )
+            ) {
+                logger.info("SuiNS name not registered (FN responded notExists)", { name });
+                return null;
+            }
+            throw error;
+        }
     }
 }

--- a/portal/common/lib/src/rpc_selector.ts
+++ b/portal/common/lib/src/rpc_selector.ts
@@ -184,9 +184,7 @@ export class RPCSelector implements RPCSelectorInterface {
             // chain for the notExists code.
             if (
                 error instanceof AggregateError &&
-                error.errors.some((e) =>
-                    isNotExistsError((e as Error & { cause?: unknown }).cause),
-                )
+                error.errors.some((e) => isNotExistsError((e as Error & { cause?: unknown }).cause))
             ) {
                 logger.info("SuiNS name not registered (FN responded notExists)", { name });
                 return null;

--- a/portal/common/lib/src/url_fetcher.ts
+++ b/portal/common/lib/src/url_fetcher.ts
@@ -36,6 +36,39 @@ type AggregatorResult =
 export const QUILT_PATCH_ID_INTERNAL_HEADER = "x-wal-quilt-patch-internal-id";
 
 /**
+ * Returns true if the error chain contains evidence that the FN cleanly
+ * answered "object does not exist" — i.e. the SuiNS name is not registered.
+ *
+ * Rationale: SuiNS lookup uses `getDynamicField`, which derives the field's
+ * object id and fetches it. For an unregistered name, the FN responds with
+ * `error.code: "notExists"` (a healthy response). The @mysten/sui SDK turns
+ * that into `ObjectError(code: "notExists", "Object 0x... does not exist")`
+ * and throws. After the RPCSelector's failover machinery exhausts retries,
+ * that error ends up wrapped in an `AggregateError`, with each entry's
+ * `cause` carrying the original.
+ *
+ * Name registration is determinate on-chain state, so a single FN saying
+ * "notExists" is authoritative. We don't require *every* cause to be
+ * notExists, because secondary FNs in the priority list (public providers
+ * like blastapi/suiet) frequently return 403/502 due to rate limiting or
+ * auth, and those failures are unrelated to the answer to the lookup.
+ */
+function isUnregisteredSuiNsName(error: unknown): boolean {
+    const causes: unknown[] = [];
+    if (error instanceof AggregateError) {
+        for (const e of error.errors) {
+            causes.push((e as Error & { cause?: unknown }).cause ?? e);
+        }
+    } else {
+        causes.push(error);
+    }
+    return causes.some(
+        (c) =>
+            typeof c === "object" && c !== null && (c as { code?: unknown }).code === "notExists",
+    );
+}
+
+/**
  * Discriminated union returned by `fetchUrl`.
  *
  * Uses a `status` field as the discriminator, similar to Rust enums.
@@ -215,9 +248,22 @@ export class UrlFetcher {
                 subdomain: parsedUrl.subdomain,
             });
             return noObjectIdFound();
-        } catch {
+        } catch (error) {
+            // The @mysten/sui SDK's getDynamicField throws ObjectError(code:
+            // "notExists") when the FN cleanly answers "object does not exist"
+            // — which is exactly what happens for any unregistered <name>.sui
+            // (the dynamic field address is queried directly). That's a
+            // healthy FN response, not a connectivity failure, so it must not
+            // bump the FN-fail counter (which feeds our pager alert).
+            if (isUnregisteredSuiNsName(error)) {
+                logger.warn("SuiNS name is not registered (FN responded notExists)", {
+                    subdomain: parsedUrl.subdomain,
+                });
+                return noObjectIdFound();
+            }
             logger.error("Unable to reach the full node during suins domain resolution", {
                 subdomain: parsedUrl.subdomain,
+                error: formatError(error),
             });
             return fullNodeFail();
         }

--- a/portal/common/lib/src/url_fetcher.ts
+++ b/portal/common/lib/src/url_fetcher.ts
@@ -36,39 +36,6 @@ type AggregatorResult =
 export const QUILT_PATCH_ID_INTERNAL_HEADER = "x-wal-quilt-patch-internal-id";
 
 /**
- * Returns true if the error chain contains evidence that the FN cleanly
- * answered "object does not exist" — i.e. the SuiNS name is not registered.
- *
- * Rationale: SuiNS lookup uses `getDynamicField`, which derives the field's
- * object id and fetches it. For an unregistered name, the FN responds with
- * `error.code: "notExists"` (a healthy response). The @mysten/sui SDK turns
- * that into `ObjectError(code: "notExists", "Object 0x... does not exist")`
- * and throws. After the RPCSelector's failover machinery exhausts retries,
- * that error ends up wrapped in an `AggregateError`, with each entry's
- * `cause` carrying the original.
- *
- * Name registration is determinate on-chain state, so a single FN saying
- * "notExists" is authoritative. We don't require *every* cause to be
- * notExists, because secondary FNs in the priority list (public providers
- * like blastapi/suiet) frequently return 403/502 due to rate limiting or
- * auth, and those failures are unrelated to the answer to the lookup.
- */
-function isUnregisteredSuiNsName(error: unknown): boolean {
-    const causes: unknown[] = [];
-    if (error instanceof AggregateError) {
-        for (const e of error.errors) {
-            causes.push((e as Error & { cause?: unknown }).cause ?? e);
-        }
-    } else {
-        causes.push(error);
-    }
-    return causes.some(
-        (c) =>
-            typeof c === "object" && c !== null && (c as { code?: unknown }).code === "notExists",
-    );
-}
-
-/**
  * Discriminated union returned by `fetchUrl`.
  *
  * Uses a `status` field as the discriminator, similar to Rust enums.
@@ -249,18 +216,6 @@ export class UrlFetcher {
             });
             return noObjectIdFound();
         } catch (error) {
-            // The @mysten/sui SDK's getDynamicField throws ObjectError(code:
-            // "notExists") when the FN cleanly answers "object does not exist"
-            // — which is exactly what happens for any unregistered <name>.sui
-            // (the dynamic field address is queried directly). That's a
-            // healthy FN response, not a connectivity failure, so it must not
-            // bump the FN-fail counter (which feeds our pager alert).
-            if (isUnregisteredSuiNsName(error)) {
-                logger.warn("SuiNS name is not registered (FN responded notExists)", {
-                    subdomain: parsedUrl.subdomain,
-                });
-                return noObjectIdFound();
-            }
             logger.error("Unable to reach the full node during suins domain resolution", {
                 subdomain: parsedUrl.subdomain,
                 error: formatError(error),

--- a/portal/common/lib/tests/rpc_selector_get_name_record.test.ts
+++ b/portal/common/lib/tests/rpc_selector_get_name_record.test.ts
@@ -1,0 +1,136 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { RPCSelector } from "@lib/rpc_selector";
+import { PriorityExecutor, PriorityUrl } from "@lib/priority_executor";
+
+/**
+ * Tests that RPCSelector.getNameRecord handles ObjectError(notExists)
+ * correctly: returns null (no retries) instead of propagating the error.
+ *
+ * The @mysten/sui SDK throws ObjectError(code: "notExists") when the FN
+ * cleanly responds that a dynamic field doesn't exist — which is exactly
+ * what happens for any unregistered SuiNS name. This is an authoritative
+ * answer (name registration is determinate on-chain state), so the
+ * RPCSelector should stop immediately and return null.
+ */
+
+/** Mirrors @mysten/sui ObjectError shape (not publicly exported). */
+class ObjectErrorLike extends Error {
+    public code: string;
+    constructor(code: string, message: string) {
+        super(message);
+        this.code = code;
+        this.name = "ObjectError";
+    }
+}
+
+// We construct the RPCSelector via its public constructor, but need to
+// control what the underlying SuiNS client returns. We do this by
+// intercepting the SuinsClient.getNameRecord call at the network level.
+// Instead, we'll test at the PriorityExecutor integration level by
+// creating an RPCSelector with a real executor but mocked clients.
+
+describe("RPCSelector.getNameRecord — notExists handling", () => {
+    const urls: PriorityUrl[] = [
+        { url: "http://fn1.test", retries: 2, metric: 100 },
+        { url: "http://fn2.test", retries: 2, metric: 200 },
+    ];
+
+    it("returns null without retrying when FN responds notExists", async () => {
+        const notExistsError = new ObjectErrorLike(
+            "notExists",
+            "Object 0xdeadbeef does not exist",
+        );
+
+        // Track how many times the executor's callback is invoked to verify
+        // no retries happen.
+        let callCount = 0;
+
+        const executor = new PriorityExecutor(urls, 0);
+        const invokeSpy = vi.spyOn(executor, "invoke").mockImplementation(async (execute) => {
+            // Simulate what invokeWithFailover does: call execute for the
+            // first URL, which detects notExists and returns "stop".
+            callCount++;
+            const result = await execute(urls[0].url);
+            if (result.status === "stop") {
+                const wrapped = new Error(`stop from ${urls[0].url}`, { cause: result.error });
+                throw new AggregateError([wrapped], "Stopped");
+            }
+            return result.value;
+        });
+
+        // Build RPCSelector and replace its executor with our spy.
+        const rpcSelector = new RPCSelector(urls, "testnet");
+        (rpcSelector as unknown as { executor: PriorityExecutor }).executor = executor;
+
+        // The getNameRecord catch block should detect notExists and return null.
+        // But we need invokeWithFailover to actually run... Let's take a
+        // different approach: test the full flow by mocking fetch.
+        invokeSpy.mockRestore();
+
+        // More direct approach: mock the global fetch to simulate the FN
+        // throwing notExists. The SuinsClient uses the Sui JSON-RPC client
+        // which ultimately calls fetch.
+        const originalFetch = globalThis.fetch;
+        let fetchCallCount = 0;
+        globalThis.fetch = vi.fn().mockImplementation(async () => {
+            fetchCallCount++;
+            throw notExistsError;
+        });
+
+        try {
+            const result = await rpcSelector.getNameRecord("nonexistent.sui");
+            expect(result).toBeNull();
+            // Should NOT have retried — notExists triggers "stop" on first call.
+            expect(fetchCallCount).toBe(1);
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    it("retries on transient network errors", async () => {
+        const rpcSelector = new RPCSelector(urls, "testnet");
+
+        const originalFetch = globalThis.fetch;
+        let fetchCallCount = 0;
+        globalThis.fetch = vi.fn().mockImplementation(async () => {
+            fetchCallCount++;
+            throw new TypeError("fetch failed");
+        });
+
+        try {
+            await expect(rpcSelector.getNameRecord("anything.sui")).rejects.toThrow();
+            // Should have retried: 2 URLs × (1 initial + 2 retries) = 6 calls
+            expect(fetchCallCount).toBe(6);
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    it("does not retry when notExists is mixed with prior transient failures", async () => {
+        const rpcSelector = new RPCSelector(urls, "testnet");
+
+        const originalFetch = globalThis.fetch;
+        let fetchCallCount = 0;
+        globalThis.fetch = vi.fn().mockImplementation(async () => {
+            fetchCallCount++;
+            // First call: transient error (will trigger retry-same)
+            if (fetchCallCount === 1) {
+                throw new TypeError("fetch failed");
+            }
+            // Second call: notExists (should trigger stop)
+            throw new ObjectErrorLike("notExists", "Object 0xabc does not exist");
+        });
+
+        try {
+            const result = await rpcSelector.getNameRecord("test.sui");
+            expect(result).toBeNull();
+            // 1 transient failure + 1 notExists = 2 calls total (stopped on second)
+            expect(fetchCallCount).toBe(2);
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+});

--- a/portal/common/lib/tests/rpc_selector_get_name_record.test.ts
+++ b/portal/common/lib/tests/rpc_selector_get_name_record.test.ts
@@ -55,6 +55,9 @@ describe("RPCSelector.getNameRecord — notExists handling", () => {
                 const wrapped = new Error(`stop from ${urls[0].url}`, { cause: result.error });
                 throw new AggregateError([wrapped], "Stopped");
             }
+            if (result.status !== "success") {
+                throw new AggregateError([result.error ?? new Error(result.status)], "Retried");
+            }
             return result.value;
         });
 

--- a/portal/common/lib/tests/rpc_selector_get_name_record.test.ts
+++ b/portal/common/lib/tests/rpc_selector_get_name_record.test.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { RPCSelector } from "@lib/rpc_selector";
-import { PriorityExecutor, PriorityUrl } from "@lib/priority_executor";
+import { PriorityUrl } from "@lib/priority_executor";
 
 /**
  * Tests that RPCSelector.getNameRecord handles ObjectError(notExists)
@@ -26,12 +26,6 @@ class ObjectErrorLike extends Error {
     }
 }
 
-// We construct the RPCSelector via its public constructor, but need to
-// control what the underlying SuiNS client returns. We do this by
-// intercepting the SuinsClient.getNameRecord call at the network level.
-// Instead, we'll test at the PriorityExecutor integration level by
-// creating an RPCSelector with a real executor but mocked clients.
-
 describe("RPCSelector.getNameRecord — notExists handling", () => {
     const urls: PriorityUrl[] = [
         { url: "http://fn1.test", retries: 2, metric: 100 },
@@ -41,38 +35,8 @@ describe("RPCSelector.getNameRecord — notExists handling", () => {
     it("returns null without retrying when FN responds notExists", async () => {
         const notExistsError = new ObjectErrorLike("notExists", "Object 0xdeadbeef does not exist");
 
-        // Track how many times the executor's callback is invoked to verify
-        // no retries happen.
-        let callCount = 0;
-
-        const executor = new PriorityExecutor(urls, 0);
-        const invokeSpy = vi.spyOn(executor, "invoke").mockImplementation(async (execute) => {
-            // Simulate what invokeWithFailover does: call execute for the
-            // first URL, which detects notExists and returns "stop".
-            callCount++;
-            const result = await execute(urls[0].url);
-            if (result.status === "stop") {
-                const wrapped = new Error(`stop from ${urls[0].url}`, { cause: result.error });
-                throw new AggregateError([wrapped], "Stopped");
-            }
-            if (result.status !== "success") {
-                throw new AggregateError([result.error ?? new Error(result.status)], "Retried");
-            }
-            return result.value;
-        });
-
-        // Build RPCSelector and replace its executor with our spy.
         const rpcSelector = new RPCSelector(urls, "testnet");
-        (rpcSelector as unknown as { executor: PriorityExecutor }).executor = executor;
 
-        // The getNameRecord catch block should detect notExists and return null.
-        // But we need invokeWithFailover to actually run... Let's take a
-        // different approach: test the full flow by mocking fetch.
-        invokeSpy.mockRestore();
-
-        // More direct approach: mock the global fetch to simulate the FN
-        // throwing notExists. The SuinsClient uses the Sui JSON-RPC client
-        // which ultimately calls fetch.
         const originalFetch = globalThis.fetch;
         let fetchCallCount = 0;
         globalThis.fetch = vi.fn().mockImplementation(async () => {

--- a/portal/common/lib/tests/rpc_selector_get_name_record.test.ts
+++ b/portal/common/lib/tests/rpc_selector_get_name_record.test.ts
@@ -39,10 +39,7 @@ describe("RPCSelector.getNameRecord — notExists handling", () => {
     ];
 
     it("returns null without retrying when FN responds notExists", async () => {
-        const notExistsError = new ObjectErrorLike(
-            "notExists",
-            "Object 0xdeadbeef does not exist",
-        );
+        const notExistsError = new ObjectErrorLike("notExists", "Object 0xdeadbeef does not exist");
 
         // Track how many times the executor's callback is invoked to verify
         // no retries happen.

--- a/portal/common/lib/tests/suins_exception_shape.testnet.test.ts
+++ b/portal/common/lib/tests/suins_exception_shape.testnet.test.ts
@@ -6,56 +6,27 @@ import { RPCSelector } from "@lib/rpc_selector";
 import { parsePriorityUrlList } from "@lib/priority_executor";
 
 /**
- * Integration test — confirms what the @mysten/sui SDK actually throws when
- * a SuiNS name is not registered on testnet. The portal relies on this
- * exception shape to distinguish "name not registered" (healthy FN, just no
- * record) from "FN unreachable".
+ * Integration test — confirms that RPCSelector.getNameRecord returns null
+ * for an unregistered SuiNS name on real testnet, without retrying all FNs.
  *
  * Skipped unless RPC_URL_LIST is set (e.g. via .env.test). Hits real testnet
  * so it's a few seconds and may be flaky if all FNs in the priority list are
  * down at once.
  *
- * Real-world observation: the *primary* FN
- * (https://fullnode.testnet.sui.io) returns ObjectError(code: "notExists",
- * "Object 0x... does not exist"), which is the authoritative answer.
- * Secondary FNs (blastapi, suiet) frequently return SuiHTTPStatusError 403
- * or 502 because they're rate-limited or unauthenticated. The failover
- * machinery tries every URL anyway, so the AggregateError ends up containing
- * both kinds of cause. Our error-handling logic must treat the presence of
- * any "notExists" cause as proof that the name doesn't exist (since name
- * registration is determinate on-chain state).
+ * Before the fix, getNameRecord would throw an AggregateError after
+ * retrying every FN. Now it returns null on the first notExists response.
  */
 const rpcEnv = process.env.RPC_URL_LIST;
 
-describe.skipIf(!rpcEnv)("SuiNS exception shape on real testnet", () => {
+describe.skipIf(!rpcEnv)("SuiNS name resolution on real testnet", () => {
     const rpcSelector = new RPCSelector(parsePriorityUrlList(rpcEnv ?? ""), "testnet");
 
-    it("returns AggregateError whose causes include ObjectError(notExists) for an unregistered name", async () => {
+    it("returns null for an unregistered name", async () => {
         // A name we are confident is not registered. Random suffix avoids
         // collisions if someone happens to register it in the future.
-        const subdomain = `walrus-portal-test-nonexistent-${Date.now()}`;
+        const name = `walrus-portal-test-nonexistent-${Date.now()}.sui`;
 
-        let thrown: unknown;
-        try {
-            await rpcSelector.getNameRecord(`${subdomain}.sui`);
-        } catch (e) {
-            thrown = e;
-        }
-
-        expect(thrown).toBeInstanceOf(AggregateError);
-
-        const aggregate = thrown as AggregateError;
-        const causes = aggregate.errors.map((e: Error) => (e as Error & { cause?: unknown }).cause);
-
-        // At least one cause must be the ObjectError(notExists) thrown by
-        // the SDK when the FN cleanly answers "object does not exist". This
-        // is the marker our fix uses to discriminate name-not-found from
-        // real FN failure.
-        const notExistsCauses = causes.filter(
-            (c): c is Error & { code: string } =>
-                c instanceof Error && (c as Error & { code?: string }).code === "notExists",
-        );
-        expect(notExistsCauses.length).toBeGreaterThan(0);
-        expect(notExistsCauses[0].message).toMatch(/Object 0x[0-9a-f]+ does not exist/i);
+        const result = await rpcSelector.getNameRecord(name);
+        expect(result).toBeNull();
     }, 30_000);
 });

--- a/portal/common/lib/tests/suins_exception_shape.testnet.test.ts
+++ b/portal/common/lib/tests/suins_exception_shape.testnet.test.ts
@@ -1,0 +1,61 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { RPCSelector } from "@lib/rpc_selector";
+import { parsePriorityUrlList } from "@lib/priority_executor";
+
+/**
+ * Integration test — confirms what the @mysten/sui SDK actually throws when
+ * a SuiNS name is not registered on testnet. The portal relies on this
+ * exception shape to distinguish "name not registered" (healthy FN, just no
+ * record) from "FN unreachable".
+ *
+ * Skipped unless RPC_URL_LIST is set (e.g. via .env.test). Hits real testnet
+ * so it's a few seconds and may be flaky if all FNs in the priority list are
+ * down at once.
+ *
+ * Real-world observation: the *primary* FN
+ * (https://fullnode.testnet.sui.io) returns ObjectError(code: "notExists",
+ * "Object 0x... does not exist"), which is the authoritative answer.
+ * Secondary FNs (blastapi, suiet) frequently return SuiHTTPStatusError 403
+ * or 502 because they're rate-limited or unauthenticated. The failover
+ * machinery tries every URL anyway, so the AggregateError ends up containing
+ * both kinds of cause. Our error-handling logic must treat the presence of
+ * any "notExists" cause as proof that the name doesn't exist (since name
+ * registration is determinate on-chain state).
+ */
+const rpcEnv = process.env.RPC_URL_LIST;
+
+describe.skipIf(!rpcEnv)("SuiNS exception shape on real testnet", () => {
+    const rpcSelector = new RPCSelector(parsePriorityUrlList(rpcEnv ?? ""), "testnet");
+
+    it("returns AggregateError whose causes include ObjectError(notExists) for an unregistered name", async () => {
+        // A name we are confident is not registered. Random suffix avoids
+        // collisions if someone happens to register it in the future.
+        const subdomain = `walrus-portal-test-nonexistent-${Date.now()}`;
+
+        let thrown: unknown;
+        try {
+            await rpcSelector.getNameRecord(`${subdomain}.sui`);
+        } catch (e) {
+            thrown = e;
+        }
+
+        expect(thrown).toBeInstanceOf(AggregateError);
+
+        const aggregate = thrown as AggregateError;
+        const causes = aggregate.errors.map((e: Error) => (e as Error & { cause?: unknown }).cause);
+
+        // At least one cause must be the ObjectError(notExists) thrown by
+        // the SDK when the FN cleanly answers "object does not exist". This
+        // is the marker our fix uses to discriminate name-not-found from
+        // real FN failure.
+        const notExistsCauses = causes.filter(
+            (c): c is Error & { code: string } =>
+                c instanceof Error && (c as Error & { code?: string }).code === "notExists",
+        );
+        expect(notExistsCauses.length).toBeGreaterThan(0);
+        expect(notExistsCauses[0].message).toMatch(/Object 0x[0-9a-f]+ does not exist/i);
+    }, 30_000);
+});

--- a/portal/common/lib/tests/url_fetcher_resolve_object_id.test.ts
+++ b/portal/common/lib/tests/url_fetcher_resolve_object_id.test.ts
@@ -1,0 +1,189 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the instrumentation singleton so we can spy on counter bumps without
+// binding to the Prometheus port.
+vi.mock("@lib/instrumentation", () => ({
+    instrumentationFacade: {
+        bumpFullNodeFailRequests: vi.fn(),
+        bumpAggregatorFailRequests: vi.fn(),
+        bumpBlobUnavailableRequests: vi.fn(),
+        bumpNoObjectIdFoundRequests: vi.fn(),
+        bumpGenericErrors: vi.fn(),
+        bumpSiteNotFoundRequests: vi.fn(),
+        bumpBlockedRequests: vi.fn(),
+        increaseRequestsMade: vi.fn(),
+        recordResolveSuiNsAddressTime: vi.fn(),
+        recordResolveDomainAndFetchUrlResponseTime: vi.fn(),
+        recordAggregatorTime: vi.fn(),
+        recordResourceNotFoundRequests: vi.fn(),
+        recordHashMismatchRequests: vi.fn(),
+        recordFetchRoutesAndRedirectsFieldObjectsTime: vi.fn(),
+        recordRoutesAndRedirectsResolutionTime: vi.fn(),
+        recordFullNodeFailRequests: vi.fn(),
+    },
+}));
+
+import { UrlFetcher } from "@lib/url_fetcher";
+import { ResourceFetcher } from "@lib/resource";
+import { SuiNSResolver } from "@lib/suins";
+import { WalrusSitesRouter } from "@lib/routing";
+import { PriorityExecutor } from "@lib/priority_executor";
+import { instrumentationFacade } from "@lib/instrumentation";
+import { HttpStatusCodes } from "@lib/http/http_status_codes";
+
+/**
+ * The portal's `resolveObjectId` is supposed to bump
+ * `ws_num_full_node_fail_counter` only when the Sui full node is genuinely
+ * unreachable. In production we observe that the same counter is also being
+ * bumped when a SuiNS subdomain is simply not registered: the FN responds
+ * healthily with `error.code: "notExists"` for the dynamic field lookup, but
+ * the @mysten/sui SDK turns that response into a thrown `ObjectError("Object
+ * <id> does not exist")`. The portal's catch-all then treats this exception
+ * the same as a real connectivity failure.
+ *
+ * These tests capture the desired behaviour:
+ *   - A real connectivity failure (network error, timeout) → 503 + counter
+ *     bumped.
+ *   - A "name not registered" exception (`notExists` from the FN) → 404 (the
+ *     same response we already return when `getNameRecord` resolves to null)
+ *     and the counter is NOT bumped.
+ *
+ * The second test starts as RED on `main` and turns GREEN after the fix.
+ */
+describe("UrlFetcher.resolveObjectId — counter discrimination", () => {
+    let suinsResolver: SuiNSResolver;
+    let urlFetcher: UrlFetcher;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        suinsResolver = {
+            hardcodedSubdomains: vi.fn().mockReturnValue(null),
+            resolveSuiNsAddress: vi.fn(),
+        } as unknown as SuiNSResolver;
+
+        urlFetcher = new UrlFetcher(
+            {} as ResourceFetcher,
+            suinsResolver,
+            {} as WalrusSitesRouter,
+            new PriorityExecutor([{ url: "http://localhost:1", retries: 0, metric: 100 }]),
+            // b36 resolution disabled so we always hit the SuiNS branch.
+            false,
+        );
+    });
+
+    /**
+     * Builds the kind of `AggregateError` that bubbles up to `resolveObjectId`
+     * after `RPCSelector.invokeWithFailover` exhausts retries. Each entry in
+     * `errors[]` wraps the original underlying error as `cause` (see
+     * priority_executor.ts).
+     */
+    function buildAggregateAfterFailover(causes: unknown[]): AggregateError {
+        const wrapped = causes.map(
+            (cause, i) =>
+                new Error(`retry-same from http://localhost:1 (attempt ${i + 1})`, { cause }),
+        );
+        return new AggregateError(wrapped, "All URLs exhausted");
+    }
+
+    /** Mirrors @mysten/sui ObjectError shape (we don't import it because the
+     * package doesn't re-export it from the public entry point). */
+    class ObjectErrorLike extends Error {
+        public code: string;
+        constructor(code: string, message: string) {
+            super(message);
+            this.code = code;
+            this.name = "ObjectError";
+        }
+    }
+
+    it("returns 503 and bumps FN-fail counter on a real network failure", async () => {
+        const networkErr = new TypeError("fetch failed");
+        // simulate an undici-style cause chain
+        (networkErr as Error & { cause?: unknown }).cause = Object.assign(
+            new Error("ECONNREFUSED"),
+            {
+                code: "ECONNREFUSED",
+            },
+        );
+
+        (suinsResolver.resolveSuiNsAddress as ReturnType<typeof vi.fn>).mockRejectedValue(
+            buildAggregateAfterFailover([networkErr]),
+        );
+
+        const result = await urlFetcher.resolveObjectId({ subdomain: "anything", path: "/" });
+
+        expect(result).toBeInstanceOf(Response);
+        expect((result as Response).status).toBe(HttpStatusCodes.SERVICE_UNAVAILABLE);
+        expect(instrumentationFacade.bumpFullNodeFailRequests).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns 503 and bumps FN-fail counter on a request timeout", async () => {
+        const timeoutErr = new Error("Request timed out");
+
+        (suinsResolver.resolveSuiNsAddress as ReturnType<typeof vi.fn>).mockRejectedValue(
+            buildAggregateAfterFailover([timeoutErr]),
+        );
+
+        const result = await urlFetcher.resolveObjectId({ subdomain: "anything", path: "/" });
+
+        expect((result as Response).status).toBe(HttpStatusCodes.SERVICE_UNAVAILABLE);
+        expect(instrumentationFacade.bumpFullNodeFailRequests).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns 404 and does NOT bump FN-fail counter when the SuiNS name is not registered", async () => {
+        // This is what @mysten/sui's getDynamicField → getObjects throws when
+        // the FN cleanly answers "this object does not exist" (which is what
+        // happens for any unregistered <name>.sui — the dynamic field's
+        // address is queried directly).
+        const objectErr = new ObjectErrorLike(
+            "notExists",
+            "Object 0x5f181e7e58e6f8f9c3a1c6e5d4b9e2a8d3f7c1b2a3e4d5c6b7a8f9e0d1c2b3a4 does not exist",
+        );
+
+        (suinsResolver.resolveSuiNsAddress as ReturnType<typeof vi.fn>).mockRejectedValue(
+            buildAggregateAfterFailover([objectErr]),
+        );
+
+        const result = await urlFetcher.resolveObjectId({
+            subdomain: "definitely-not-registered-xyz",
+            path: "/",
+        });
+
+        expect((result as Response).status).toBe(HttpStatusCodes.NOT_FOUND);
+        // The crux: this counter must NOT increment, otherwise our alert fires
+        // for unregistered-name lookups even though the FN is healthy.
+        expect(instrumentationFacade.bumpFullNodeFailRequests).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 when the AggregateError mixes notExists with secondary-FN errors", async () => {
+        // Real-world shape observed against testnet: the primary FN cleanly
+        // returns notExists (the authoritative answer — name registration is
+        // determinate on-chain state) but failover keeps going and the
+        // secondary FNs (blastapi, suiet, etc.) often return 403/502 because
+        // they're rate-limited or unauthenticated. We must not let those
+        // unrelated failures inflate the FN-fail counter when we have proof
+        // the name doesn't exist.
+        const objectErr = new ObjectErrorLike("notExists", "Object 0xdeadbeef does not exist");
+        const httpErr = Object.assign(new Error("Unexpected status code: 403"), {
+            status: 403,
+            statusText: "Forbidden",
+        });
+        const httpErr2 = Object.assign(new Error("Unexpected status code: 502"), {
+            status: 502,
+            statusText: "Bad Gateway",
+        });
+
+        (suinsResolver.resolveSuiNsAddress as ReturnType<typeof vi.fn>).mockRejectedValue(
+            buildAggregateAfterFailover([objectErr, httpErr, httpErr2]),
+        );
+
+        const result = await urlFetcher.resolveObjectId({ subdomain: "mixed", path: "/" });
+
+        expect((result as Response).status).toBe(HttpStatusCodes.NOT_FOUND);
+        expect(instrumentationFacade.bumpFullNodeFailRequests).not.toHaveBeenCalled();
+    });
+});

--- a/portal/common/lib/tests/url_fetcher_resolve_object_id.test.ts
+++ b/portal/common/lib/tests/url_fetcher_resolve_object_id.test.ts
@@ -35,25 +35,14 @@ import { instrumentationFacade } from "@lib/instrumentation";
 import { HttpStatusCodes } from "@lib/http/http_status_codes";
 
 /**
- * The portal's `resolveObjectId` is supposed to bump
- * `ws_num_full_node_fail_counter` only when the Sui full node is genuinely
- * unreachable. In production we observe that the same counter is also being
- * bumped when a SuiNS subdomain is simply not registered: the FN responds
- * healthily with `error.code: "notExists"` for the dynamic field lookup, but
- * the @mysten/sui SDK turns that response into a thrown `ObjectError("Object
- * <id> does not exist")`. The portal's catch-all then treats this exception
- * the same as a real connectivity failure.
+ * Tests that `resolveObjectId` only bumps `ws_num_full_node_fail_counter`
+ * for genuine FN connectivity failures.
  *
- * These tests capture the desired behaviour:
- *   - A real connectivity failure (network error, timeout) → 503 + counter
- *     bumped.
- *   - A "name not registered" exception (`notExists` from the FN) → 404 (the
- *     same response we already return when `getNameRecord` resolves to null)
- *     and the counter is NOT bumped.
- *
- * The second test starts as RED on `main` and turns GREEN after the fix.
+ * Unregistered SuiNS names are now handled at the RPCSelector level
+ * (getNameRecord returns null), so they never reach the catch block here.
+ * See rpc_selector_get_name_record.test.ts for the notExists tests.
  */
-describe("UrlFetcher.resolveObjectId — counter discrimination", () => {
+describe("UrlFetcher.resolveObjectId — FN-fail counter", () => {
     let suinsResolver: SuiNSResolver;
     let urlFetcher: UrlFetcher;
 
@@ -75,43 +64,9 @@ describe("UrlFetcher.resolveObjectId — counter discrimination", () => {
         );
     });
 
-    /**
-     * Builds the kind of `AggregateError` that bubbles up to `resolveObjectId`
-     * after `RPCSelector.invokeWithFailover` exhausts retries. Each entry in
-     * `errors[]` wraps the original underlying error as `cause` (see
-     * priority_executor.ts).
-     */
-    function buildAggregateAfterFailover(causes: unknown[]): AggregateError {
-        const wrapped = causes.map(
-            (cause, i) =>
-                new Error(`retry-same from http://localhost:1 (attempt ${i + 1})`, { cause }),
-        );
-        return new AggregateError(wrapped, "All URLs exhausted");
-    }
-
-    /** Mirrors @mysten/sui ObjectError shape (we don't import it because the
-     * package doesn't re-export it from the public entry point). */
-    class ObjectErrorLike extends Error {
-        public code: string;
-        constructor(code: string, message: string) {
-            super(message);
-            this.code = code;
-            this.name = "ObjectError";
-        }
-    }
-
     it("returns 503 and bumps FN-fail counter on a real network failure", async () => {
-        const networkErr = new TypeError("fetch failed");
-        // simulate an undici-style cause chain
-        (networkErr as Error & { cause?: unknown }).cause = Object.assign(
-            new Error("ECONNREFUSED"),
-            {
-                code: "ECONNREFUSED",
-            },
-        );
-
         (suinsResolver.resolveSuiNsAddress as ReturnType<typeof vi.fn>).mockRejectedValue(
-            buildAggregateAfterFailover([networkErr]),
+            new TypeError("fetch failed"),
         );
 
         const result = await urlFetcher.resolveObjectId({ subdomain: "anything", path: "/" });
@@ -122,10 +77,8 @@ describe("UrlFetcher.resolveObjectId — counter discrimination", () => {
     });
 
     it("returns 503 and bumps FN-fail counter on a request timeout", async () => {
-        const timeoutErr = new Error("Request timed out");
-
         (suinsResolver.resolveSuiNsAddress as ReturnType<typeof vi.fn>).mockRejectedValue(
-            buildAggregateAfterFailover([timeoutErr]),
+            new Error("Request timed out"),
         );
 
         const result = await urlFetcher.resolveObjectId({ subdomain: "anything", path: "/" });
@@ -134,54 +87,15 @@ describe("UrlFetcher.resolveObjectId — counter discrimination", () => {
         expect(instrumentationFacade.bumpFullNodeFailRequests).toHaveBeenCalledTimes(1);
     });
 
-    it("returns 404 and does NOT bump FN-fail counter when the SuiNS name is not registered", async () => {
-        // This is what @mysten/sui's getDynamicField → getObjects throws when
-        // the FN cleanly answers "this object does not exist" (which is what
-        // happens for any unregistered <name>.sui — the dynamic field's
-        // address is queried directly).
-        const objectErr = new ObjectErrorLike(
-            "notExists",
-            "Object 0x5f181e7e58e6f8f9c3a1c6e5d4b9e2a8d3f7c1b2a3e4d5c6b7a8f9e0d1c2b3a4 does not exist",
-        );
-
-        (suinsResolver.resolveSuiNsAddress as ReturnType<typeof vi.fn>).mockRejectedValue(
-            buildAggregateAfterFailover([objectErr]),
-        );
+    it("returns 404 and does NOT bump FN-fail counter when SuiNS name is not registered", async () => {
+        // After the fix, getNameRecord returns null for unregistered names,
+        // so resolveSuiNsAddress returns null — no throw, no catch block.
+        (suinsResolver.resolveSuiNsAddress as ReturnType<typeof vi.fn>).mockResolvedValue(null);
 
         const result = await urlFetcher.resolveObjectId({
             subdomain: "definitely-not-registered-xyz",
             path: "/",
         });
-
-        expect((result as Response).status).toBe(HttpStatusCodes.NOT_FOUND);
-        // The crux: this counter must NOT increment, otherwise our alert fires
-        // for unregistered-name lookups even though the FN is healthy.
-        expect(instrumentationFacade.bumpFullNodeFailRequests).not.toHaveBeenCalled();
-    });
-
-    it("returns 404 when the AggregateError mixes notExists with secondary-FN errors", async () => {
-        // Real-world shape observed against testnet: the primary FN cleanly
-        // returns notExists (the authoritative answer — name registration is
-        // determinate on-chain state) but failover keeps going and the
-        // secondary FNs (blastapi, suiet, etc.) often return 403/502 because
-        // they're rate-limited or unauthenticated. We must not let those
-        // unrelated failures inflate the FN-fail counter when we have proof
-        // the name doesn't exist.
-        const objectErr = new ObjectErrorLike("notExists", "Object 0xdeadbeef does not exist");
-        const httpErr = Object.assign(new Error("Unexpected status code: 403"), {
-            status: 403,
-            statusText: "Forbidden",
-        });
-        const httpErr2 = Object.assign(new Error("Unexpected status code: 502"), {
-            status: 502,
-            statusText: "Bad Gateway",
-        });
-
-        (suinsResolver.resolveSuiNsAddress as ReturnType<typeof vi.fn>).mockRejectedValue(
-            buildAggregateAfterFailover([objectErr, httpErr, httpErr2]),
-        );
-
-        const result = await urlFetcher.resolveObjectId({ subdomain: "mixed", path: "/" });
 
         expect((result as Response).status).toBe(HttpStatusCodes.NOT_FOUND);
         expect(instrumentationFacade.bumpFullNodeFailRequests).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

The portal's FN-failure metric was getting bumped every time someone visited a URL with an unregistered SuiNS name. The `@mysten/sui` SDK throws an `ObjectError` with `code: "notExists"` when the FN authoritatively answers "this dynamic field does not exist" — that's a clean negative response, not an FN failure, but the `RPCSelector` was treating it as a transient error and retrying across all configured RPCs before bubbling up.

This PR teaches `RPCSelector` to recognize `notExists` and short-circuit:

- `rpc_selector.ts`: add `isNotExistsError` duck-type check (the SDK doesn't export `ObjectError`). In `invokeWithFailover`, return `status: "stop"` on `notExists` so we don't retry across RPCs. In `getNameRecord`, unwrap the resulting `AggregateError` and return `null` — the documented "name not registered" signal — instead of throwing.
- `url_fetcher.ts`: include the actual error in the log line when SuiNS resolution fails, so the next debugging pass isn't blind.

Tests cover both the RPC-selector path (`rpc_selector_get_name_record.test.ts`), the URL-fetcher path (`url_fetcher_resolve_object_id.test.ts`), and pin the SDK's exception shape against testnet (`suins_exception_shape.testnet.test.ts`) so we get a loud failure if `@mysten/sui` changes the error type.

## Test plan

- [x] `bun -F common test` passes
- [ ] Verify on a deployed portal that hitting an unregistered SuiNS name no longer increments the FN-failure counter
- [ ] Verify a real FN outage still increments the counter