### PR TITLE
feat(site-builder): validate route/redirect patterns at deploy, flag-gated legacy rewrite

### DIFF
--- a/site-builder/src/args.rs
+++ b/site-builder/src/args.rs
@@ -423,6 +423,23 @@ pub struct PublishOptions {
     /// See the `list-directory` command. Warning: Rewrites all `index.html` files.
     #[arg(long)]
     pub list_directory: bool,
+    /// Rewrite legacy route patterns to their glob equivalents before storing them on-chain.
+    ///
+    /// Historically a `*` in a route pattern was matched as a regex `.*` and could cross `/`
+    /// boundaries. Portals are migrating to glob matching, where `*` matches within a single
+    /// path segment and a whole-segment `**` crosses segments. With this flag, patterns that
+    /// relied on the old reach are rewritten before comparing and storing routes, so the
+    /// on-chain routes use the glob spelling: `*` becomes `/**`, and a trailing `/*` becomes
+    /// `/**/*` (e.g. `/docs/*` -> `/docs/**/*`). Redirect patterns are never rewritten.
+    ///
+    /// WARNING: rewritten patterns such as `/docs/**/*` are only matched by portals with glob
+    /// routing enabled; portals still running legacy (regex) routing skip them. Do not enable
+    /// this flag until the portal fleet runs glob routing.
+    ///
+    /// The rewrite is in-memory only: `ws-resources.json` is not modified.
+    // TODO(sew-1001): remove with the routing migration.
+    #[arg(long)]
+    pub rewrite_legacy_routes: bool,
     /// Common configurations.
     #[clap(flatten)]
     pub walrus_options: WalrusStoreOptions,

--- a/site-builder/src/args.rs
+++ b/site-builder/src/args.rs
@@ -434,7 +434,7 @@ pub struct PublishOptions {
     ///
     /// WARNING: rewritten patterns such as `/docs/**/*` are only matched by portals with glob
     /// routing enabled; portals still running legacy (regex) routing skip them. Do not enable
-    /// this flag until the portal fleet runs glob routing.
+    /// this flag until portal deployments run glob routing.
     ///
     /// The rewrite is in-memory only: `ws-resources.json` is not modified.
     // TODO(sew-1001): remove with the routing migration.

--- a/site-builder/src/publish.rs
+++ b/site-builder/src/publish.rs
@@ -5,7 +5,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 use sui_types::base_types::{ObjectID, SuiAddress};
 use walrus_sui::types::transaction::{ExecuteTransactionResponse, TransactionEffectsStatus};
 
@@ -18,6 +18,7 @@ use crate::{
         config::WSResources,
         estimates::Estimator,
         manager::{BlobExtensionResult, BlobExtensions, SiteManager},
+        path_patterns,
         quilts::QuiltsManager,
         resource::{ParsedResources, ResourceData, ResourceManager, ResourceSet, SiteOps},
         RemoteSiteFactory,
@@ -140,7 +141,7 @@ impl SiteEditor<EditOptions> {
         Option<ExecuteTransactionResponse>,
         SiteDataDiffSummary,
     )> {
-        let (resource_manager, mut quilts_manager, mut site_manager) =
+        let (mut resource_manager, mut quilts_manager, mut site_manager) =
             self.create_managers().await?;
         if self.is_list_directory() {
             self.preprocess_directory(&resource_manager)?;
@@ -166,6 +167,51 @@ impl SiteEditor<EditOptions> {
         // Parse directory to get unchanged and changed resources
         let parsed = resource_manager.read_dir(self.directory(), &existing_site)?;
         display::done();
+
+        // Validate route/redirect patterns before any Walrus spend or estimate:
+        // a doomed deploy must fail here.
+        // TODO(sew-1001): remove the legacy-route rewrite with the routing migration.
+        let rewrite_session = match resource_manager.ws_resources.as_mut() {
+            Some(ws) if self.edit_options.publish_options.rewrite_legacy_routes => {
+                match path_patterns::RewriteSession::apply(&mut ws.routes) {
+                    Ok(session) => session,
+                    Err(collisions) => {
+                        bail!(path_patterns::format_rewrite_collisions(&collisions))
+                    }
+                }
+            }
+            _ => path_patterns::RewriteSession::empty(),
+        };
+        if !rewrite_session.pairs().is_empty() {
+            display::info(path_patterns::format_rewrite_notice(
+                rewrite_session.pairs(),
+            ));
+        }
+        let report = path_patterns::check_write_boundary(
+            resource_manager
+                .ws_resources
+                .as_ref()
+                .and_then(|ws| ws.routes.as_ref()),
+            existing_site.routes(),
+            resource_manager
+                .ws_resources
+                .as_ref()
+                .and_then(|ws| ws.redirects.as_ref()),
+            existing_site.redirects(),
+            rewrite_session.pairs(),
+        );
+        for warning in &report.warnings {
+            display::warning(path_patterns::format_warning(
+                warning,
+                rewrite_session.pairs(),
+            ));
+        }
+        if !report.errors.is_empty() {
+            bail!(path_patterns::format_errors(
+                &report.errors,
+                rewrite_session.pairs()
+            ));
+        }
 
         let walrus_pkg = self
             .config
@@ -314,7 +360,7 @@ impl SiteEditor<EditOptions> {
 
         let local_site_data = resource_manager.to_site_data(resource_set);
 
-        let (response, summary) = site_manager
+        let (response, mut summary) = site_manager
             .update_site(
                 &local_site_data,
                 &existing_site,
@@ -322,6 +368,12 @@ impl SiteEditor<EditOptions> {
                 walrus_pkg,
             )
             .await?;
+        summary.route_rewrites = rewrite_session.pairs().to_vec();
+
+        // The rewrite is in-memory only: persisting writes the whole WSResources back to disk.
+        if let Some(ws) = resource_manager.ws_resources.as_mut() {
+            rewrite_session.restore(&mut ws.routes);
+        }
         self.persist_site_identifier(resource_manager, &site_manager, response.as_ref())?;
 
         Ok((site_manager.active_address()?, response, summary))

--- a/site-builder/src/site.rs
+++ b/site-builder/src/site.rs
@@ -7,6 +7,7 @@ pub mod content;
 pub mod contracts;
 pub mod estimates;
 pub mod manager;
+pub mod path_patterns;
 pub mod quilts;
 pub mod resource;
 
@@ -78,6 +79,7 @@ impl SiteDataDiff<'_> {
             metadata_updated: !self.metadata_op.is_noop(),
             site_name_updated: !self.site_name_op.is_noop(),
             extend_ops: self.extend_ops.clone(),
+            route_rewrites: Vec::new(),
         }
     }
 }
@@ -142,21 +144,11 @@ impl SiteData {
     }
 
     fn redirects_diff(&self, start: &Self) -> RedirectOps {
-        match (&self.redirects, &start.redirects) {
-            (Some(r), Some(s)) => r.diff(s),
-            (None, Some(_)) => RedirectOps::Replace(Redirects::empty()),
-            (Some(s), None) => RedirectOps::Replace(s.clone()),
-            _ => RedirectOps::Unchanged,
-        }
+        Redirects::diff_opt(self.redirects.as_ref(), start.redirects.as_ref())
     }
 
     fn routes_diff(&self, start: &Self) -> RouteOps {
-        match (&self.routes, &start.routes) {
-            (Some(r), Some(s)) => r.diff(s),
-            (None, Some(_)) => RouteOps::Replace(Routes::empty()),
-            (Some(s), None) => RouteOps::Replace(s.clone()),
-            _ => RouteOps::Unchanged,
-        }
+        Routes::diff_opt(self.routes.as_ref(), start.routes.as_ref())
     }
 
     /// Current logic is to return MetadataOp::Update only when metadata read
@@ -180,6 +172,14 @@ impl SiteData {
 
     pub fn resources(&self) -> &ResourceSet {
         &self.resources
+    }
+
+    pub fn routes(&self) -> Option<&Routes> {
+        self.routes.as_ref()
+    }
+
+    pub fn redirects(&self) -> Option<&Redirects> {
+        self.redirects.as_ref()
     }
 }
 

--- a/site-builder/src/site/path_patterns.rs
+++ b/site-builder/src/site/path_patterns.rs
@@ -171,12 +171,12 @@ pub enum PatternIssueKind {
     /// unchanged on-chain.
     GlobInvalid,
     /// Valid glob, but beyond the legacy (regex) matcher's limits: portals
-    /// with the glob flag off skip it, so it only takes effect once the fleet
-    /// runs glob routing.
+    /// with the glob flag off skip it, so it only takes effect once portal
+    /// deployments run glob routing.
     LegacySkipped,
     /// A pattern our own `--rewrite-legacy-routes` rewrite produced that
-    /// legacy portals cannot match: deploying it before the fleet runs glob
-    /// routing is a sequencing hazard.
+    /// legacy portals cannot match: deploying it before portal deployments
+    /// run glob routing is a sequencing hazard.
     // TODO(sew-1001): remove with the routing migration.
     LegacyAfterRewrite,
     /// Informational: the pattern's `*` crossed `/` under the legacy regex
@@ -534,7 +534,7 @@ pub fn format_warning(issue: &PatternIssue, rewritten: &[(String, String)]) -> S
             format!(
                 "'{original}' was rewritten to '{pattern}', which portals still running legacy \
                  (regex) routing cannot match ({reason}) and will skip. Only deploy with \
-                 --rewrite-legacy-routes once the portal fleet runs glob routing."
+                 --rewrite-legacy-routes once portal deployments run glob routing."
             )
         }
         PatternIssueKind::StarNarrowing => format!(

--- a/site-builder/src/site/path_patterns.rs
+++ b/site-builder/src/site/path_patterns.rs
@@ -1,0 +1,582 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Validating and rewriting owner-supplied route/redirect patterns.
+//!
+//! This is a deliberate 1:1 port of the validation and rewrite rules in
+//! `portal/common/lib/src/path_patterns.ts` (introduced in PR #720); the
+//! portal's matching functions (`matchGlob` et al.) are NOT ported, since the
+//! site-builder never matches paths — it only validates patterns at deploy
+//! time.
+//!
+//! KEEP IN SYNC: any change to the portal's validation rules, reason-string
+//! wordings, or rewrite table must be mirrored here, and vice versa. The
+//! reason strings returned by the validators must match the portal's
+//! byte-for-byte.
+//!
+//! Grammar: `*` matches within one path segment, a whole-segment `**` matches
+//! across segments, and every other character is a literal.
+//!
+//! Wildcard caps keep matching cheap: glob patterns (redirects always; routes
+//! when the flag is on) allow one `*` per segment and one `**` per pattern, so
+//! the portal's `matchGlob` never backtracks. The legacy regex branch (routes,
+//! flag off) allows only path characters plus `*` and `.`, capping the
+//! compiled regex at two `.*`s — worst case quadratic, a bounded stall rather
+//! than a freeze. Rejected regex metacharacters are plain literals under the
+//! glob matcher.
+
+use std::collections::BTreeMap;
+
+use crate::types::{RedirectOps, Redirects, RouteOps, Routes};
+
+#[cfg(test)]
+#[path = "../unit_tests/site.path_patterns.tests.rs"]
+mod path_patterns_tests;
+
+/// Max total `*` characters in a legacy-regex pattern (glob is bounded per segment).
+pub const MAX_STARS: usize = 2;
+
+/// Max whole-segment `**` globstars in a glob pattern (each adds backtracking).
+pub const MAX_GLOBSTARS: usize = 1;
+
+/// Regex metacharacters rejected in legacy-regex route patterns. Only `*` (the
+/// wildcard, translated to `.*`) and `.` (today's any-char) are allowed through.
+const ILLEGAL_REGEX_CHARS: [char; 12] =
+    ['(', ')', '[', ']', '{', '}', '+', '?', '^', '$', '|', '\\'];
+
+/// Number of `*` characters in `text`. Iterates chars (code points), not bytes.
+pub fn count_stars(text: &str) -> usize {
+    text.chars().filter(|&c| c == '*').count()
+}
+
+/// Validates a glob route/redirect pattern. Each segment may use at most one
+/// `*` or be a whole-segment `**`, and a pattern may have at most one `**`.
+/// Callers skip (and report) patterns that fail rather than feeding them to
+/// the matcher.
+///
+/// `Err(reason)` mirrors the portal's `PatternValidation` reason strings
+/// exactly.
+pub fn validate_glob_pattern(pattern: &str) -> Result<(), String> {
+    let mut globstars = 0;
+    for segment in pattern.split('/') {
+        if segment == "**" {
+            globstars += 1;
+            continue;
+        }
+        // Any other segment may use at most one `*` (so `bar**`, `a*b*`, `***`
+        // are rejected: `**` is only valid as a whole segment).
+        if count_stars(segment) > 1 {
+            return Err(format!(
+                r#"segment "{segment}" may use at most one '*', or be a whole-segment '**'"#
+            ));
+        }
+    }
+    if globstars > MAX_GLOBSTARS {
+        return Err(format!("{globstars} '**' globstars (max {MAX_GLOBSTARS})"));
+    }
+    Ok(())
+}
+
+/// Validates a legacy-regex route pattern (the matcher used while the glob
+/// flag is off). Rejects regex metacharacters and caps the total wildcard
+/// count. Callers skip (and report) patterns that fail rather than feeding
+/// them to the matcher.
+///
+/// `Err(reason)` mirrors the portal's `PatternValidation` reason strings
+/// exactly.
+pub fn validate_regex_pattern(pattern: &str) -> Result<(), String> {
+    if let Some(illegal) = pattern.chars().find(|c| ILLEGAL_REGEX_CHARS.contains(c)) {
+        return Err(format!(r#"unsupported character "{illegal}""#));
+    }
+    let total = count_stars(pattern);
+    if total > MAX_STARS {
+        return Err(format!("{total} '*' characters (max {MAX_STARS} in total)"));
+    }
+    Ok(())
+}
+
+/// Rewrites a legacy regex route pattern as the equivalent glob, so a site
+/// authored for the old regex matcher keeps the same reach once glob routing
+/// is on. Under the regex a `*` became `.*` and crossed `/`, so:
+///  - a bare `*` matched everything, and becomes a root globstar `/**`;
+///  - a trailing `/` then `*` matched paths one or more levels below the
+///    prefix; the regex needed that slash, so it never matched the bare
+///    prefix. It becomes a globstar plus a required segment, keeping that
+///    reach without shadowing an exact route for the prefix itself.
+///
+/// A `*` in the middle of a pattern stays within its segment, and a pattern
+/// that already uses `**` is returned unchanged.
+pub fn rewrite_legacy_route_pattern(pattern: &str) -> String {
+    if pattern.contains("**") {
+        pattern.to_owned() // already a glob pattern
+    } else if pattern == "*" {
+        "/**".to_owned() // bare catch-all matches everything
+    } else if let Some(prefix) = pattern.strip_suffix("/*") {
+        // Require the slash plus a segment, so the catch-all matches strictly
+        // below the prefix and never the bare prefix (as the regex did).
+        format!("{prefix}/**/*")
+    } else {
+        pattern.to_owned()
+    }
+}
+
+/// Site-builder-specific (not in the portal): true when a pattern's reach
+/// narrows under glob matching and no rewrite will widen it back — it has a
+/// `*` that under the legacy regex crossed `/` boundaries, but is neither the
+/// bare catch-all nor a trailing `/*` (both of which
+/// [`rewrite_legacy_route_pattern`] widens back), and is not already a glob.
+///
+/// Known accepted gap: a pattern like `/a/*/b/*` has a narrowing middle star
+/// but escapes via the trailing-`/*` exclusion (deliberate, pinned by test).
+// TODO(sew-1001): remove with the routing migration.
+pub fn narrows_under_glob(pattern: &str) -> bool {
+    count_stars(pattern) > 0
+        && pattern != "*"
+        && !pattern.ends_with("/*")
+        && !pattern.contains("**")
+}
+
+/// Which pattern set a [`PatternIssue`] was found in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PatternTarget {
+    /// A route pattern (a key of the site's routes).
+    Route,
+    /// A redirect pattern (a key of the site's redirects).
+    Redirect,
+}
+
+impl PatternTarget {
+    /// Singular noun for user-facing messages.
+    fn noun(self) -> &'static str {
+        match self {
+            Self::Route => "route",
+            Self::Redirect => "redirect",
+        }
+    }
+
+    /// Plural noun for user-facing messages.
+    fn plural(self) -> &'static str {
+        match self {
+            Self::Route => "routes",
+            Self::Redirect => "redirects",
+        }
+    }
+}
+
+/// What is wrong (or noteworthy) about a pattern at the write boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PatternIssueKind {
+    /// Not valid glob syntax: portals cannot match it. A hard error when the
+    /// pattern's set is about to be written; a warning when the set stays
+    /// unchanged on-chain.
+    GlobInvalid,
+    /// Valid glob, but beyond the legacy (regex) matcher's limits: portals
+    /// with the glob flag off skip it, so it only takes effect once the fleet
+    /// runs glob routing.
+    LegacySkipped,
+    /// A pattern our own `--rewrite-legacy-routes` rewrite produced that
+    /// legacy portals cannot match: deploying it before the fleet runs glob
+    /// routing is a sequencing hazard.
+    // TODO(sew-1001): remove with the routing migration.
+    LegacyAfterRewrite,
+    /// Informational: the pattern's `*` crossed `/` under the legacy regex
+    /// matcher but stays within one segment under glob, narrowing its reach.
+    // TODO(sew-1001): remove with the routing migration.
+    StarNarrowing,
+}
+
+/// One validation finding for a single route/redirect pattern.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PatternIssue {
+    /// Which set the pattern belongs to.
+    pub target: PatternTarget,
+    /// The pattern as it appears in the (to-be-written or on-chain) set.
+    pub pattern: String,
+    /// The validator's reason string; empty for
+    /// [`PatternIssueKind::StarNarrowing`], whose user text is produced
+    /// entirely by [`format_warning`].
+    pub reason: String,
+    /// What is wrong (or noteworthy) about the pattern.
+    pub kind: PatternIssueKind,
+}
+
+/// Everything [`check_write_boundary`] found: `errors` must block the deploy,
+/// `warnings` must not.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WriteBoundaryReport {
+    /// Structurally invalid patterns in a set about to be written on-chain.
+    pub errors: Vec<PatternIssue>,
+    /// Non-blocking findings: invalid-but-unchanged patterns, legacy-portal
+    /// skips, rewrite sequencing hazards, and narrowing notes.
+    pub warnings: Vec<PatternIssue>,
+}
+
+/// Distinct route patterns that [`apply_route_rewrites`] would collapse into
+/// the same stored key (which would silently drop all but one value).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RewriteCollision {
+    /// The contested rewritten key.
+    pub rewritten: String,
+    /// The original patterns (sorted) that all rewrite to `rewritten`.
+    pub originals: Vec<String>,
+}
+
+/// Validates the route and redirect patterns of a deploy at the write
+/// boundary, i.e. against what the deploy actually stores on-chain.
+///
+/// Written-vs-unchanged is decided by [`Routes::diff_opt`] and
+/// [`Redirects::diff_opt`] — the same single source of truth the deploy's
+/// site diff uses — so this check cannot diverge from what is written. Sets
+/// are stored replace-all, so when a set changes, every key of the complete
+/// new set is validated (including patterns this deploy did not touch);
+/// structurally invalid ones are hard [`WriteBoundaryReport::errors`]. When a
+/// locally-declared set is unchanged, the same checks run but invalid
+/// patterns are only warnings: nothing new lands on-chain, so the deploy may
+/// proceed.
+///
+/// Routes additionally take the migration checks (legacy-portal skips,
+/// rewrite sequencing hazards, `*`-narrowing notes); redirects are
+/// glob-structural only, since they never went through the legacy regex
+/// matcher.
+///
+/// `local_routes` is the post-rewrite set when `--rewrite-legacy-routes` is
+/// on (raw otherwise), and `rewritten` holds the `(original, stored)` pairs
+/// the rewrite actually changed (empty when the flag is off).
+pub fn check_write_boundary(
+    local_routes: Option<&Routes>,
+    existing_routes: Option<&Routes>,
+    local_redirects: Option<&Redirects>,
+    existing_redirects: Option<&Redirects>,
+    rewritten: &[(String, String)],
+) -> WriteBoundaryReport {
+    let mut report = WriteBoundaryReport::default();
+
+    match Routes::diff_opt(local_routes, existing_routes) {
+        RouteOps::Replace(written) => {
+            classify_written(route_pattern_issues(&written, rewritten), &mut report)
+        }
+        // Nothing new lands on-chain, so nothing can block: every finding in
+        // a locally-declared-but-unchanged set is a warning.
+        RouteOps::Unchanged => {
+            if let Some(local) = local_routes {
+                report
+                    .warnings
+                    .extend(route_pattern_issues(local, rewritten));
+            }
+        }
+    }
+
+    match Redirects::diff_opt(local_redirects, existing_redirects) {
+        RedirectOps::Replace(written) => {
+            classify_written(redirect_pattern_issues(&written), &mut report)
+        }
+        RedirectOps::Unchanged => {
+            if let Some(local) = local_redirects {
+                report.warnings.extend(redirect_pattern_issues(local));
+            }
+        }
+    }
+
+    report
+}
+
+/// Classifies the findings of a set that is about to be written on-chain: a
+/// structurally invalid glob pattern blocks the deploy, every other finding
+/// (legacy-portal skips, rewrite sequencing hazards, narrowing notes) warns.
+/// Together with the warnings-only `Unchanged` arms in
+/// [`check_write_boundary`], this is the validator's entire
+/// blocking-vs-non-blocking posture: flipping any class is a change here
+/// alone.
+fn classify_written(issues: Vec<PatternIssue>, report: &mut WriteBoundaryReport) {
+    for issue in issues {
+        if issue.kind == PatternIssueKind::GlobInvalid {
+            report.errors.push(issue);
+        } else {
+            report.warnings.push(issue);
+        }
+    }
+}
+
+/// Every finding for a route set, in key order: the glob-structural check,
+/// then — for glob-valid patterns only — the migration checks.
+fn route_pattern_issues(set: &Routes, rewritten: &[(String, String)]) -> Vec<PatternIssue> {
+    let mut issues = Vec::new();
+    for (pattern, _) in set.0.iter() {
+        match glob_invalid_issue(PatternTarget::Route, pattern) {
+            // A glob-invalid pattern produces exactly this one issue; the
+            // migration checks only apply to glob-valid patterns.
+            Some(issue) => issues.push(issue),
+            None => issues.extend(route_migration_issue(pattern, rewritten)),
+        }
+    }
+    issues
+}
+
+/// Every finding for a redirect set, in key order: glob-structural only —
+/// redirects never took the legacy regex path, so no migration checks apply.
+fn redirect_pattern_issues(set: &Redirects) -> Vec<PatternIssue> {
+    set.0
+        .iter()
+        .filter_map(|(pattern, _)| glob_invalid_issue(PatternTarget::Redirect, pattern))
+        .collect()
+}
+
+/// The glob-structural check shared by routes and redirects.
+fn glob_invalid_issue(target: PatternTarget, pattern: &str) -> Option<PatternIssue> {
+    validate_glob_pattern(pattern)
+        .err()
+        .map(|reason| PatternIssue {
+            target,
+            pattern: pattern.to_owned(),
+            reason,
+            kind: PatternIssueKind::GlobInvalid,
+        })
+}
+
+/// The migration checks for a glob-valid route pattern: skipped by the legacy
+/// matcher (a sequencing hazard when the pattern is one of our own rewrite
+/// outputs), otherwise the `*`-narrowing note.
+// TODO(sew-1001): remove with the routing migration.
+fn route_migration_issue(pattern: &str, rewritten: &[(String, String)]) -> Option<PatternIssue> {
+    match validate_regex_pattern(pattern) {
+        Err(reason) => {
+            let kind = if rewritten.iter().any(|(_, stored)| stored == pattern) {
+                PatternIssueKind::LegacyAfterRewrite
+            } else {
+                PatternIssueKind::LegacySkipped
+            };
+            Some(PatternIssue {
+                target: PatternTarget::Route,
+                pattern: pattern.to_owned(),
+                reason,
+                kind,
+            })
+        }
+        Ok(()) => narrows_under_glob(pattern).then(|| PatternIssue {
+            target: PatternTarget::Route,
+            pattern: pattern.to_owned(),
+            reason: String::new(),
+            kind: PatternIssueKind::StarNarrowing,
+        }),
+    }
+}
+
+/// Rewrites every route key through [`rewrite_legacy_route_pattern`], in
+/// place, keeping each value with its key.
+///
+/// Returns the `(original, stored)` pairs that actually changed, sorted by
+/// original. If two or more distinct originals rewrite to the same key (e.g.
+/// `/docs/*` and `/docs/**/*` both become `/docs/**/*`), their entries merge
+/// into one when the values are identical (nothing is lost); when the values
+/// differ, picking one would silently drop a route, so `routes` is left
+/// unchanged and all such collisions are returned.
+pub fn apply_route_rewrites(
+    routes: &mut Routes,
+) -> Result<Vec<(String, String)>, Vec<RewriteCollision>> {
+    // Detect collisions up front, so a failed rewrite leaves `routes` untouched.
+    let mut entries_by_stored: BTreeMap<String, Vec<(&String, &String)>> = BTreeMap::new();
+    for (original, value) in routes.0.iter() {
+        entries_by_stored
+            .entry(rewrite_legacy_route_pattern(original))
+            .or_default()
+            .push((original, value));
+    }
+    let collisions: Vec<RewriteCollision> = entries_by_stored
+        .into_iter()
+        .filter(|(_, entries)| {
+            entries.len() > 1 && entries.iter().any(|&(_, value)| value != entries[0].1)
+        })
+        .map(|(rewritten, entries)| RewriteCollision {
+            rewritten,
+            // Already sorted: pushed in the route map's key order.
+            originals: entries
+                .into_iter()
+                .map(|(original, _)| original.clone())
+                .collect(),
+        })
+        .collect();
+    if !collisions.is_empty() {
+        return Err(collisions);
+    }
+
+    // Rebuild the map under the rewritten keys; identical-value collisions
+    // merge into a single entry. Record the changed pairs (sorted by
+    // original, as the map iterates in key order).
+    let mut changed = Vec::new();
+    routes.0.map_keys(|original| {
+        let stored = rewrite_legacy_route_pattern(original);
+        if stored != *original {
+            changed.push((original.clone(), stored.clone()));
+        }
+        stored
+    });
+    Ok(changed)
+}
+
+/// One application of `--rewrite-legacy-routes`: applies the rewrite and
+/// holds everything needed to report it (the changed pairs) and to undo it in
+/// memory (the pre-rewrite routes) before the configuration file is
+/// persisted.
+// TODO(sew-1001): remove with the routing migration.
+#[derive(Debug, Default)]
+pub struct RewriteSession {
+    original_routes: Option<Routes>,
+    pairs: Vec<(String, String)>,
+}
+
+impl RewriteSession {
+    /// A session that rewrote nothing (flag off, or no routes declared).
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Applies [`apply_route_rewrites`] to `routes`, capturing the original
+    /// set (only when something changed) and the changed pairs.
+    pub fn apply(routes: &mut Option<Routes>) -> Result<Self, Vec<RewriteCollision>> {
+        let Some(routes) = routes.as_mut() else {
+            return Ok(Self::empty());
+        };
+        let original = routes.clone();
+        let pairs = apply_route_rewrites(routes)?;
+        Ok(Self {
+            original_routes: (!pairs.is_empty()).then_some(original),
+            pairs,
+        })
+    }
+
+    /// The `(original, stored)` pairs the rewrite changed, sorted by original.
+    pub fn pairs(&self) -> &[(String, String)] {
+        &self.pairs
+    }
+
+    /// Restores the pre-rewrite routes. The rewrite is in-memory only, and
+    /// persisting the configuration file writes the whole `WSResources` back
+    /// to disk, so this must run before that write. Consumes the session:
+    /// there is nothing left to restore twice.
+    pub fn restore(self, routes: &mut Option<Routes>) {
+        if let Some(original) = self.original_routes {
+            *routes = Some(original);
+        }
+    }
+}
+
+/// One blocking message covering every structurally invalid pattern in a set
+/// about to be written. `rewritten` (the `(original, stored)` pairs from
+/// [`apply_route_rewrites`]) recovers the original spelling for route patterns
+/// the rewrite changed, so the error points at what is actually in
+/// ws-resources.json.
+pub fn format_errors(errors: &[PatternIssue], rewritten: &[(String, String)]) -> String {
+    let mut message = format!(
+        "found {} invalid route/redirect pattern(s); portals cannot match them, refusing to \
+         store them on-chain:\n",
+        errors.len()
+    );
+    for issue in errors {
+        // Redirects are never rewritten: only look a route pattern up.
+        let original = (issue.target == PatternTarget::Route)
+            .then(|| {
+                rewritten
+                    .iter()
+                    .find_map(|(original, stored)| (stored == &issue.pattern).then_some(original))
+            })
+            .flatten();
+        match original {
+            Some(original) => message.push_str(&format!(
+                "  - route pattern '{original}' (stored as '{}' by --rewrite-legacy-routes): {}\n",
+                issue.pattern, issue.reason
+            )),
+            None => message.push_str(&format!(
+                "  - {} pattern '{}': {}\n",
+                issue.target.noun(),
+                issue.pattern,
+                issue.reason
+            )),
+        }
+    }
+    message.push_str(
+        "Routes and redirects are stored as complete sets, so every pattern in \
+         ws-resources.json must be valid before this deploy can proceed — including patterns \
+         you did not change.",
+    );
+    message
+}
+
+/// The user text for one warning. `rewritten` (the `(original, stored)` pairs
+/// from [`apply_route_rewrites`]) recovers the original spelling for
+/// [`PatternIssueKind::LegacyAfterRewrite`]; the other kinds ignore it.
+pub fn format_warning(issue: &PatternIssue, rewritten: &[(String, String)]) -> String {
+    let PatternIssue {
+        target,
+        pattern,
+        reason,
+        kind,
+    } = issue;
+    match kind {
+        PatternIssueKind::GlobInvalid => {
+            let (noun, set) = (target.noun(), target.plural());
+            format!(
+                "On-chain {noun} pattern '{pattern}' is invalid ({reason}); portals skip it \
+                 when matching. This deploy leaves {set} unchanged and can proceed, but fix \
+                 the pattern in ws-resources.json: the next deploy that modifies {set} will \
+                 refuse to store it."
+            )
+        }
+        PatternIssueKind::LegacySkipped => format!(
+            "Route pattern '{pattern}' is valid glob syntax, but exceeds the legacy matcher's \
+             limits ({reason}); portals still running legacy (regex) routing skip it. It only \
+             takes effect on portals with glob routing enabled."
+        ),
+        PatternIssueKind::LegacyAfterRewrite => {
+            let original = rewritten
+                .iter()
+                .find_map(|(original, stored)| (stored == pattern).then_some(original.as_str()))
+                .unwrap_or(pattern.as_str());
+            format!(
+                "'{original}' was rewritten to '{pattern}', which portals still running legacy \
+                 (regex) routing cannot match ({reason}) and will skip. Only deploy with \
+                 --rewrite-legacy-routes once the portal fleet runs glob routing."
+            )
+        }
+        PatternIssueKind::StarNarrowing => format!(
+            "Note on route pattern '{pattern}': under glob routing, '*' matches within a \
+             single path segment (legacy regex routing let it cross '/'). The pattern is \
+             valid and stored as-is; if you want it to match everything below a prefix, use \
+             a whole-segment '**' — e.g. '/foo/**' matches '/foo' and everything under it."
+        ),
+    }
+}
+
+/// The `--rewrite-legacy-routes` notice: which route patterns are stored in
+/// rewritten (glob) form.
+pub fn format_rewrite_notice(rewritten: &[(String, String)]) -> String {
+    let mut message = format!(
+        "--rewrite-legacy-routes: storing {} route pattern(s) in glob form (ws-resources.json \
+         is not modified):",
+        rewritten.len()
+    );
+    for (original, stored) in rewritten {
+        message.push_str(&format!("\n  - '{original}' -> '{stored}'"));
+    }
+    message
+}
+
+/// The blocking message for rewrite collisions, one line per contested key.
+pub fn format_rewrite_collisions(collisions: &[RewriteCollision]) -> String {
+    collisions
+        .iter()
+        .map(|collision| {
+            let originals = collision
+                .originals
+                .iter()
+                .map(|original| format!("'{original}'"))
+                .collect::<Vec<_>>()
+                .join(" and ");
+            format!(
+                "--rewrite-legacy-routes produced conflicting route patterns: {originals} both \
+                 rewrite to '{}'. Remove or merge these entries in ws-resources.json.",
+                collision.rewritten
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}

--- a/site-builder/src/summary.rs
+++ b/site-builder/src/summary.rs
@@ -117,6 +117,9 @@ pub struct SiteDataDiffSummary {
     pub metadata_updated: bool,
     pub site_name_updated: bool,
     pub extend_ops: ExtendOps,
+    /// `(original, stored)` route-pattern pairs rewritten by `--rewrite-legacy-routes`.
+    // TODO(sew-1001): remove with the routing migration.
+    pub route_rewrites: Vec<(String, String)>,
 }
 
 impl From<&SiteDataDiff<'_>> for SiteDataDiffSummary {
@@ -128,6 +131,7 @@ impl From<&SiteDataDiff<'_>> for SiteDataDiffSummary {
             metadata_updated: !value.metadata_op.is_noop(),
             site_name_updated: !value.site_name_op.is_noop(),
             extend_ops: value.extend_ops.clone(),
+            route_rewrites: Vec::new(),
         }
     }
 }
@@ -146,6 +150,7 @@ impl Summarizable for SiteDataDiffSummary {
             && !self.metadata_updated
             && !self.site_name_updated
             && self.extend_ops.is_noop()
+            && self.route_rewrites.is_empty()
         {
             return "No operation needs to be performed.".to_owned();
         }
@@ -159,7 +164,19 @@ impl Summarizable for SiteDataDiffSummary {
         } else {
             "No resource operations performed.".to_owned()
         };
-        let route_str = self.route_ops.to_summary();
+        let mut route_str = self.route_ops.to_summary();
+        if !self.route_rewrites.is_empty() {
+            let rewrite_lines = self
+                .route_rewrites
+                .iter()
+                .map(|(original, stored)| format!("  - '{original}' -> '{stored}'"))
+                .collect::<Vec<_>>()
+                .join("\n");
+            route_str = format!(
+                "{route_str}\nRoute patterns rewritten to glob form \
+                (--rewrite-legacy-routes):\n{rewrite_lines}"
+            );
+        }
         let redirect_str = self.redirect_ops.to_summary();
         let metadata_str = if self.metadata_updated {
             "Metadata updated."
@@ -174,5 +191,54 @@ impl Summarizable for SiteDataDiffSummary {
         let extend_str = self.extend_ops.to_summary();
 
         format!("{resource_str}\n{route_str}\n{redirect_str}\n{metadata_str}\n{site_name_str}\n{extend_str}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn all_noop_summary(route_rewrites: Vec<(String, String)>) -> SiteDataDiffSummary {
+        SiteDataDiffSummary {
+            resource_ops: Vec::new(),
+            route_ops: RouteOps::Unchanged,
+            redirect_ops: RedirectOps::Unchanged,
+            metadata_updated: false,
+            site_name_updated: false,
+            extend_ops: ExtendOps::Noop,
+            route_rewrites,
+        }
+    }
+
+    #[test]
+    fn test_route_rewrites_rendered() {
+        let summary = all_noop_summary(vec![
+            ("/docs/*".to_owned(), "/docs/**/*".to_owned()),
+            ("*".to_owned(), "/**".to_owned()),
+        ]);
+        let text = summary.to_summary();
+        assert!(
+            text.contains("Route patterns rewritten to glob form (--rewrite-legacy-routes):"),
+            "missing rewrite header in: {text}"
+        );
+        assert!(text.contains("  - '/docs/*' -> '/docs/**/*'"));
+        assert!(text.contains("  - '*' -> '/**'"));
+    }
+
+    #[test]
+    fn test_all_noop_with_rewrites_does_not_early_return() {
+        // The key regression scenario: an idempotent re-deploy with the rewrite
+        // flag on (rewrite applied, diff Unchanged) must still surface the
+        // rewrite notice instead of "No operation needs to be performed.".
+        let summary = all_noop_summary(vec![("/docs/*".to_owned(), "/docs/**/*".to_owned())]);
+        let text = summary.to_summary();
+        assert!(!text.contains("No operation needs to be performed."));
+        assert!(text.contains("Route patterns rewritten to glob form"));
+    }
+
+    #[test]
+    fn test_all_noop_without_rewrites_early_returns() {
+        let summary = all_noop_summary(Vec::new());
+        assert_eq!(summary.to_summary(), "No operation needs to be performed.");
     }
 }

--- a/site-builder/src/types.rs
+++ b/site-builder/src/types.rs
@@ -101,6 +101,16 @@ where
         self.0.entry(key)
     }
 
+    /// Rebuilds the map with every key passed through `f`, keeping each value
+    /// with its (re-keyed) entry. If `f` maps two keys to the same output, the
+    /// entry with the greatest original key wins.
+    pub fn map_keys(&mut self, mut f: impl FnMut(&K) -> K) {
+        self.0 = std::mem::take(&mut self.0)
+            .into_iter()
+            .map(|(key, value)| (f(&key), value))
+            .collect();
+    }
+
     #[allow(unused)]
     pub fn insert(&mut self, key: K, value: V) -> Option<V> {
         self.0.insert(key, value)
@@ -207,6 +217,20 @@ impl Routes {
             RouteOps::Replace(self.clone())
         }
     }
+
+    /// Single source of truth for how optional local/existing route sets diff.
+    ///
+    /// Used by both site diffing and write-boundary pattern validation, which must never
+    /// diverge. Semantics: local `None` + existing `Some` = remove-all (`Replace` with an
+    /// empty set); local `Some` + existing `None` = fresh write.
+    pub fn diff_opt(local: Option<&Routes>, existing: Option<&Routes>) -> RouteOps {
+        match (local, existing) {
+            (Some(l), Some(e)) => l.diff(e),
+            (None, Some(_)) => RouteOps::Replace(Routes::empty()),
+            (Some(l), None) => RouteOps::Replace(l.clone()),
+            (None, None) => RouteOps::Unchanged,
+        }
+    }
 }
 
 impl AssociatedContractStruct for Routes {
@@ -251,6 +275,20 @@ impl Redirects {
             RedirectOps::Unchanged
         } else {
             RedirectOps::Replace(self.clone())
+        }
+    }
+
+    /// Single source of truth for how optional local/existing redirect sets diff.
+    ///
+    /// Used by both site diffing and write-boundary pattern validation, which must never
+    /// diverge. Semantics: local `None` + existing `Some` = remove-all (`Replace` with an
+    /// empty set); local `Some` + existing `None` = fresh write.
+    pub fn diff_opt(local: Option<&Redirects>, existing: Option<&Redirects>) -> RedirectOps {
+        match (local, existing) {
+            (Some(l), Some(e)) => l.diff(e),
+            (None, Some(_)) => RedirectOps::Replace(Redirects::empty()),
+            (Some(l), None) => RedirectOps::Replace(l.clone()),
+            (None, None) => RedirectOps::Unchanged,
         }
     }
 }

