### PR TITLE
chore: Bump version to 2.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9401,7 +9401,7 @@ checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "site-builder"
-version = "2.10.0"
+version = "2.11.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["site-builder"]
 
 [workspace.package]
-version = "2.10.0"
+version = "2.11.0"
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/portal/bun.lock
+++ b/portal/bun.lock
@@ -38,7 +38,7 @@
     },
     "server": {
       "name": "server",
-      "version": "2.10.0",
+      "version": "2.11.0",
       "dependencies": {
         "@logtape/logtape": "^0.11.0",
         "@vercel/edge-config": "^1.4.0",
@@ -62,7 +62,7 @@
     },
     "worker": {
       "name": "worker",
-      "version": "2.10.0",
+      "version": "2.11.0",
       "dependencies": {
         "@mysten/sui": "^2.20.1",
         "buffer": "^6.0.3",

--- a/portal/server/package.json
+++ b/portal/server/package.json
@@ -1,7 +1,7 @@
 {
     "name": "server",
     "description": "The server based implementation of the Walrus Sites portal.",
-    "version": "2.10.0",
+    "version": "2.11.0",
     "private": true,
     "scripts": {
         "start": "bun --hot run index.ts",

--- a/portal/worker/package.json
+++ b/portal/worker/package.json
@@ -1,7 +1,7 @@
 {
     "name": "worker",
     "description": "The service-worker based implementation of the Walrus Sites portal.",
-    "version": "2.10.0",
+    "version": "2.11.0",
     "dependencies": {
         "@mysten/sui": "^2.20.1",
         "buffer": "^6.0.3",

--- a/site-builder/Cargo.toml
+++ b/site-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "site-builder"
-version = "2.10.0"
+version = "2.11.0"
 edition = "2021"
 license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,7 @@ sonar.organization=mystenlabs
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=walrus-sites
-sonar.projectVersion=2.10.0
+sonar.projectVersion=2.11.0
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=portal/common/lib/src,site-builder/src


### PR DESCRIPTION
Version bump for the v2.11.0 release (SEW-1005).

- Bump version to 2.11.0 in Cargo.toml, site-builder/Cargo.toml, portal/server/package.json, portal/worker/package.json, sonar-project.properties
- Regenerate Cargo.lock and portal/bun.lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)