### PR TITLE
fix(site-builder): migrate off JSON-RPC-only client methods and bump walrus deps to testnet-v1.51.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1562,8 +1562,8 @@ dependencies = [
 
 [[package]]
 name = "checkpoint-downloader"
-version = "1.51.1"
-source = "git+https://github.com/MystenLabs/walrus?tag=testnet-v1.51.1#01ada87c9f40e8bde9ad81861a8fbe6b20878361"
+version = "1.51.2"
+source = "git+https://github.com/MystenLabs/walrus?tag=testnet-v1.51.2#7741b19a32941912f0a46ac34bf6b05ede86f3c3"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1579,7 +1579,7 @@ dependencies = [
  "tokio",
  "tokio-util 0.7.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
- "typed-store 1.51.1",
+ "typed-store 1.51.2",
  "walrus-sui",
  "walrus-utils",
 ]
@@ -12712,8 +12712,8 @@ dependencies = [
 
 [[package]]
 name = "typed-store"
-version = "1.51.1"
-source = "git+https://github.com/MystenLabs/walrus?tag=testnet-v1.51.1#01ada87c9f40e8bde9ad81861a8fbe6b20878361"
+version = "1.51.2"
+source = "git+https://github.com/MystenLabs/walrus?tag=testnet-v1.51.2#7741b19a32941912f0a46ac34bf6b05ede86f3c3"
 dependencies = [
  "async-trait",
  "bcs",
@@ -13058,8 +13058,8 @@ dependencies = [
 
 [[package]]
 name = "walrus-core"
-version = "1.51.1"
-source = "git+https://github.com/MystenLabs/walrus?tag=testnet-v1.51.1#01ada87c9f40e8bde9ad81861a8fbe6b20878361"
+version = "1.51.2"
+source = "git+https://github.com/MystenLabs/walrus?tag=testnet-v1.51.2#7741b19a32941912f0a46ac34bf6b05ede86f3c3"
 dependencies = [
  "base64 0.22.1",
  "bcs",
@@ -13080,8 +13080,8 @@ dependencies = [
 
 [[package]]
 name = "walrus-proc-macros"
-version = "1.51.1"
-source = "git+https://github.com/MystenLabs/walrus?tag=testnet-v1.51.1#01ada87c9f40e8bde9ad81861a8fbe6b20878361"
+version = "1.51.2"
+source = "git+https://github.com/MystenLabs/walrus?tag=testnet-v1.51.2#7741b19a32941912f0a46ac34bf6b05ede86f3c3"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -13091,8 +13091,8 @@ dependencies = [
 
 [[package]]
 name = "walrus-sdk"
-version = "1.51.1"
-source = "git+https://github.com/MystenLabs/walrus?tag=testnet-v1.51.1#01ada87c9f40e8bde9ad81861a8fbe6b20878361"
+version = "1.51.2"
+source = "git+https://github.com/MystenLabs/walrus?tag=testnet-v1.51.2#7741b19a32941912f0a46ac34bf6b05ede86f3c3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -13137,8 +13137,8 @@ dependencies = [
 
 [[package]]
 name = "walrus-service"
-version = "1.51.1"
-source = "git+https://github.com/MystenLabs/walrus?tag=testnet-v1.51.1#01ada87c9f40e8bde9ad81861a8fbe6b20878361"
+version = "1.51.2"
+source = "git+https://github.com/MystenLabs/walrus?tag=testnet-v1.51.2#7741b19a32941912f0a46ac34bf6b05ede86f3c3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13226,7 +13226,7 @@ dependencies = [
  "tracing-opentelemetry 0.32.1",
  "tracing-subscriber",
  "twox-hash 2.1.2",
- "typed-store 1.51.1",
+ "typed-store 1.51.2",
  "utoipa",
  "utoipa-redoc",
  "uuid",
@@ -13243,8 +13243,8 @@ dependencies = [
 
 [[package]]
 name = "walrus-storage-node-client"
-version = "1.51.1"
-source = "git+https://github.com/MystenLabs/walrus?tag=testnet-v1.51.1#01ada87c9f40e8bde9ad81861a8fbe6b20878361"
+version = "1.51.2"
+source = "git+https://github.com/MystenLabs/walrus?tag=testnet-v1.51.2#7741b19a32941912f0a46ac34bf6b05ede86f3c3"
 dependencies = [
  "bcs",
  "bytes",
@@ -13278,8 +13278,8 @@ dependencies = [
 
 [[package]]
 name = "walrus-sui"
-version = "1.51.1"
-source = "git+https://github.com/MystenLabs/walrus?tag=testnet-v1.51.1#01ada87c9f40e8bde9ad81861a8fbe6b20878361"
+version = "1.51.2"
+source = "git+https://github.com/MystenLabs/walrus?tag=testnet-v1.51.2#7741b19a32941912f0a46ac34bf6b05ede86f3c3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13340,8 +13340,8 @@ dependencies = [
 
 [[package]]
 name = "walrus-test-utils"
-version = "1.51.1"
-source = "git+https://github.com/MystenLabs/walrus?tag=testnet-v1.51.1#01ada87c9f40e8bde9ad81861a8fbe6b20878361"
+version = "1.51.2"
+source = "git+https://github.com/MystenLabs/walrus?tag=testnet-v1.51.2#7741b19a32941912f0a46ac34bf6b05ede86f3c3"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -13354,8 +13354,8 @@ dependencies = [
 
 [[package]]
 name = "walrus-utils"
-version = "1.51.1"
-source = "git+https://github.com/MystenLabs/walrus?tag=testnet-v1.51.1#01ada87c9f40e8bde9ad81861a8fbe6b20878361"
+version = "1.51.2"
+source = "git+https://github.com/MystenLabs/walrus?tag=testnet-v1.51.2#7741b19a32941912f0a46ac34bf6b05ede86f3c3"
 dependencies = [
  "anyhow",
  "bytes",

--- a/site-builder/Cargo.toml
+++ b/site-builder/Cargo.toml
@@ -51,9 +51,9 @@ tonic = { version = "0.14.6", default-features = false }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 # TODO: change to v1.50 when ready; pinned for walrus#3389 (owner/version/digest on ObjectChangeEntry).
-walrus-sdk = { git = "https://github.com/MystenLabs/walrus", tag = "testnet-v1.51.1" }
-walrus-sui = { git = "https://github.com/MystenLabs/walrus", tag = "testnet-v1.51.1" }
-walrus-utils = { git = "https://github.com/MystenLabs/walrus", tag = "testnet-v1.51.1" }
+walrus-sdk = { git = "https://github.com/MystenLabs/walrus", tag = "testnet-v1.51.2" }
+walrus-sui = { git = "https://github.com/MystenLabs/walrus", tag = "testnet-v1.51.2" }
+walrus-utils = { git = "https://github.com/MystenLabs/walrus", tag = "testnet-v1.51.2" }
 
 [dev-dependencies]
 gag = "1.0.0"
@@ -62,7 +62,7 @@ sui-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.74.0
 sui-move-build = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.74.0" }
 tempfile = "3.20.0"
 test-cluster = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.74.0" }
-walrus-service = { git = "https://github.com/MystenLabs/walrus", tag = "testnet-v1.51.1", features = [
+walrus-service = { git = "https://github.com/MystenLabs/walrus", tag = "testnet-v1.51.2", features = [
   "test-utils",
 ] }
-walrus-test-utils = { git = "https://github.com/MystenLabs/walrus", tag = "testnet-v1.51.1" }
+walrus-test-utils = { git = "https://github.com/MystenLabs/walrus", tag = "testnet-v1.51.2" }

--- a/site-builder/src/site.rs
+++ b/site-builder/src/site.rs
@@ -12,7 +12,6 @@ pub mod resource;
 
 use anyhow::{Context, Result};
 use resource::{ResourceSet, SiteOps};
-use sui_sdk::rpc_types::SuiObjectDataOptions;
 use sui_types::{base_types::ObjectID, dynamic_field::derive_dynamic_field_id, TypeTag};
 use walrus_sui::{contracts::TypeOriginMap, dynamic_field_info::DynamicFieldInfo};
 use walrus_utils::http::bytes::Bytes;
@@ -221,30 +220,19 @@ impl RemoteSiteFactory<'_> {
 
         tracing::info!(
             count = resource_df_ids.len(),
-            "fetching resource dynamic fields via multi_get"
+            "fetching resource dynamic fields via batched object gets"
         );
 
-        let responses = self
-            .sui_client
-            .multi_get_object_with_options_batched(
-                &resource_df_ids,
-                SuiObjectDataOptions::new().with_bcs().with_type(),
-            )
-            .await?;
+        let resource_dfs: Vec<ResourceDynamicField> =
+            self.sui_client.get_sui_objects(&resource_df_ids).await?;
 
         let mut resources = ResourceSet::empty();
-        resources.extend(
-            responses
-                .iter()
-                .map(|resp| {
-                    contracts::get_sui_object_from_object_response::<ResourceDynamicField>(resp)
-                        .map(|df| df.value)
-                })
-                .collect::<Result<Vec<_>>>()?,
-        );
+        resources.extend(resource_dfs.into_iter().map(|df| df.value));
 
         tracing::debug!("fetching the routes and redirects from the dynamic fields");
-        let (routes, redirects) = self.get_routes_and_redirects(site_id).await?;
+        let (routes, redirects) = self
+            .get_routes_and_redirects(site_id, &dynamic_fields)
+            .await?;
 
         Ok(SiteData {
             resources,
@@ -255,11 +243,16 @@ impl RemoteSiteFactory<'_> {
         })
     }
 
-    /// Fetches routes and redirects by deriving their DF object IDs from the known keys
-    /// and batch-fetching them in a single RPC call.
+    /// Fetches routes and redirects by deriving their DF object IDs from the known keys,
+    /// checking their existence against the site's dynamic field listing, and fetching each
+    /// existing field.
+    ///
+    /// The existence check uses the already-fetched `dynamic_fields` so that a missing routes or
+    /// redirects field results in `None` without relying on per-object not-found errors.
     async fn get_routes_and_redirects(
         &self,
         site_id: ObjectID,
+        dynamic_fields: &[DynamicFieldInfo],
     ) -> Result<(Option<Routes>, Option<Redirects>)> {
         let vec_u8_tag = TypeTag::Vector(Box::new(TypeTag::U8));
 
@@ -274,37 +267,23 @@ impl RemoteSiteFactory<'_> {
             &bcs::to_bytes(&REDIRECTS_DF_KEY.to_vec())?,
         )?;
 
-        // Batch-fetch both in a single RPC call.
-        let responses = self
-            .sui_client
-            .multi_get_object_with_options(
-                &[routes_df_id, redirects_df_id],
-                SuiObjectDataOptions::new().with_bcs().with_type(),
-            )
-            .await?;
+        let df_exists = |id: ObjectID| dynamic_fields.iter().any(|field| field.field_id == id);
 
-        let routes = responses[0]
-            .data
-            .as_ref()
-            .map(|_| {
-                contracts::get_sui_object_from_object_response::<SuiDynamicField<Vec<u8>, Routes>>(
-                    &responses[0],
-                )
-            })
-            .transpose()?
-            .map(|df| df.value);
+        let routes = if df_exists(routes_df_id) {
+            let field: SuiDynamicField<Vec<u8>, Routes> =
+                self.sui_client.get_sui_object(routes_df_id).await?;
+            Some(field.value)
+        } else {
+            None
+        };
 
-        let redirects =
-            responses[1]
-                .data
-                .as_ref()
-                .map(|_| {
-                    contracts::get_sui_object_from_object_response::<
-                        SuiDynamicField<Vec<u8>, Redirects>,
-                    >(&responses[1])
-                })
-                .transpose()?
-                .map(|df| df.value);
+        let redirects = if df_exists(redirects_df_id) {
+            let field: SuiDynamicField<Vec<u8>, Redirects> =
+                self.sui_client.get_sui_object(redirects_df_id).await?;
+            Some(field.value)
+        } else {
+            None
+        };
 
         Ok((routes, redirects))
     }


### PR DESCRIPTION
## Context

Sui testnet fullnodes no longer serve JSON-RPC. Walrus testnet-v1.51.2 fixes client startup against gRPC-only endpoints and makes its remaining JSON-RPC-only wrapper methods crate-private (they can't work against testnet at runtime regardless). That visibility change is why the automated bump to v1.51.2 failed on Jul 9 with two E0624 errors: site.rs calls two of those wrappers. This PR replaces the automated bump.

That visibility change is what broke the automated dependency bump here ("Bump dependency versions" run on Jul 9, two E0624 errors): site-builder calls two of those wrappers in `site.rs`. This PR supersedes the failed automated bump and unblocks the site-builder release, which is the last leg before the walrus scheduled-compatibility canary can go green again.

## Changes (two commits, lockstep)

**1. Migrate the two site.rs call sites to gRPC-backed APIs**

 - Resource dynamic fields: multi_get_object_with_options_batched + manual deserialization → get_sui_objects::<ResourceDynamicField>(). Drop-in: it batch-fetches and BCS-decodes, chunking internally at 100 objects per request.
  - Routes/redirects: same DF-id derivation as before, but existence is checked against the site's already-fetched dynamic-field listing (no extra RPC), then each existing field is fetched with get_sui_object. This is the part worth reviewer attention: it preserves missing-field ⇒ None without mapping fetch errors to None — relevant because SiteData feeds the update diff, and a transient error misread as "no routes" could delete a site's routes on update.

**2. `chore(site-builder): bump walrus deps to testnet-v1.51.2`**

- Bumps all walrus pins from `testnet-v1.51.1` to `testnet-v1.51.2` plus the lockfile. The Sui tag stays at `testnet-v1.74.0`, which already matches walrus v1.51.2.

The two changes only work together: the migration alone still fails E2E (v1.51.1 crates cannot construct a Sui client against testnet), and the bump alone does not compile (the E0624s). Hence one PR, two commits for review clarity.

## Validation

- Compiles against both testnet-v1.51.1 and testnet-v1.51.2 pins.
- walrus v1.51.2's client path is already running in production on the testnet fleet.

## After merge
Cut a site-builder release so the published site-builder-testnet-latest binaries work against testnet again.
