### PR TITLE
chore: bump version to 2.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9401,7 +9401,7 @@ checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "site-builder"
-version = "2.11.1"
+version = "2.12.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["site-builder"]
 
 [workspace.package]
-version = "2.11.1"
+version = "2.12.0"
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/portal/bun.lock
+++ b/portal/bun.lock
@@ -36,7 +36,7 @@
     },
     "server": {
       "name": "server",
-      "version": "2.11.1",
+      "version": "2.12.0",
       "dependencies": {
         "@logtape/logtape": "^0.11.0",
         "@vercel/edge-config": "^1.4.0",
@@ -60,7 +60,7 @@
     },
     "worker": {
       "name": "worker",
-      "version": "2.11.1",
+      "version": "2.12.0",
       "dependencies": {
         "@mysten/sui": "^2.20.1",
         "buffer": "^6.0.3",

--- a/portal/server/package.json
+++ b/portal/server/package.json
@@ -1,7 +1,7 @@
 {
     "name": "server",
     "description": "The server based implementation of the Walrus Sites portal.",
-    "version": "2.11.1",
+    "version": "2.12.0",
     "private": true,
     "scripts": {
         "start": "bun --hot run index.ts",

--- a/portal/worker/package.json
+++ b/portal/worker/package.json
@@ -1,7 +1,7 @@
 {
     "name": "worker",
     "description": "The service-worker based implementation of the Walrus Sites portal.",
-    "version": "2.11.1",
+    "version": "2.12.0",
     "dependencies": {
         "@mysten/sui": "^2.20.1",
         "buffer": "^6.0.3",

--- a/site-builder/Cargo.toml
+++ b/site-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "site-builder"
-version = "2.11.1"
+version = "2.12.0"
 edition = "2021"
 license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,7 @@ sonar.organization=mystenlabs
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=walrus-sites
-sonar.projectVersion=2.11.1
+sonar.projectVersion=2.12.0
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=portal/common/lib/src,site-builder/src


### PR DESCRIPTION
Bumps the release version to 2.12.0.

- 2.11.1 was a patch bump, but this release includes a feature: the portal glob route/redirect matcher (#720), so per the release template it should be a minor bump
- Updates all version files and lock files

🤖 Generated with [Claude Code](https://claude.com/claude-code)