### PR TITLE
fix(ci): read the release tag from the event payload

### DIFF
--- a/.github/workflows/attach-binaries-to-release.yml
+++ b/.github/workflows/attach-binaries-to-release.yml
@@ -1,5 +1,5 @@
 name: Attach Walrus Sites binaries to a release
-run-name: Attach Walrus Sites binaries to a ${{ github.event.inputs.site-builder-tag || github.ref_name }} release
+run-name: Attach Walrus Sites binaries to a ${{ github.event.inputs.site-builder-tag || github.event.release.tag_name || github.ref_name }} release
 
 on:
   release:
@@ -14,7 +14,7 @@ on:
 concurrency: ${{ github.workflow }}-${{ inputs.site-builder-tag || github.ref }}
 
 env:
-  TAG_NAME: "${{ github.event.inputs.site-builder-tag || github.ref_name }}"
+  TAG_NAME: "${{ github.event.inputs.site-builder-tag || github.event.release.tag_name || github.ref_name }}"
   CARGO_TERM_COLOR: always
   # Disable incremental compilation.
   #
@@ -60,6 +60,7 @@ jobs:
         id: validate_tag_name
         run: |
           export site_builder_tag=$(echo ${{ env.TAG_NAME }} | sed s/'refs\/tags\/'//)
+          [[ -z "${site_builder_tag}" ]] && echo "tag cannot be empty" && exit 1
           [[ "${site_builder_tag}" == "main" ]] && echo "tag cannot be equals to 'main'" && exit 1
           echo "site-builder-tag=${site_builder_tag}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
The mainnet-v2.11.0 release run of `attach-binaries-to-release.yml` failed with `GitHub Releases requires a tag`: the `release: created` event fired before the tag ref existed, so `github.ref_name` was empty and every job built binaries it could not attach.

- fall back to `github.event.release.tag_name` before `github.ref_name` — the payload always carries the tag, regardless of ref-creation timing
- fail fast in the validate step when the resolved tag is empty, instead of building for 30+ minutes and failing at the attach step

🤖 Generated with [Claude Code](https://claude.com/claude-code)