--- a/site-builder/src/unit_tests/site.path_patterns.tests.rs
+++ b/site-builder/src/unit_tests/site.path_patterns.tests.rs
@@ -1,0 +1,738 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Unit tests for `site::path_patterns`.
+//!
+//! The corpus mirrors `portal/common/lib/tests/path_patterns.test.ts` 1:1 and
+//! then adds site-builder-specific cases (`narrows_under_glob`, portal-unseen
+//! edges, and the write-boundary enforcement engine). Keep in sync with the
+//! portal test corpus.
+
+use super::*;
+use crate::types::{Redirect, Redirects, RouteOps, Routes};
+
+#[test]
+fn test_count_stars() {
+    let cases = vec![("", 0), ("/foo", 0), ("/foo/*", 1), ("/**", 2), ("a*b*", 2)];
+
+    for (text, expected) in cases {
+        assert_eq!(count_stars(text), expected, "count_stars({text:?})");
+    }
+}
+
+#[test]
+fn test_validate_glob_pattern_accepts() {
+    let cases = vec![
+        "/*",
+        "/**",
+        "/foo",
+        "/foo/*",
+        "/assets/*.js",
+        "/blog/old-*",
+        "/a/*/b/*",
+        "/foo/**/bar",
+        "/foo/**/*",
+        "/legacy/**/*",
+        "/wiki/Foo_(bar)",
+        "/list[0]",
+        "/path!/+",
+    ];
+
+    for pattern in cases {
+        assert_eq!(
+            validate_glob_pattern(pattern),
+            Ok(()),
+            "validate_glob_pattern({pattern:?})"
+        );
+    }
+}
+
+#[test]
+fn test_validate_glob_pattern_rejects_per_segment() {
+    let cases = vec![
+        ("/foo/bar**", "bar**"),
+        ("a*b*", "a*b*"),
+        ("/x/a*a*a*/y", "a*a*a*"),
+        ("***", "***"),
+        ("/**bar**/x", "**bar**"),
+        ("/*foo*", "*foo*"),
+    ];
+
+    for (pattern, segment) in cases {
+        assert_eq!(
+            validate_glob_pattern(pattern),
+            Err(format!(
+                r#"segment "{segment}" may use at most one '*', or be a whole-segment '**'"#
+            )),
+            "validate_glob_pattern({pattern:?})"
+        );
+    }
+}
+
+#[test]
+fn test_validate_glob_pattern_rejects_globstars() {
+    let cases = vec!["/foo/**/*/**/bar", "/a/**/b/**", "/**/x/**/y"];
+
+    for pattern in cases {
+        assert_eq!(
+            validate_glob_pattern(pattern),
+            Err("2 '**' globstars (max 1)".to_owned()),
+            "validate_glob_pattern({pattern:?})"
+        );
+    }
+}
+
+#[test]
+fn test_validate_regex_pattern_accepts() {
+    let cases = vec!["/*", "/foo", "/foo/*", "/a/*/b/*", "a*b*", "/index.html"];
+
+    for pattern in cases {
+        assert_eq!(
+            validate_regex_pattern(pattern),
+            Ok(()),
+            "validate_regex_pattern({pattern:?})"
+        );
+    }
+}
+
+#[test]
+fn test_validate_regex_pattern_rejects_stars() {
+    let cases = vec!["/a/*/b/*/c/*", "/a*b*c*", "***"];
+
+    for pattern in cases {
+        assert_eq!(
+            validate_regex_pattern(pattern),
+            Err("3 '*' characters (max 2 in total)".to_owned()),
+            "validate_regex_pattern({pattern:?})"
+        );
+    }
+}
+
+#[test]
+fn test_validate_regex_pattern_rejects_metachars() {
+    let cases = vec![
+        ("/foo(", '('),
+        ("/foo)", ')'),
+        ("/foo[a]", '['),
+        ("/foo{2}", '{'),
+        ("/a+b", '+'),
+        ("/a?b", '?'),
+        ("/a|b", '|'),
+        ("/p$", '$'),
+        ("/a\\b", '\\'),
+    ];
+
+    for (pattern, illegal) in cases {
+        assert_eq!(
+            validate_regex_pattern(pattern),
+            Err(format!(r#"unsupported character "{illegal}""#)),
+            "validate_regex_pattern({pattern:?})"
+        );
+    }
+}
+
+#[test]
+fn test_validate_regex_pattern_rejects_every_illegal_char() {
+    // The portal-mirrored cases above never surface '^', ']', or '}' as the
+    // leftmost offender; sweep the whole set so dropping any char from
+    // ILLEGAL_REGEX_CHARS fails a test.
+    for c in ILLEGAL_REGEX_CHARS {
+        assert_eq!(
+            validate_regex_pattern(&format!("/p{c}q")),
+            Err(format!(r#"unsupported character "{c}""#)),
+            "validate_regex_pattern with {c:?}"
+        );
+    }
+}
+
+#[test]
+fn test_rewrite_legacy_route_pattern() {
+    let cases = vec![
+        ("*", "/**"),
+        ("/*", "/**/*"),
+        ("/docs/*", "/docs/**/*"),
+        // Mid-pattern, glued, and within-segment stars are deliberately
+        // untouched; existing globs pass through unchanged.
+        ("/forms/*/admin", "/forms/*/admin"),
+        ("/blog/old-*", "/blog/old-*"),
+        ("/foo/**", "/foo/**"),
+        ("/about", "/about"),
+    ];
+
+    for (pattern, expected) in cases {
+        assert_eq!(
+            rewrite_legacy_route_pattern(pattern),
+            expected,
+            "rewrite_legacy_route_pattern({pattern:?})"
+        );
+    }
+}
+
+#[test]
+fn test_narrows_under_glob() {
+    let cases = vec![
+        ("/api*", true),
+        ("/forms/*/admin", true),
+        ("/blog/old-*", true),
+        ("*", false),
+        ("/foo/*", false),
+        ("/foo/**", false),
+        ("", false),
+        // Accepted gap: the narrowing middle star escapes via the
+        // trailing-/* exclusion (deliberate; flagged to the migration owner).
+        ("/a/*/b/*", false),
+    ];
+
+    for (pattern, expected) in cases {
+        assert_eq!(
+            narrows_under_glob(pattern),
+            expected,
+            "narrows_under_glob({pattern:?})"
+        );
+    }
+}
+
+/// Edge cases the portal test corpus does not cover: pin exact behavior (and
+/// no panics) so it cannot drift silently.
+#[test]
+fn test_portal_unseen_edges() {
+    // The empty pattern is valid under both validators and rewrites unchanged.
+    assert_eq!(validate_glob_pattern(""), Ok(()));
+    assert_eq!(validate_regex_pattern(""), Ok(()));
+    assert_eq!(rewrite_legacy_route_pattern(""), "");
+
+    // A bare globstar is a single whole-segment `**`: glob-valid.
+    assert_eq!(validate_glob_pattern("**"), Ok(()));
+
+    // No leading slash: the trailing-/* rewrite still applies.
+    assert_eq!(rewrite_legacy_route_pattern("foo/*"), "foo/**/*");
+
+    // Empty segments from a double slash are fine (zero stars).
+    assert_eq!(validate_glob_pattern("/foo//bar"), Ok(()));
+
+    // Unicode: stars are counted per code point, not per byte.
+    assert_eq!(count_stars("日*本*"), 2);
+    assert_eq!(rewrite_legacy_route_pattern("/café/*"), "/café/**/*");
+    assert_eq!(
+        validate_glob_pattern("/日*本*/x"),
+        Err(r#"segment "日*本*" may use at most one '*', or be a whole-segment '**'"#.to_owned())
+    );
+}
+
+// Write-boundary enforcement (site-builder only; not mirrored in the portal).
+
+fn make_routes(pairs: &[(&str, &str)]) -> Routes {
+    Routes(
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
+            .collect(),
+    )
+}
+
+fn make_redirects(patterns: &[&str]) -> Redirects {
+    Redirects(
+        patterns
+            .iter()
+            .map(|p| {
+                (
+                    (*p).to_owned(),
+                    Redirect {
+                        location: "/target".to_owned(),
+                        status_code: 301,
+                    },
+                )
+            })
+            .collect(),
+    )
+}
+
+fn expect_glob_invalid(target: PatternTarget, pattern: &str, segment: &str) -> PatternIssue {
+    PatternIssue {
+        target,
+        pattern: pattern.to_owned(),
+        reason: format!(
+            r#"segment "{segment}" may use at most one '*', or be a whole-segment '**'"#
+        ),
+        kind: PatternIssueKind::GlobInvalid,
+    }
+}
+
+#[test]
+fn test_apply_route_rewrites_rewrites_keys_and_reports_changes() {
+    let mut routes = make_routes(&[
+        ("/docs/*", "/index.html"),
+        ("/about", "/about.html"),
+        ("*", "/404.html"),
+    ]);
+
+    let changed = apply_route_rewrites(&mut routes).expect("no collisions");
+
+    // Only the pairs that actually changed, sorted by original.
+    assert_eq!(
+        changed,
+        vec![
+            ("*".to_owned(), "/**".to_owned()),
+            ("/docs/*".to_owned(), "/docs/**/*".to_owned()),
+        ]
+    );
+    // Keys are rewritten in place; each value stays with its original entry.
+    assert_eq!(
+        routes,
+        make_routes(&[
+            ("/docs/**/*", "/index.html"),
+            ("/about", "/about.html"),
+            ("/**", "/404.html"),
+        ])
+    );
+}
+
+#[test]
+fn test_apply_route_rewrites_collision_leaves_routes_unchanged() {
+    // Colliding keys with DIFFERENT values: merging would drop a route.
+    let mut routes = make_routes(&[("/docs/*", "/a.html"), ("/docs/**/*", "/b.html")]);
+    let before = routes.clone();
+
+    let collisions = apply_route_rewrites(&mut routes).expect_err("colliding rewrites");
+
+    assert_eq!(
+        collisions,
+        vec![RewriteCollision {
+            rewritten: "/docs/**/*".to_owned(),
+            originals: vec!["/docs/*".to_owned(), "/docs/**/*".to_owned()],
+        }]
+    );
+    assert_eq!(routes, before, "a failed rewrite must not mutate the input");
+}
+
+#[test]
+fn test_apply_route_rewrites_merges_identical_value_collisions() {
+    // Colliding keys with the SAME value lose nothing: merge instead of failing.
+    let mut routes = make_routes(&[
+        ("/docs/*", "/a.html"),
+        ("/docs/**/*", "/a.html"),
+        ("/other", "/b.html"),
+    ]);
+
+    let changed = apply_route_rewrites(&mut routes).expect("identical values must merge");
+
+    assert_eq!(
+        changed,
+        vec![("/docs/*".to_owned(), "/docs/**/*".to_owned())]
+    );
+    assert_eq!(
+        routes,
+        make_routes(&[("/docs/**/*", "/a.html"), ("/other", "/b.html")])
+    );
+}
+
+#[test]
+fn test_rewrite_session_applies_reports_and_restores() {
+    let mut routes = Some(make_routes(&[("/docs/*", "/a.html"), ("/fine", "/b.html")]));
+
+    let session = RewriteSession::apply(&mut routes).expect("no collisions");
+    assert_eq!(
+        session.pairs(),
+        &[("/docs/*".to_owned(), "/docs/**/*".to_owned())]
+    );
+    assert_eq!(
+        routes,
+        Some(make_routes(&[
+            ("/docs/**/*", "/a.html"),
+            ("/fine", "/b.html")
+        ]))
+    );
+
+    session.restore(&mut routes);
+    assert_eq!(
+        routes,
+        Some(make_routes(&[("/docs/*", "/a.html"), ("/fine", "/b.html")]))
+    );
+}
+
+#[test]
+fn test_rewrite_session_empty_cases() {
+    // Explicitly empty session (flag off): no pairs.
+    assert!(RewriteSession::empty().pairs().is_empty());
+
+    // No routes declared: empty session, restore is a no-op.
+    let mut routes: Option<Routes> = None;
+    let session = RewriteSession::apply(&mut routes).expect("no routes, no collisions");
+    assert!(session.pairs().is_empty());
+    session.restore(&mut routes);
+    assert_eq!(routes, None);
+
+    // Routes present but nothing to rewrite: no pairs, restore keeps the set.
+    let mut routes = Some(make_routes(&[("/docs/**", "/a.html")]));
+    let before = routes.clone();
+    let session = RewriteSession::apply(&mut routes).expect("no collisions");
+    assert!(session.pairs().is_empty());
+    session.restore(&mut routes);
+    assert_eq!(routes, before);
+
+    // Value-losing collisions propagate.
+    let mut routes = Some(make_routes(&[
+        ("/docs/*", "/a.html"),
+        ("/docs/**/*", "/b.html"),
+    ]));
+    assert!(RewriteSession::apply(&mut routes).is_err());
+}
+
+/// THE key regression for `--rewrite-legacy-routes`: rewriting the local
+/// legacy-spelled routes into the on-chain glob spelling must make the diff
+/// idempotent (`Unchanged`), while the raw spelling would replace the set on
+/// every deploy.
+#[test]
+fn test_apply_route_rewrites_then_diff_is_idempotent() {
+    let existing = make_routes(&[("/docs/**/*", "/index.html"), ("/**", "/404.html")]);
+
+    let mut local = make_routes(&[("/docs/*", "/index.html"), ("*", "/404.html")]);
+    apply_route_rewrites(&mut local).expect("no collisions");
+    assert!(matches!(
+        Routes::diff_opt(Some(&local), Some(&existing)),
+        RouteOps::Unchanged
+    ));
+
+    let raw_local = make_routes(&[("/docs/*", "/index.html"), ("*", "/404.html")]);
+    assert!(matches!(
+        Routes::diff_opt(Some(&raw_local), Some(&existing)),
+        RouteOps::Replace(_)
+    ));
+}
+
+#[test]
+fn test_check_write_boundary_replace_collects_all_offenders() {
+    let local = make_routes(&[("a*b*", "/v1"), ("/x/a*a*a*/y", "/v2"), ("/fine", "/v3")]);
+
+    let report = check_write_boundary(Some(&local), None, None, None, &[]);
+
+    // Both offenders, in key order, each with its exact validator reason.
+    assert_eq!(
+        report.errors,
+        vec![
+            expect_glob_invalid(PatternTarget::Route, "/x/a*a*a*/y", "a*a*a*"),
+            expect_glob_invalid(PatternTarget::Route, "a*b*", "a*b*"),
+        ]
+    );
+    assert!(report.warnings.is_empty(), "'/fine' must produce nothing");
+}
+
+#[test]
+fn test_check_write_boundary_unchanged_invalid_is_warning() {
+    let set = make_routes(&[("a*b*", "/v")]);
+
+    let report = check_write_boundary(Some(&set), Some(&set), None, None, &[]);
+
+    assert!(
+        report.errors.is_empty(),
+        "nothing is written; deploy proceeds"
+    );
+    assert_eq!(
+        report.warnings,
+        vec![expect_glob_invalid(PatternTarget::Route, "a*b*", "a*b*")]
+    );
+}
+
+#[test]
+fn test_check_write_boundary_empty_and_none_sets() {
+    // The existing on-chain set is deliberately invalid: only the set about
+    // to be written is validated, never the one being removed/replaced.
+    let on_chain = make_routes(&[("a*b*", "/v")]);
+    let empty = Routes::empty();
+
+    let cases: Vec<(Option<&Routes>, Option<&Routes>)> = vec![
+        // Removal is a Replace with the empty set: nothing to validate.
+        (None, Some(&on_chain)),
+        (None, None),
+        // Replacing with an explicitly empty set validates nothing either.
+        (Some(&empty), Some(&on_chain)),
+    ];
+
+    for (local, existing) in cases {
+        let report = check_write_boundary(local, existing, None, None, &[]);
+        assert!(
+            report.errors.is_empty() && report.warnings.is_empty(),
+            "expected empty report for local={local:?}, existing={existing:?}"
+        );
+    }
+}
+
+#[test]
+fn test_check_write_boundary_fresh_publish_validates() {
+    let local = make_routes(&[("***", "/v")]);
+
+    let report = check_write_boundary(Some(&local), None, None, None, &[]);
+
+    assert_eq!(
+        report.errors,
+        vec![expect_glob_invalid(PatternTarget::Route, "***", "***")]
+    );
+    assert!(report.warnings.is_empty());
+}
+
+#[test]
+fn test_check_write_boundary_redirects_glob_structural_only() {
+    // Regex metacharacters are glob literals: no issue of any kind.
+    let parens = make_redirects(&["/wiki/(x)"]);
+    let report = check_write_boundary(None, None, Some(&parens), None, &[]);
+    assert!(report.errors.is_empty() && report.warnings.is_empty());
+
+    // Structurally invalid: an error when written, a warning when unchanged.
+    let invalid = make_redirects(&["/a/**/b/**"]);
+    let issue = PatternIssue {
+        target: PatternTarget::Redirect,
+        pattern: "/a/**/b/**".to_owned(),
+        reason: "2 '**' globstars (max 1)".to_owned(),
+        kind: PatternIssueKind::GlobInvalid,
+    };
+
+    let written = check_write_boundary(None, None, Some(&invalid), None, &[]);
+    assert_eq!(written.errors, vec![issue.clone()]);
+    assert!(written.warnings.is_empty());
+
+    let unchanged = check_write_boundary(None, None, Some(&invalid), Some(&invalid), &[]);
+    assert!(unchanged.errors.is_empty());
+    assert_eq!(unchanged.warnings, vec![issue]);
+
+    // A pattern that takes legacy/narrowing warnings as a route takes none
+    // as a redirect, written or unchanged.
+    let star = make_redirects(&["/api*"]);
+    for existing in [None, Some(&star)] {
+        let report = check_write_boundary(None, None, Some(&star), existing, &[]);
+        assert!(
+            report.errors.is_empty() && report.warnings.is_empty(),
+            "existing={existing:?}"
+        );
+    }
+}
+
+#[test]
+fn test_check_write_boundary_legacy_and_narrowing_warnings() {
+    let local = make_routes(&[("/a/*/b/**", "/v1"), ("/api*", "/v2"), ("/foo/*", "/v3")]);
+
+    let report = check_write_boundary(Some(&local), None, None, None, &[]);
+
+    assert!(report.errors.is_empty());
+    assert_eq!(
+        report.warnings,
+        vec![
+            // Glob-valid but over the legacy star cap: skipped by legacy
+            // portals (no rewrite involved, so not a sequencing hazard).
+            PatternIssue {
+                target: PatternTarget::Route,
+                pattern: "/a/*/b/**".to_owned(),
+                reason: "3 '*' characters (max 2 in total)".to_owned(),
+                kind: PatternIssueKind::LegacySkipped,
+            },
+            // StarNarrowing carries no validator reason: pinned empty.
+            PatternIssue {
+                target: PatternTarget::Route,
+                pattern: "/api*".to_owned(),
+                reason: String::new(),
+                kind: PatternIssueKind::StarNarrowing,
+            },
+        ]
+    );
+}
+
+#[test]
+fn test_check_write_boundary_rewrite_sequencing_hazard() {
+    let local = make_routes(&[("/docs/**/*", "/index.html"), ("/**", "/404.html")]);
+    let rewritten = [
+        ("/docs/*".to_owned(), "/docs/**/*".to_owned()),
+        ("*".to_owned(), "/**".to_owned()),
+    ];
+
+    let report = check_write_boundary(Some(&local), None, None, None, &rewritten);
+
+    // `/**` is 2 stars = legacy-valid, so rewriting `*` is hazard-free; only
+    // the 3-star rewrite output `/docs/**/*` trips the sequencing hazard.
+    assert!(report.errors.is_empty());
+    assert_eq!(
+        report.warnings,
+        vec![PatternIssue {
+            target: PatternTarget::Route,
+            pattern: "/docs/**/*".to_owned(),
+            reason: "3 '*' characters (max 2 in total)".to_owned(),
+            kind: PatternIssueKind::LegacyAfterRewrite,
+        }]
+    );
+
+    // The rendered hazard names both the original and the stored spelling.
+    assert_eq!(
+        format_warning(&report.warnings[0], &rewritten),
+        concat!(
+            "'/docs/*' was rewritten to '/docs/**/*', which portals still running legacy ",
+            "(regex) routing cannot match (3 '*' characters (max 2 in total)) and will skip. ",
+            "Only deploy with --rewrite-legacy-routes once the portal fleet runs glob routing.",
+        )
+    );
+}
+
+#[test]
+fn test_check_write_boundary_glob_invalid_suppresses_secondary_warnings() {
+    // Were `a*b*` glob-valid it would also be flagged as narrowing; the
+    // glob-structural failure must be the only issue reported for it.
+    let set = make_routes(&[("a*b*", "/v")]);
+
+    let report = check_write_boundary(Some(&set), Some(&set), None, None, &[]);
+
+    assert!(report.errors.is_empty());
+    assert_eq!(report.warnings.len(), 1, "exactly one issue in total");
+    assert_eq!(report.warnings[0].kind, PatternIssueKind::GlobInvalid);
+}
+
+#[test]
+fn test_format_errors_text_shape() {
+    let errors = vec![
+        expect_glob_invalid(PatternTarget::Route, "a*b*", "a*b*"),
+        expect_glob_invalid(PatternTarget::Route, "/x/a*a*a*/y", "a*a*a*"),
+        PatternIssue {
+            target: PatternTarget::Redirect,
+            pattern: "/a/**/b/**".to_owned(),
+            reason: "2 '**' globstars (max 1)".to_owned(),
+            kind: PatternIssueKind::GlobInvalid,
+        },
+    ];
+
+    let expected = concat!(
+        "found 3 invalid route/redirect pattern(s); portals cannot match them, ",
+        "refusing to store them on-chain:\n",
+        "  - route pattern 'a*b*': segment \"a*b*\" may use at most one '*', ",
+        "or be a whole-segment '**'\n",
+        "  - route pattern '/x/a*a*a*/y': segment \"a*a*a*\" may use at most one '*', ",
+        "or be a whole-segment '**'\n",
+        "  - redirect pattern '/a/**/b/**': 2 '**' globstars (max 1)\n",
+        "Routes and redirects are stored as complete sets, so every pattern in ",
+        "ws-resources.json must be valid before this deploy can proceed — including ",
+        "patterns you did not change.",
+    );
+
+    assert_eq!(format_errors(&errors, &[]), expected);
+}
+
+#[test]
+fn test_format_errors_names_original_spelling_for_rewritten_patterns() {
+    // A pattern can be glob-invalid AND changed by the rewrite (an invalid
+    // segment before a trailing `/*`): the error must point at the spelling
+    // that actually exists in ws-resources.json, not the rewritten one.
+    let errors = vec![expect_glob_invalid(
+        PatternTarget::Route,
+        "/a*b*/**/*",
+        "a*b*",
+    )];
+    let rewritten = [("/a*b*/*".to_owned(), "/a*b*/**/*".to_owned())];
+
+    let expected = concat!(
+        "found 1 invalid route/redirect pattern(s); portals cannot match them, ",
+        "refusing to store them on-chain:\n",
+        "  - route pattern '/a*b*/*' (stored as '/a*b*/**/*' by --rewrite-legacy-routes): ",
+        "segment \"a*b*\" may use at most one '*', or be a whole-segment '**'\n",
+        "Routes and redirects are stored as complete sets, so every pattern in ",
+        "ws-resources.json must be valid before this deploy can proceed — including ",
+        "patterns you did not change.",
+    );
+
+    assert_eq!(format_errors(&errors, &rewritten), expected);
+}
+
+/// Pins the remaining user-facing wordings byte-exact (the hazard text is
+/// pinned in the sequencing-hazard test, `format_errors` in the text-shape
+/// test): the message builders' strings are settled and must not drift.
+#[test]
+fn test_format_warning_and_rewrite_texts() {
+    assert_eq!(
+        format_warning(
+            &expect_glob_invalid(PatternTarget::Route, "a*b*", "a*b*"),
+            &[]
+        ),
+        concat!(
+            "On-chain route pattern 'a*b*' is invalid (segment \"a*b*\" may use at most ",
+            "one '*', or be a whole-segment '**'); portals skip it when matching. This deploy ",
+            "leaves routes unchanged and can proceed, but fix the pattern in ",
+            "ws-resources.json: the next deploy that modifies routes will refuse to store it.",
+        )
+    );
+
+    let glob_invalid_redirect = PatternIssue {
+        target: PatternTarget::Redirect,
+        pattern: "/a/**/b/**".to_owned(),
+        reason: "2 '**' globstars (max 1)".to_owned(),
+        kind: PatternIssueKind::GlobInvalid,
+    };
+    assert_eq!(
+        format_warning(&glob_invalid_redirect, &[]),
+        concat!(
+            "On-chain redirect pattern '/a/**/b/**' is invalid (2 '**' globstars (max 1)); ",
+            "portals skip it when matching. This deploy leaves redirects unchanged and can ",
+            "proceed, but fix the pattern in ws-resources.json: the next deploy that modifies ",
+            "redirects will refuse to store it.",
+        )
+    );
+
+    let legacy_skipped = PatternIssue {
+        target: PatternTarget::Route,
+        pattern: "/a/*/b/**".to_owned(),
+        reason: "3 '*' characters (max 2 in total)".to_owned(),
+        kind: PatternIssueKind::LegacySkipped,
+    };
+    assert_eq!(
+        format_warning(&legacy_skipped, &[]),
+        concat!(
+            "Route pattern '/a/*/b/**' is valid glob syntax, but exceeds the legacy matcher's ",
+            "limits (3 '*' characters (max 2 in total)); portals still running legacy (regex) ",
+            "routing skip it. It only takes effect on portals with glob routing enabled.",
+        )
+    );
+
+    let narrowing = PatternIssue {
+        target: PatternTarget::Route,
+        pattern: "/api*".to_owned(),
+        reason: String::new(),
+        kind: PatternIssueKind::StarNarrowing,
+    };
+    assert_eq!(
+        format_warning(&narrowing, &[]),
+        concat!(
+            "Note on route pattern '/api*': under glob routing, '*' matches within a single ",
+            "path segment (legacy regex routing let it cross '/'). The pattern is valid and ",
+            "stored as-is; if you want it to match everything below a prefix, use a ",
+            "whole-segment '**' — e.g. '/foo/**' matches '/foo' and everything under it.",
+        )
+    );
+
+    let rewritten = [
+        ("*".to_owned(), "/**".to_owned()),
+        ("/docs/*".to_owned(), "/docs/**/*".to_owned()),
+    ];
+    assert_eq!(
+        format_rewrite_notice(&rewritten),
+        concat!(
+            "--rewrite-legacy-routes: storing 2 route pattern(s) in glob form ",
+            "(ws-resources.json is not modified):\n",
+            "  - '*' -> '/**'\n",
+            "  - '/docs/*' -> '/docs/**/*'",
+        )
+    );
+
+    let collisions = [
+        RewriteCollision {
+            rewritten: "/**".to_owned(),
+            originals: vec!["*".to_owned(), "/**".to_owned()],
+        },
+        RewriteCollision {
+            rewritten: "/docs/**/*".to_owned(),
+            originals: vec!["/docs/*".to_owned(), "/docs/**/*".to_owned()],
+        },
+    ];
+    assert_eq!(
+        format_rewrite_collisions(&collisions),
+        concat!(
+            "--rewrite-legacy-routes produced conflicting route patterns: '*' and '/**' both ",
+            "rewrite to '/**'. Remove or merge these entries in ws-resources.json.\n",
+            "--rewrite-legacy-routes produced conflicting route patterns: '/docs/*' and ",
+            "'/docs/**/*' both rewrite to '/docs/**/*'. Remove or merge these entries in ",
+            "ws-resources.json.",
+        )
+    );
+}

--- a/site-builder/src/unit_tests/site.path_patterns.tests.rs
+++ b/site-builder/src/unit_tests/site.path_patterns.tests.rs
@@ -564,7 +564,7 @@ fn test_check_write_boundary_rewrite_sequencing_hazard() {
         concat!(
             "'/docs/*' was rewritten to '/docs/**/*', which portals still running legacy ",
             "(regex) routing cannot match (3 '*' characters (max 2 in total)) and will skip. ",
-            "Only deploy with --rewrite-legacy-routes once the portal fleet runs glob routing.",
+            "Only deploy with --rewrite-legacy-routes once portal deployments run glob routing.",
         )
     );
 }

--- a/site-builder/tests/localnode/args_builder/publish_options_builder.rs
+++ b/site-builder/tests/localnode/args_builder/publish_options_builder.rs
@@ -16,6 +16,9 @@ pub struct PublishOptionsBuilder {
     /// Preprocess the directory before publishing.
     /// See the `list-directory` command. Warning: Rewrites all `index.html` files.
     pub list_directory: bool,
+    /// Rewrite legacy route patterns to their glob equivalents before storing them on-chain.
+    // TODO(sew-1001): remove with the routing migration.
+    pub rewrite_legacy_routes: bool,
     /// Common configurations.
     // Note: We are currently re-using `WalrusStoreOptionsBuilder`'s methods for convenience,
     // and keeping walrus_store_options_builder mod private.
@@ -35,6 +38,7 @@ impl PublishOptionsBuilder {
         let PublishOptionsBuilder {
             directory,
             list_directory,
+            rewrite_legacy_routes,
             walrus_options,
         } = self;
         let Some(directory) = directory else {
@@ -46,6 +50,7 @@ impl PublishOptionsBuilder {
         Ok(PublishOptions {
             directory,
             list_directory,
+            rewrite_legacy_routes,
             walrus_options,
         })
     }
@@ -57,6 +62,11 @@ impl PublishOptionsBuilder {
 
     pub fn with_list_directory(mut self, list_directory: bool) -> Self {
         self.list_directory = list_directory;
+        self
+    }
+
+    pub fn with_rewrite_legacy_routes(mut self, rewrite_legacy_routes: bool) -> Self {
+        self.rewrite_legacy_routes = rewrite_legacy_routes;
         self
     }
 

--- a/site-builder/tests/rewrite_legacy_routes.rs
+++ b/site-builder/tests/rewrite_legacy_routes.rs
@@ -1,0 +1,215 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end tests for deploy-time route-pattern validation and the
+//! `--rewrite-legacy-routes` flag, against a local test cluster.
+
+use std::{collections::BTreeMap, fs::File, path::Path};
+
+use site_builder::{
+    args::{Commands, EpochCountOrMax},
+    site_config::WSResources,
+    types::{Redirect, Redirects, Routes, VecMap},
+};
+
+#[allow(dead_code)]
+mod localnode;
+use localnode::{
+    args_builder::{ArgsBuilder, PublishOptionsBuilder},
+    TestSetup,
+};
+
+#[allow(dead_code)]
+mod helpers;
+use helpers::create_test_site;
+
+/// Writes a `ws-resources.json` with legacy-spelled routes (both rewrite
+/// arms: a bare `*` and a trailing `/*`), an untouched exact route, and one
+/// glob redirect, into the site directory.
+fn write_legacy_ws_resources(directory: &Path) -> anyhow::Result<()> {
+    let ws_resources = WSResources {
+        routes: Some(Routes(VecMap(BTreeMap::from([
+            ("*".to_owned(), "/file_0.html".to_owned()),
+            ("/docs/*".to_owned(), "/file_1.html".to_owned()),
+            ("/exact".to_owned(), "/file_0.html".to_owned()),
+        ])))),
+        redirects: Some(Redirects(VecMap(BTreeMap::from([(
+            "/redirects/**/*".to_owned(),
+            Redirect {
+                location: "/file_0.html".to_owned(),
+                status_code: 302,
+            },
+        )])))),
+        ..Default::default()
+    };
+    serde_json::to_writer_pretty(
+        File::create(directory.join("ws-resources.json"))?,
+        &ws_resources,
+    )?;
+    Ok(())
+}
+
+fn read_ws_resources(directory: &Path) -> anyhow::Result<WSResources> {
+    Ok(serde_json::from_reader(File::open(
+        directory.join("ws-resources.json"),
+    )?)?)
+}
+
+fn route_keys(routes: &Routes) -> Vec<&String> {
+    routes.0 .0.keys().collect()
+}
+
+/// The full life of `--rewrite-legacy-routes`:
+/// 1. publish with the flag: on-chain routes carry the glob spellings, while
+///    `ws-resources.json` keeps the author's legacy spellings (in-memory-only
+///    rewrite) and gains the new `object_id`;
+/// 2. redirects are never rewritten;
+/// 3. an update with the flag is idempotent (same stored spellings);
+/// 4. an update WITHOUT the flag reverts the stored spellings to the raw
+///    legacy ones — the documented ratchet.
+#[tokio::test]
+#[ignore]
+async fn rewrite_legacy_routes_publish_update_revert() -> anyhow::Result<()> {
+    let cluster = TestSetup::start_local_test_cluster(None).await?;
+    let site_dir = create_test_site(2)?;
+    let directory = site_dir.path().to_path_buf();
+    write_legacy_ws_resources(&directory)?;
+
+    // Publish with the flag on.
+    let args = ArgsBuilder::default()
+        .with_config(Some(cluster.sites_config_path().to_owned()))
+        .with_command(Commands::Publish {
+            publish_options: PublishOptionsBuilder::default()
+                .with_directory(directory.clone())
+                .with_epoch_count_or_max(EpochCountOrMax::Epochs(1_u32.try_into().unwrap()))
+                .with_rewrite_legacy_routes(true)
+                .build()?,
+            site_name: None,
+        })
+        .build()?;
+    site_builder::run(args).await?;
+
+    let site_id = *cluster.last_site_created().await?.id.object_id();
+    let routes = cluster
+        .site_routes(site_id)
+        .await?
+        .expect("routes should exist on chain");
+    assert_eq!(
+        route_keys(&routes),
+        ["/**", "/docs/**/*", "/exact"],
+        "on-chain routes must use the rewritten glob spellings"
+    );
+    println!("✓ published with rewritten routes");
+
+    // The rewrite is in-memory only: the file keeps the author's spellings,
+    // while persist added the new object_id.
+    let on_disk = read_ws_resources(&directory)?;
+    assert_eq!(
+        route_keys(on_disk.routes.as_ref().expect("routes on disk")),
+        ["*", "/docs/*", "/exact"],
+        "ws-resources.json must keep the legacy spellings"
+    );
+    assert_eq!(on_disk.object_id, Some(site_id));
+    println!("✓ ws-resources.json kept the legacy spellings");
+
+    // Redirects are never rewritten.
+    let redirects = cluster
+        .site_redirects(site_id)
+        .await?
+        .expect("redirects should exist on chain");
+    assert!(redirects.0 .0.contains_key("/redirects/**/*"));
+    assert_eq!(redirects.0.len(), 1);
+
+    // Update with the flag on: rewrite-then-diff must be idempotent.
+    let args = ArgsBuilder::default()
+        .with_config(Some(cluster.sites_config_path().to_owned()))
+        .with_command(Commands::Update {
+            publish_options: PublishOptionsBuilder::default()
+                .with_directory(directory.clone())
+                .with_epoch_count_or_max(EpochCountOrMax::Max)
+                .with_rewrite_legacy_routes(true)
+                .build()?,
+            object_id: site_id,
+        })
+        .build()?;
+    site_builder::run(args).await?;
+    let routes = cluster.site_routes(site_id).await?.expect("routes");
+    assert_eq!(route_keys(&routes), ["/**", "/docs/**/*", "/exact"]);
+    println!("✓ flag-on re-deploy is idempotent");
+
+    // Update WITHOUT the flag: the raw legacy spellings diff against the
+    // stored glob spellings and replace them — the documented revert ratchet.
+    let args = ArgsBuilder::default()
+        .with_config(Some(cluster.sites_config_path().to_owned()))
+        .with_command(Commands::Update {
+            publish_options: PublishOptionsBuilder::default()
+                .with_directory(directory)
+                .with_epoch_count_or_max(EpochCountOrMax::Max)
+                .build()?,
+            object_id: site_id,
+        })
+        .build()?;
+    site_builder::run(args).await?;
+    let routes = cluster.site_routes(site_id).await?.expect("routes");
+    assert_eq!(
+        route_keys(&routes),
+        ["*", "/docs/*", "/exact"],
+        "a flag-off re-deploy reverts to the legacy spellings"
+    );
+    println!("✓ flag-off re-deploy reverted the spellings");
+
+    Ok(())
+}
+
+/// A structurally invalid glob pattern in a to-be-written set fails the
+/// publish before anything is stored, naming the offender with the portal's
+/// exact reason string; nothing is persisted on the error path.
+#[tokio::test]
+#[ignore]
+async fn publish_rejects_invalid_glob_pattern() -> anyhow::Result<()> {
+    let cluster = TestSetup::start_local_test_cluster(None).await?;
+    let site_dir = create_test_site(1)?;
+    let directory = site_dir.path().to_path_buf();
+
+    let ws_resources = WSResources {
+        routes: Some(Routes(VecMap(BTreeMap::from([(
+            "a*b*".to_owned(),
+            "/file_0.html".to_owned(),
+        )])))),
+        ..Default::default()
+    };
+    serde_json::to_writer_pretty(
+        File::create(directory.join("ws-resources.json"))?,
+        &ws_resources,
+    )?;
+
+    let args = ArgsBuilder::default()
+        .with_config(Some(cluster.sites_config_path().to_owned()))
+        .with_command(Commands::Publish {
+            publish_options: PublishOptionsBuilder::default()
+                .with_directory(directory.clone())
+                .with_epoch_count_or_max(EpochCountOrMax::Epochs(1_u32.try_into().unwrap()))
+                .build()?,
+            site_name: None,
+        })
+        .build()?;
+    let error = site_builder::run(args)
+        .await
+        .expect_err("publish must refuse the invalid pattern");
+    let error_msg = format!("{error:?}");
+    assert!(
+        error_msg.contains("refusing to store them on-chain"),
+        "unexpected error: {error_msg}"
+    );
+    assert!(
+        error_msg.contains(r#"segment "a*b*" may use at most one '*', or be a whole-segment '**'"#),
+        "unexpected error: {error_msg}"
+    );
+    println!("✓ invalid pattern refused with the pinned reason string");
+
+    // The error path never persists: no object_id was written back.
+    let on_disk = read_ws_resources(&directory)?;
+    assert_eq!(on_disk.object_id, None);
+
+    Ok(())
+}


### PR DESCRIPTION
PR 2 of sites-glob-migration ([SEW-999](https://linear.app/mysten-labs/issue/SEW-999)). Portal matcher: #720. Flags die in SEW-1001.

⚠️ **Sequencing hazard**: `--rewrite-legacy-routes` stores `/docs/*` as `/docs/**/*` (3 stars) — legacy-routing portals skip it. Keep the flag off/undocumented until portal deployments run glob routing.

**What**
- Deploy-time validation (ships on): structurally invalid glob patterns hard-error **before any Walrus spend** when the route/redirect set is written; warn-only when the set is unchanged on-chain. Migration warnings: legacy-skipped (>2 stars / regex metachars) + `*`-narrowing note.
- `--rewrite-legacy-routes` (default off): in-memory `*` → `/**`, trailing `/*` → `<prefix>/**/*` before diff/store; re-deploys idempotent; never written to ws-resources.json; summary prints `'old' -> 'new'` pairs.

**Decisions**
- Validation unconditional, not flag-gated: its value is *before* portal deployments flip to glob routing; a default-off check misses the window.
- Rules + reason strings byte-mirror portal `path_patterns.ts` @ `583dbc9`; corpus-pinned on both sides, keep-in-sync doc both ways.
- Written-vs-unchanged decided by new `Routes/Redirects::diff_opt` — the same source `SiteData::diff` uses; validation cannot diverge from the write.
- Sets store replace-all → touching any route validates the complete set (error text says so).
- Redirects: glob-validated, never rewritten (scope add vs stale ticket text — portals already glob-match redirects).
- Rewrite collisions: merge when values identical, hard-error naming both originals when they differ.

**Open for review**
1. Posture — error on glob-invalid, warn on legacy-incompatible; flip = ~5 lines in `classify_written`.
2. Flag name/mechanism (portal used an env var; SEW-1043 unifies portal flags; this one dies in SEW-1001).
3. ws-resources.json write-back deferred — the notice prints paste-ready pairs.
4. Known gap: `/a/*/b/*` escapes the narrowing note (test-pinned, deliberate).

**Tests**: unit corpus byte-mirrors the portal's; localnode e2e (`tests/rewrite_legacy_routes.rs`) covers the on-chain legs — rewritten spellings stored, ws-resources.json untouched, flag-on idempotency, flag-off revert, pre-store refusal of invalid patterns.

**Follow-ups**: mirror 3 illegal-char cases to portal corpus; unify Routes/Redirects twin APIs.

Note (unrelated to this diff): smoke-testing locally, site-builder deploys against testnet failed with JSON-RPC `404`s from `fullnode.testnet.sui.io` . Site-builder still uses JSON-RPC via `WalletContext` in a few spots that will need migrating: `dev_inspect` gas estimation (`site/manager.rs:444`), gas selection (`:685`), object refs (`:405`) — and the gRPC retry client takes its URL from the wallet env rather than `rpc_url` (`:85`). Weirdly, `e2e-upgrade` — which runs real site-builder deploys against testnet — still passes from the CI runners; we haven't pinned down why the endpoint behaves differently there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

